### PR TITLE
Check for errors when getting collector from client

### DIFF
--- a/sumologic/resource_sumologic_collector.go
+++ b/sumologic/resource_sumologic_collector.go
@@ -55,20 +55,28 @@ func resourceSumologicCollector() *schema.Resource {
 func resourceSumologicCollectorRead(d *schema.ResourceData, meta interface{}) error {
 	c := meta.(*Client)
 
-	id, err := strconv.Atoi(d.Id())
-
 	var collector *Collector
+	id, err := strconv.Atoi(d.Id())
 	if err != nil {
-		collector, _ = c.GetCollectorName(d.Id())
+		collector, err = c.GetCollectorName(d.Id())
+		if err != nil {
+			log.Printf("[WARN] Collector not found when looking by name: %s, err: %v", d.Id(), err)
+			d.SetId("")
+			return err
+		}
 		d.SetId(strconv.Itoa(collector.ID))
 	} else {
-		collector, _ = c.GetCollector(id)
+		collector, err = c.GetCollector(id)
+		if err != nil {
+			log.Printf("[WARN] Collector not found when looking by id: %d, err: %v", id, err)
+			d.SetId("")
+			return err
+		}
 	}
 
 	if collector == nil {
 		log.Printf("[WARN] Collector not found, removing from state: %v - %v", id, err)
 		d.SetId("")
-
 		return nil
 	}
 


### PR DESCRIPTION
If the is not performed then on some occasions `collector` might be set to `nil` and then 

```go
d.SetId(strconv.Itoa(collector.ID))
```

will panic as below:

```
2020-10-12T09:25:33.603Z [DEBUG] plugin: plugin process exited: path=/terraform/.terraform/plugins/linux_amd64/terraform-provider-kubernetes_v1.11.4_x4 pid=110
2020-10-12T09:25:33.603Z [DEBUG] plugin: plugin exited
2020/10/12 09:25:33 [TRACE] [walkImport] Exiting eval tree: provider.kubernetes (close)
2020/10/12 09:25:33 [TRACE] vertex "provider.kubernetes (close)": visit complete
2020/10/12 09:25:33 [TRACE] <root>: eval: *terraform.EvalRefresh
2020/10/12 09:25:33 [TRACE] GRPCProvider: ReadResource
2020-10-12T09:25:33.750Z [DEBUG] plugin.terraform-provider-sumologic_v2.0.3_x4: panic: runtime error: invalid memory address or nil pointer dereference
2020-10-12T09:25:33.750Z [DEBUG] plugin.terraform-provider-sumologic_v2.0.3_x4: [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xda406d]
2020-10-12T09:25:33.750Z [DEBUG] plugin.terraform-provider-sumologic_v2.0.3_x4:
2020-10-12T09:25:33.750Z [DEBUG] plugin.terraform-provider-sumologic_v2.0.3_x4: goroutine 46 [running]:
2020-10-12T09:25:33.750Z [DEBUG] plugin.terraform-provider-sumologic_v2.0.3_x4: github.com/terraform-providers/terraform-provider-sumologic/sumologic.resourceSumologicCollectorRead(0xc0001ce5b0, 0x102cb20, 0xc0004f60a0, 0xc0001ce5b0, 0x0)
2020-10-12T09:25:33.750Z [DEBUG] plugin.terraform-provider-sumologic_v2.0.3_x4:         /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-sumologic/sumologic/resource_sumologic_collector.go:77 +0x11d
2020-10-12T09:25:33.750Z [DEBUG] plugin.terraform-provider-sumologic_v2.0.3_x4: github.com/hashicorp/terraform-plugin-sdk/helper/schema.(*Resource).RefreshWithoutUpgrade(0xc000174880, 0xc0005268c0, 0x102cb20, 0xc0004f60a0, 0xc00000e240, 0x0, 0x0)
2020-10-12T09:25:33.750Z [DEBUG] plugin.terraform-provider-sumologic_v2.0.3_x4:         /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-sumologic/vendor/github.com/hashicorp/terraform-plugin-sdk/helper/schema/resource.go:455 +0x119
2020-10-12T09:25:33.750Z [DEBUG] plugin.terraform-provider-sumologic_v2.0.3_x4: github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin.(*GRPCProviderServer).ReadResource(0xc00015e4d0, 0x12b6020, 0xc00058e960, 0xc0005266e0, 0xc00015e4d0, 0xc00058e960, 0xc00025eb30)
2020-10-12T09:25:33.750Z [DEBUG] plugin.terraform-provider-sumologic_v2.0.3_x4:         /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-sumologic/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin/grpc_provider.go:525 +0x3d8
2020-10-12T09:25:33.750Z [DEBUG] plugin.terraform-provider-sumologic_v2.0.3_x4: github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5._Provider_ReadResource_Handler(0xff81a0, 0xc00015e4d0, 0x12b6020, 0xc00058e960, 0xc0000aeba0, 0x0, 0x12b6020, 0xc00058e960, 0xc000590240, 0x88)
2020-10-12T09:25:33.750Z [DEBUG] plugin.terraform-provider-sumologic_v2.0.3_x4:         /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-sumologic/vendor/github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5/tfplugin5.pb.go:3153 +0x217
2020-10-12T09:25:33.750Z [DEBUG] plugin.terraform-provider-sumologic_v2.0.3_x4: google.golang.org/grpc.(*Server).processUnaryRPC(0xc0002bd680, 0x12c1f00, 0xc0000b0d80, 0xc00013e200, 0xc00012ede0, 0x19d8550, 0x0, 0x0, 0x0)
2020-10-12T09:25:33.750Z [DEBUG] plugin.terraform-provider-sumologic_v2.0.3_x4:         /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-sumologic/vendor/google.golang.org/grpc/server.go:1024 +0x4f4
2020-10-12T09:25:33.750Z [DEBUG] plugin.terraform-provider-sumologic_v2.0.3_x4: google.golang.org/grpc.(*Server).handleStream(0xc0002bd680, 0x12c1f00, 0xc0000b0d80, 0xc00013e200, 0x0)
2020-10-12T09:25:33.750Z [DEBUG] plugin.terraform-provider-sumologic_v2.0.3_x4:         /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-sumologic/vendor/google.golang.org/grpc/server.go:1313 +0xd97
2020-10-12T09:25:33.750Z [DEBUG] plugin.terraform-provider-sumologic_v2.0.3_x4: google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc0000a8400, 0xc0002bd680, 0x12c1f00, 0xc0000b0d80, 0xc00013e200)
2020-10-12T09:25:33.750Z [DEBUG] plugin.terraform-provider-sumologic_v2.0.3_x4:         /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-sumologic/vendor/google.golang.org/grpc/server.go:722 +0xbb
2020-10-12T09:25:33.750Z [DEBUG] plugin.terraform-provider-sumologic_v2.0.3_x4: created by google.golang.org/grpc.(*Server).serveStreams.func1
2020-10-12T09:25:33.750Z [DEBUG] plugin.terraform-provider-sumologic_v2.0.3_x4:         /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/terraform-providers/terraform-provider-sumologic/vendor/google.golang.org/grpc/server.go:720 +0xa1
2020-10-12T09:25:33.751Z [DEBUG] plugin: plugin process exited: path=/terraform/.terraform/plugins/linux_amd64/terraform-provider-sumologic_v2.0.3_x4 pid=95 error="exit status 2"
2020/10/12 09:25:33 [ERROR] <root>: eval: *terraform.EvalRefresh, err: rpc error: code = Canceled desc = context canceled
2020/10/12 09:25:33 [ERROR] <root>: eval: *terraform.EvalSequence, err: rpc error: code = Canceled desc = context canceled
```