### PR TITLE
Monitor Documentation Updates & ValidateFunc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/posener/complete v1.2.3 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect
+	github.com/stretchr/testify v1.4.0
 	github.com/ulikunitz/xz v0.5.6 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	golang.org/x/crypto v0.0.0-20200210222208-86ce3cb69678 // indirect

--- a/go.sum
+++ b/go.sum
@@ -394,6 +394,7 @@ github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTd
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=

--- a/sumologic/resource_sumologic_monitors_library_monitor.go
+++ b/sumologic/resource_sumologic_monitors_library_monitor.go
@@ -1,6 +1,7 @@
 package sumologic
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -143,8 +144,9 @@ func resourceSumologicMonitorsLibraryMonitor() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"action_type": {
-										Type:     schema.TypeString,
-										Required: true,
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validateActionType,
 									},
 									"subject": {
 										Type:     schema.TypeString,
@@ -410,4 +412,16 @@ func resourceToMonitorsLibraryMonitor(d *schema.ResourceData) MonitorsLibraryMon
 		Status:             d.Get("status").(string),
 		GroupNotifications: d.Get("group_notifications").(bool),
 	}
+}
+
+func validateActionType(val interface{}, key string) (warns []string, errs []error) {
+	v := val.(string)
+	switch v {
+	case
+		"EmailAction",
+		"NamedConnectionAction":
+		return
+	}
+	errs = append(errs, fmt.Errorf("%q must be one of [EmailAction, NamedConnectionAction], got [%s]", key, v))
+	return
 }

--- a/sumologic/resource_sumologic_monitors_library_monitor_test.go
+++ b/sumologic/resource_sumologic_monitors_library_monitor_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAccSumologicMonitorsLibraryMonitor_basic(t *testing.T) {
@@ -33,6 +34,7 @@ func TestAccSumologicMonitorsLibraryMonitor_basic(t *testing.T) {
 		},
 	})
 }
+
 func TestAccMonitorsLibraryMonitor_create(t *testing.T) {
 	var monitorsLibraryMonitor MonitorsLibraryMonitor
 	testNameSuffix := acctest.RandString(16)
@@ -107,6 +109,20 @@ func TestAccMonitorsLibraryMonitor_create(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccMonitorsLibraryMonitor_validateActionType(t *testing.T) {
+	assert := assert.New(t)
+
+	warns, errs := validateActionType("InvalidAction", "notifications.0.notification.0.action_type")
+	assert.Len(warns, 0)
+	assert.Len(errs, 1)
+
+	assert.Equal("\"notifications.0.notification.0.action_type\" must be one of [EmailAction, NamedConnectionAction], got [InvalidAction]", errs[0].(error).Error())
+
+	warns, errs = validateActionType("EmailAction", "notifications.0.notification.0.action_type")
+	assert.Len(warns, 0)
+	assert.Len(errs, 0)
 }
 
 func TestAccMonitorsLibraryMonitor_update(t *testing.T) {


### PR DESCRIPTION
Added:
* ValidateFunc to ensure that the user defines one of the two valid options (`EmailAction`, `NamedConnectionAction`). Provides a user-friendly error message if not.
* Monitor documentation updates to cover the notification blocks a bit better. Also added an example for a `NamedConnectionAction` notification alert here.
