### PR TITLE
Add support for AWS Metadata Source

### DIFF
--- a/sumologic/provider.go
+++ b/sumologic/provider.go
@@ -41,6 +41,7 @@ func Provider() terraform.ResourceProvider {
 			"sumologic_collector":                          resourceSumologicCollector(),
 			"sumologic_http_source":                        resourceSumologicHTTPSource(),
 			"sumologic_polling_source":                     resourceSumologicPollingSource(),
+			"sumologic_metadata_source":                    resourceSumologicMetadataSource(),
 			"sumologic_cloudsyslog_source":                 resourceSumologicCloudsyslogSource(),
 			"sumologic_role":                               resourceSumologicRole(),
 			"sumologic_user":                               resourceSumologicUser(),

--- a/sumologic/resource_sumologic_metadata_source.go
+++ b/sumologic/resource_sumologic_metadata_source.go
@@ -75,15 +75,7 @@ func resourceSumologicMetadataSource() *schema.Resource {
 				"type": {
 					Type:         schema.TypeString,
 					Required:     true,
-					ValidateFunc: validation.StringInSlice([]string{"S3BucketPathExpression", "CloudWatchPath", "AwsMetadataPath"}, false),
-				},
-				"bucket_name": {
-					Type:     schema.TypeString,
-					Optional: true,
-				},
-				"path_expression": {
-					Type:     schema.TypeString,
-					Optional: true,
+					ValidateFunc: validation.StringInSlice([]string{"AwsMetadataPath"}, false),
 				},
 				"limit_to_regions": {
 					Type:     schema.TypeList,
@@ -214,8 +206,6 @@ func getMetadataThirdPartyPathAttributes(pollingResource []MetadataResource) []m
 	for _, t := range pollingResource {
 		mapping := map[string]interface{}{
 			"type":                t.Path.Type,
-			"bucket_name":         t.Path.BucketName,
-			"path_expression":     t.Path.PathExpression,
 			"limit_to_regions":    t.Path.LimitToRegions,
 			"limit_to_namespaces": t.Path.LimitToNamespaces,
 			"tag_filters":         t.Path.TagFilters,

--- a/sumologic/resource_sumologic_metadata_source.go
+++ b/sumologic/resource_sumologic_metadata_source.go
@@ -1,0 +1,279 @@
+package sumologic
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func resourceSumologicMetadataSource() *schema.Resource {
+	pollingMetadataSource := resourceSumologicSource()
+	pollingMetadataSource.Create = resourceSumologicMetadataSourceCreate
+	pollingMetadataSource.Read = resourceSumologicMetadataSourceRead
+	pollingMetadataSource.Update = resourceSumologicMetadataSourceUpdate
+	pollingMetadataSource.Importer = &schema.ResourceImporter{
+		State: resourceSumologicSourceImport,
+	}
+
+	pollingMetadataSource.Schema["content_type"] = &schema.Schema{
+		Type:         schema.TypeString,
+		Required:     true,
+		ForceNew:     true,
+		ValidateFunc: validation.StringInSlice([]string{"AwsMetadata"}, false),
+	}
+	pollingMetadataSource.Schema["scan_interval"] = &schema.Schema{
+		Type:     schema.TypeInt,
+		Required: true,
+	}
+	pollingMetadataSource.Schema["paused"] = &schema.Schema{
+		Type:     schema.TypeBool,
+		Required: true,
+	}
+	pollingMetadataSource.Schema["url"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Computed: true,
+	}
+	pollingMetadataSource.Schema["authentication"] = &schema.Schema{
+		Type:     schema.TypeList,
+		Required: true,
+		ForceNew: true,
+		MinItems: 1,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"type": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice([]string{"S3BucketAuthentication", "AWSRoleBasedAuthentication"}, false),
+				},
+				"access_key": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"secret_key": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"role_arn": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			},
+		},
+	}
+	pollingMetadataSource.Schema["path"] = &schema.Schema{
+		Type:     schema.TypeList,
+		Required: true,
+		ForceNew: true,
+		MinItems: 1,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"type": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice([]string{"S3BucketPathExpression", "CloudWatchPath", "AwsMetadataPath"}, false),
+				},
+				"bucket_name": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"path_expression": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"limit_to_regions": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+				"limit_to_namespaces": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem: &schema.Schema{
+						Type:         schema.TypeString,
+						ValidateFunc: validation.StringInSlice([]string{"AWS/EC2"}, false),
+					},
+				},
+
+				"tag_filters": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+			},
+		},
+	}
+
+	return pollingMetadataSource
+}
+
+func resourceSumologicMetadataSourceCreate(d *schema.ResourceData, meta interface{}) error {
+
+	c := meta.(*Client)
+
+	if d.Id() == "" {
+		source := resourceToMetadataSource(d)
+		sourceID, err := c.CreateMetadataSource(source, d.Get("collector_id").(int))
+
+		if err != nil {
+			return err
+		}
+
+		id := strconv.Itoa(sourceID)
+
+		d.SetId(id)
+	}
+
+	return resourceSumologicMetadataSourceRead(d, meta)
+}
+
+func resourceSumologicMetadataSourceUpdate(d *schema.ResourceData, meta interface{}) error {
+	c := meta.(*Client)
+
+	source := resourceToMetadataSource(d)
+
+	err := c.UpdateMetadataSource(source, d.Get("collector_id").(int))
+
+	if err != nil {
+		return err
+	}
+
+	return resourceSumologicMetadataSourceRead(d, meta)
+}
+
+func resourceSumologicMetadataSourceRead(d *schema.ResourceData, meta interface{}) error {
+	c := meta.(*Client)
+
+	id, _ := strconv.Atoi(d.Id())
+	source, err := c.GetMetadataSource(d.Get("collector_id").(int), id)
+
+	if err != nil {
+		return err
+	}
+
+	if source == nil {
+		log.Printf("[WARN] Polling source not found, removing from state: %v - %v", id, err)
+		d.SetId("")
+
+		return nil
+	}
+
+	pollingResources := source.ThirdPartyRef.Resources
+	path := getMetadataThirdPartyPathAttributes(pollingResources)
+
+	if err := d.Set("path", path); err != nil {
+		return err
+	}
+
+	if err := resourceSumologicSourceRead(d, source.Source); err != nil {
+		return fmt.Errorf("%s", err)
+	}
+	d.Set("content_type", source.ContentType)
+	d.Set("scan_interval", source.ScanInterval)
+	d.Set("paused", source.Paused)
+	d.Set("url", source.URL)
+
+	return nil
+}
+
+func resourceToMetadataSource(d *schema.ResourceData) MetadataSource {
+	source := resourceToSource(d)
+	source.Type = "Polling"
+
+	pollingMetadataSource := MetadataSource{
+		Source:       source,
+		Paused:       d.Get("paused").(bool),
+		ScanInterval: d.Get("scan_interval").(int),
+		ContentType:  d.Get("content_type").(string),
+		URL:          d.Get("url").(string),
+	}
+
+	pollingResource := MetadataResource{
+		ServiceType:    d.Get("content_type").(string),
+		Authentication: getMetadataAuthentication(d),
+		Path:           getMetadataPathSettings(d),
+	}
+
+	pollingMetadataSource.ThirdPartyRef.Resources = append(pollingMetadataSource.ThirdPartyRef.Resources, pollingResource)
+
+	return pollingMetadataSource
+}
+
+func getMetadataThirdPartyPathAttributes(pollingResource []MetadataResource) []map[string]interface{} {
+
+	var s []map[string]interface{}
+
+	for _, t := range pollingResource {
+		mapping := map[string]interface{}{
+			"type":                t.Path.Type,
+			"bucket_name":         t.Path.BucketName,
+			"path_expression":     t.Path.PathExpression,
+			"limit_to_regions":    t.Path.LimitToRegions,
+			"limit_to_namespaces": t.Path.LimitToNamespaces,
+			"tag_filters":         t.Path.TagFilters,
+		}
+		s = append(s, mapping)
+	}
+	return s
+}
+
+func getMetadataAuthentication(d *schema.ResourceData) MetadataAuthentication {
+	auths := d.Get("authentication").([]interface{})
+	authSettings := MetadataAuthentication{}
+
+	if len(auths) > 0 {
+		auth := auths[0].(map[string]interface{})
+		switch authType := auth["type"].(string); authType {
+		case "S3BucketAuthentication":
+			authSettings.Type = "S3BucketAuthentication"
+			authSettings.AwsID = auth["access_key"].(string)
+			authSettings.AwsKey = auth["secret_key"].(string)
+		case "AWSRoleBasedAuthentication":
+			authSettings.Type = "AWSRoleBasedAuthentication"
+			authSettings.RoleARN = auth["role_arn"].(string)
+		default:
+			log.Printf("[ERROR] Unknown authType: %v", authType)
+		}
+	}
+
+	return authSettings
+}
+
+func getMetadataPathSettings(d *schema.ResourceData) MetadataPath {
+	pathSettings := MetadataPath{}
+	paths := d.Get("path").([]interface{})
+
+	if len(paths) > 0 {
+		path := paths[0].(map[string]interface{})
+		switch pathType := path["type"].(string); pathType {
+		case "AwsMetadataPath":
+			pathSettings.Type = "AwsMetadataPath"
+			rawLimitToRegions := path["limit_to_regions"].([]interface{})
+			LimitToRegions := make([]string, len(rawLimitToRegions))
+			for i, v := range rawLimitToRegions {
+				LimitToRegions[i] = v.(string)
+			}
+
+			rawtagFilters := path["tag_filters"].([]interface{})
+			TagFilters := make([]string, len(rawtagFilters))
+			for i, v := range rawtagFilters {
+				TagFilters[i] = v.(string)
+			}
+			pathSettings.LimitToRegions = LimitToRegions
+			pathSettings.LimitToNamespaces = []string{"AWS/EC2"}
+			pathSettings.TagFilters = TagFilters
+		default:
+			log.Printf("[ERROR] Unknown resourceType in path: %v", pathType)
+		}
+	}
+
+	return pathSettings
+}

--- a/sumologic/sumologic_metadata_source.go
+++ b/sumologic/sumologic_metadata_source.go
@@ -1,0 +1,111 @@
+package sumologic
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type MetadataSource struct {
+	Source
+	ContentType   string                `json:"contentType"`
+	ScanInterval  int                   `json:"scanInterval"`
+	Paused        bool                  `json:"paused"`
+	URL           string                `json:"url"`
+	ThirdPartyRef MetadataThirdPartyRef `json:"thirdPartyRef,omitempty"`
+}
+
+type MetadataThirdPartyRef struct {
+	Resources []MetadataResource `json:"resources"`
+}
+
+type MetadataResource struct {
+	ServiceType    string                 `json:"serviceType"`
+	Authentication MetadataAuthentication `json:"authentication"`
+	Path           MetadataPath           `json:"path"`
+}
+
+type MetadataAuthentication struct {
+	Type    string `json:"type"`
+	AwsID   string `json:"awsId"`
+	AwsKey  string `json:"awsKey"`
+	RoleARN string `json:"roleARN"`
+}
+
+type MetadataPath struct {
+	Type              string   `json:"type"`
+	BucketName        string   `json:"bucketName,omitempty"`
+	PathExpression    string   `json:"pathExpression,omitempty"`
+	LimitToRegions    []string `json:"limitToRegions,omitempty"`
+	LimitToNamespaces []string `json:"limitToNamespaces,omitempty"`
+	TagFilters        []string `json:"tagFilters,omitempty"`
+}
+
+func (s *Client) CreateMetadataSource(source MetadataSource, collectorID int) (int, error) {
+
+	type MetadataSourceMessage struct {
+		Source MetadataSource `json:"source"`
+	}
+
+	request := MetadataSourceMessage{
+		Source: source,
+	}
+
+	urlPath := fmt.Sprintf("v1/collectors/%d/sources", collectorID)
+
+	body, err := s.Post(urlPath, request)
+
+	if err != nil {
+		return -1, err
+	}
+
+	var response MetadataSourceMessage
+	err = json.Unmarshal(body, &response)
+
+	if err != nil {
+		return -1, err
+	}
+
+	return response.Source.ID, nil
+}
+
+func (s *Client) GetMetadataSource(collectorID, sourceID int) (*MetadataSource, error) {
+	urlPath := fmt.Sprintf("v1/collectors/%d/sources/%d", collectorID, sourceID)
+	body, _, err := s.Get(urlPath)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if body == nil {
+		return nil, nil
+	}
+
+	type MetadataSourceResponse struct {
+		Source MetadataSource `json:"source"`
+	}
+
+	var response MetadataSourceResponse
+	err = json.Unmarshal(body, &response)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &response.Source, nil
+}
+
+func (s *Client) UpdateMetadataSource(source MetadataSource, collectorID int) error {
+	url := fmt.Sprintf("v1/collectors/%d/sources/%d", collectorID, source.ID)
+
+	type MetadataSourceMessage struct {
+		Source MetadataSource `json:"source"`
+	}
+
+	request := MetadataSourceMessage{
+		Source: source,
+	}
+
+	_, err := s.Put(url, request)
+
+	return err
+}

--- a/sumologic/sumologic_metadata_source.go
+++ b/sumologic/sumologic_metadata_source.go
@@ -33,8 +33,6 @@ type MetadataAuthentication struct {
 
 type MetadataPath struct {
 	Type              string   `json:"type"`
-	BucketName        string   `json:"bucketName,omitempty"`
-	PathExpression    string   `json:"pathExpression,omitempty"`
 	LimitToRegions    []string `json:"limitToRegions,omitempty"`
 	LimitToNamespaces []string `json:"limitToNamespaces,omitempty"`
 	TagFilters        []string `json:"tagFilters,omitempty"`

--- a/website/docs/r/metadata_source.html.markdown
+++ b/website/docs/r/metadata_source.html.markdown
@@ -1,0 +1,86 @@
+---
+layout: "sumologic"
+page_title: "SumoLogic: sumologic_metadata_source"
+description: |-
+  Provides a Sumologic Metadata (Tag) source. This source allows you to collect tags from EC2 instances running on AWS.
+---
+
+# sumologic_polling_source
+Provides a Sumologic Metadata (Tag) source. This source allows you to collect tags from EC2 instances running on AWS.
+
+__IMPORTANT:__ The AWS credentials are stored in plain-text in the state. This is a potential security issue.
+
+## Example Usage
+```hcl
+resource "sumologic_metadata_source" "terraform_metadata" {
+  name          = "Metadata source"
+  description   = "My description"
+  category      = "aws/metadata"
+  content_type  = "AwsMetadata"
+  scan_interval = 300000
+  paused        = false
+  collector_id  = "${sumologic_collector.collector.id}"
+
+  authentication {
+    type = "AWSRoleBasedAuthentication"
+    role_arn = "arn:aws:iam::604066827510:role/cw-role-SumoRole-4AOLS73TGKYI"
+  }
+
+  path {
+    type = "AwsMetadataPath"
+    limit_to_regions = ["us-west-2"]
+    limit_to_namespaces = ["AWS/EC2"]
+    tag_filters = ["Deploy*,", "!DeployStatus,", "Cluster"]
+}
+
+resource "sumologic_collector" "collector" {
+  name        = "my-collector"
+  description = "Just testing this"
+}
+```
+
+## Argument reference
+
+In addition to the common properties, the following arguments are supported:
+
+ - `content_type` - (Required) The content-type of the collected data. For Metadata source this is `AwsMetadata`. Details can be found in the [Sumologic documentation for hosted sources][1].
+ - `scan_interval` - (Required) Time interval in milliseconds of scans for new data. The default is 300000 and the minimum value is 1000 milliseconds.
+ - `paused` - (Required) When set to true, the scanner is paused. To disable, set to false.
+ - `authentication` - (Required) Authentication details for AWS access.
+     + `type` - (Required) Must be either `S3BucketAuthentication` or `AWSRoleBasedAuthentication`
+     + `access_key` - (Required) Your AWS access key if using type `S3BucketAuthentication`
+     + `secret_key` - (Required) Your AWS secret key if using type `S3BucketAuthentication`
+     + `role_arn` - (Required) Your AWS role ARN if using type `AWSRoleBasedAuthentication`
+ - `path` - (Required) The location to scan for new data.
+     + `type` - (Required) type of polling source. Only allowed value is `AwsMetadataPath`.
+     + `limit_to_regions` - (Optional) List of Amazon regions.
+     + `limit_to_namespaces` - List of namespaces. For `AwsMetadataPath` the only valid namespace is `AWS/EC2`. 
+     + `tag_filters` - (Optional) Leave this field blank to collect all tags configured for the EC2 instance. To collect a subset of tags, follow the instructions in [Define EC2 tag filters][2]
+
+### See also
+  * [Sumologic > Sources > Sources for Hosted Collectors > AWS > AWS Metadata (Tag) Source][3]
+  * [Common Source Properties][4]
+
+## Attributes Reference
+The following attributes are exported:
+
+- `id` - The internal ID of the source.
+- `url` - The HTTP endpoint to use with [SNS to notify Sumo Logic of new files](https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/Amazon-Web-Services/AWS-S3-Source#Set_up_SNS_in_AWS_(Optional)).
+
+## Import
+Metadata sources can be imported using the collector and source IDs (`collector/source`), e.g.:
+
+```hcl
+terraform import sumologic_metadata_source.test 123/456
+```
+
+Metadata sources can be imported using the collector name and source name (`collectorName/sourceName`), e.g.:
+
+```hcl
+terraform import sumologic_metadata_source.test my-test-collector/my-test-source
+```
+
+[1]: https://help.sumologic.com/Send_Data/Sources/03Use_JSON_to_Configure_Sources/JSON_Parameters_for_Hosted_Sources
+[2]:https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/Amazon-Web-Services/AWS-Metadata-(Tag)-Source#Define_EC2_tag_filters
+[3]:https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/Amazon-Web-Services/AWS-Metadata-(Tag)-Source
+[4]:https://github.com/terraform-providers/terraform-provider-sumologic/tree/master/website#common-source-properties


### PR DESCRIPTION
Solves #46 

Eg config:
```
resource "sumologic_metadata_source" "tf_metadata" {
  name          = "Amazon Metadata1"
  description   = "My description"
  category      = "aws/metadata"
  content_type  = "AwsMetadata"
  scan_interval = 300000
  paused        = false
  collector_id  = "${sumologic_collector.collector.id}"

  authentication {
    type = "AWSRoleBasedAuthentication"
    role_arn = "xxx"
  }

  path {
    type = "AwsMetadataPath"
    limit_to_regions = ["us-west-2"]
    limit_to_namespaces = ["AWS/EC2"]
    tag_filters = ["Deploy*","Cluster", "!DeployStatus"]
  }
}

```
Have created a new resource because the `tag_filters` for this source type accepts a list of strings as compared to `tag_filters` of polling source which is a list of maps with `type`, `namespace` and `tags` as keys.

Also tested CRUD functionality of this resource locally.