### PR TITLE
Add support for adding AWS XRay source

### DIFF
--- a/sumologic/resource_sumologic_polling_source.go
+++ b/sumologic/resource_sumologic_polling_source.go
@@ -19,10 +19,11 @@ func resourceSumologicPollingSource() *schema.Resource {
 	}
 
 	pollingSource.Schema["content_type"] = &schema.Schema{
-		Type:         schema.TypeString,
-		Required:     true,
-		ForceNew:     true,
-		ValidateFunc: validation.StringInSlice([]string{"AwsS3Bucket", "AwsElbBucket", "AwsCloudFrontBucket", "AwsCloudTrailBucket", "AwsS3AuditBucket", "AwsCloudWatch"}, false),
+		Type:     schema.TypeString,
+		Required: true,
+		ForceNew: true,
+		ValidateFunc: validation.StringInSlice([]string{"AwsS3Bucket", "AwsElbBucket", "AwsCloudFrontBucket",
+			"AwsCloudTrailBucket", "AwsS3AuditBucket", "AwsCloudWatch", "AwsXRay"}, false),
 	}
 	pollingSource.Schema["scan_interval"] = &schema.Schema{
 		Type:     schema.TypeInt,
@@ -73,9 +74,10 @@ func resourceSumologicPollingSource() *schema.Resource {
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"type": {
-					Type:         schema.TypeString,
-					Required:     true,
-					ValidateFunc: validation.StringInSlice([]string{"S3BucketPathExpression", "CloudWatchPath"}, false),
+					Type:     schema.TypeString,
+					Required: true,
+					ValidateFunc: validation.StringInSlice([]string{"S3BucketPathExpression", "CloudWatchPath",
+						"AwsXRayPath"}, false),
 				},
 				"bucket_name": {
 					Type:     schema.TypeString,
@@ -327,6 +329,14 @@ func getPathSettings(d *schema.ResourceData) PollingPath {
 			pathSettings.LimitToRegions = LimitToRegions
 			pathSettings.LimitToNamespaces = LimitToNamespaces
 			pathSettings.TagFilters = getTagFilters(d)
+		case "AwsXRayPath":
+			pathSettings.Type = "AwsXRayPath"
+			rawLimitToRegions := path["limit_to_regions"].([]interface{})
+			LimitToRegions := make([]string, len(rawLimitToRegions))
+			for i, v := range rawLimitToRegions {
+				LimitToRegions[i] = v.(string)
+			}
+			pathSettings.LimitToRegions = LimitToRegions
 		default:
 			log.Printf("[ERROR] Unknown resourceType in path: %v", pathType)
 		}


### PR DESCRIPTION
For AWS XRay source, we only need `limitToRegions`. `limitToNamespaces` and `tagFilters` are not supported