### PR TITLE
update content resource to allow updates using overwrite flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
-## 2.2.0 (Unreleased)
+## 2.1.3 (Unreleased)
+ENHANCEMENTS:
+* Allow updates to content resources so that dashboard links do not exprie. This creates a known bug - do not update the name of a resource.
+
+## 2.1.2 (July 24, 2020)
+ENHANCEMENTS:
+* Now parrt of the Terraform Registry - compatible with Terraform 0.13
+
 ## 2.1.1 (July 17, 2020)
 
 DOCS:

--- a/sumologic/resource_sumologic_content_test.go
+++ b/sumologic/resource_sumologic_content_test.go
@@ -98,7 +98,7 @@ func testAccCheckContentDestroy(content Content) resource.TestCheckFunc {
 
 var updateConfigJson = `{
 	"type": "SavedSearchWithScheduleSyncDefinition",
-	"name": "test-333",
+	"name": "test-121",
 	"search": {
 		"queryText": "\"warn\"",
 		"defaultTimeRange": "-15m",
@@ -106,7 +106,7 @@ var updateConfigJson = `{
 		"viewName": "",
 		"viewStartTime": "1970-01-01T00:00:00Z",
 		"queryParameters": [],
-		"parsingMode": "Manual"
+		"parsingMode": "AutoParse"
 	},
 	"searchSchedule": {
 		"cronExpression": "0 0 * * * ? *",
@@ -134,7 +134,7 @@ var updateConfigJson = `{
 		"muteErrorEmails": false,
 		"parameters": []
 	},
-	"description": "Runs every hour with timerange of 15m and sends email notifications"
+	"description": "Runs every hour with timerange of 15m and sends email notifications updated"
 }`
 
 var configJson = `{
@@ -147,7 +147,7 @@ var configJson = `{
 		"viewName": "",
 		"viewStartTime": "1970-01-01T00:00:00Z",
 		"queryParameters": [],
-		"parsingMode": "Manual"
+		"parsingMode": "AutoParse"
 	},
 	"searchSchedule": {
 		"cronExpression": "0 0 * * * ? *",

--- a/sumologic/sumologic_client.go
+++ b/sumologic/sumologic_client.go
@@ -42,7 +42,7 @@ func createNewRequest(method, url string, body io.Reader, accessID string, acces
 		return nil, err
 	}
 	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("User-Agent", "SumoLogicTerraformProvider/2.0.2")
+	req.Header.Add("User-Agent", "SumoLogicTerraformProvider/2.1.3")
 	req.SetBasicAuth(accessID, accessKey)
 	return req, nil
 }

--- a/sumologic/sumologic_content.go
+++ b/sumologic/sumologic_content.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"strconv"
 	"strings"
 	"time"
 
@@ -115,11 +116,11 @@ func (s *Client) DeleteContent(id string, timeout time.Duration) error {
 	return err
 }
 
-//CREATE
-func (s *Client) CreateContent(content Content, timeout time.Duration) (string, error) {
-	log.Println("####Begin CreateContent####")
+//CREATE or UPDATE
+func (s *Client) CreateOrUpdateContent(content Content, timeout time.Duration, overwrite bool) (string, error) {
+	log.Println("####Begin CreateOrUpdateContent####")
 
-	url := fmt.Sprintf("v2/content/folders/%s/import", content.ParentId)
+	url := fmt.Sprintf("v2/content/folders/%s/import?overwrite=%s", content.ParentId, strconv.FormatBool(overwrite))
 	log.Printf("Create content url: %s", url)
 
 	//Initiate content creation job

--- a/website/docs/r/content.html.markdown
+++ b/website/docs/r/content.html.markdown
@@ -62,7 +62,7 @@ resource "sumologic_content" "test" {
 The following arguments are supported:
 
 - `parent_id` - (Required) The identifier of the folder to import into. Identifiers from the Library in the Sumo user interface are provided in decimal format which is incompatible with Terraform. The identifier needs to be in hexadecimal format.
-- `config` - (Required) JSON block for the content to import.
+- `config` - (Required) JSON block for the content to import. NOTE: Updating the name will create a new object and leave a untracked content item (delete the existing content item and create a new content item if you want to update the name).
 
 ### Timeouts
 
@@ -70,6 +70,7 @@ The following arguments are supported:
 
 - `read` - (Default `1 minute`) Used for waiting for the import job to be successful
 - `create` - (Default `10 minutes`) Used for waiting for the import job to be successful
+- `update` - (Default `10 minutes`) Used for waiting for the import job to be successful
 - `delete` - (Default `1 minute`) Used for waiting for the deletion job to be successful
 
 ## Attributes reference


### PR DESCRIPTION
- recreating content items from the Terraform Provider deletes links to dashboards
- adding update using the overwrite API flag
- this creates a bug when changing the Name - DO NOT change the name of a resource, just delete and recreate if you have to change the name