### PR TITLE
fixing action_type connection_type compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.3.2 (October 15, 2020)
+
+DEPRECATIONS:
+
+* resource/sumologic_monitor: Deprecated `action_type` in notifications in favor of `connection_type`. (GH-94)
+
+DOCS:
+
+* Improved docs for sumologic_monitor resources with webhook connection example
+
 ## 2.3.1 (October 15, 2020)
 
 ENHANCEMENTS:

--- a/sumologic/resource_sumologic_monitors_library_monitor.go
+++ b/sumologic/resource_sumologic_monitors_library_monitor.go
@@ -308,7 +308,9 @@ func resourceSumologicMonitorsLibraryMonitorRead(d *schema.ResourceData, meta in
 		if internalNotificationDict["connectionType"] != nil {
 			internalNotification["connection_type"] = internalNotificationDict["connectionType"].(string)
 		}
-		internalNotification["action_type"] = internalNotificationDict["actionType"].(string)
+		if internalNotificationDict["actionType"] != nil {
+			internalNotification["action_type"] = internalNotificationDict["actionType"].(string)
+		}
 		if internalNotification["action_type"].(string) == "EmailAction" ||
 			internalNotification["action_type"].(string) == "Email" ||
 			internalNotification["connection_type"].(string) == "EmailAction" ||
@@ -398,7 +400,8 @@ func getNotifications(d *schema.ResourceData) []MonitorNotification {
 			notificationActionDict["connection_type"].(string) == "EmailAction" ||
 			notificationActionDict["connection_type"].(string) == "Email" {
 			notificationAction := EmailNotification{}
-			notificationAction.ActionType = notificationActionDict["action_type"].(string)
+			// notificationAction.ActionType = notificationActionDict["action_type"].(string)
+			notificationAction.ConnectionType = notificationActionDict["connection_type"].(string)
 			notificationAction.Subject = notificationActionDict["subject"].(string)
 			notificationAction.Recipients = notificationActionDict["recipients"].([]interface{})
 			notificationAction.MessageBody = notificationActionDict["message_body"].(string)
@@ -406,7 +409,8 @@ func getNotifications(d *schema.ResourceData) []MonitorNotification {
 			n.Notification = notificationAction
 		} else {
 			notificationAction := WebhookNotificiation{}
-			notificationAction.ActionType = notificationActionDict["action_type"].(string)
+			// notificationAction.ActionType = notificationActionDict["action_type"].(string)
+			notificationAction.ConnectionType = notificationActionDict["connection_type"].(string)
 			notificationAction.ConnectionID = notificationActionDict["connection_id"].(string)
 			notificationAction.PayloadOverride = notificationActionDict["payload_override"].(string)
 			n.Notification = notificationAction

--- a/sumologic/resource_sumologic_monitors_library_monitor.go
+++ b/sumologic/resource_sumologic_monitors_library_monitor.go
@@ -133,9 +133,10 @@ func resourceSumologicMonitorsLibraryMonitor() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"action_type": {
-										Type:     schema.TypeString,
-										Optional: true,
-										Computed: true,
+										Type:       schema.TypeString,
+										Optional:   true,
+										Computed:   true,
+										Deprecated: "The field `action_type` is deprecated and will be removed in a future release of the provider - please use `connection_type` instead.",
 									},
 									"connection_type": {
 										Type:     schema.TypeString,

--- a/sumologic/resource_sumologic_monitors_library_monitor.go
+++ b/sumologic/resource_sumologic_monitors_library_monitor.go
@@ -307,7 +307,6 @@ func resourceSumologicMonitorsLibraryMonitorRead(d *schema.ResourceData, meta in
 		schemaInternalNotification := make([]interface{}, 1)
 		internalNotification := make(map[string]interface{})
 		internalNotificationDict := n.Notification.(map[string]interface{})
-		log.Printf("[ROHIT DEBUG] internalNotificationDict before: %v", internalNotificationDict)
 		// log.Printf("monitor.Notification %v", n.Notification)
 		if internalNotificationDict["connectionType"] != nil {
 			internalNotification["connection_type"] = internalNotificationDict["connectionType"].(string)
@@ -322,7 +321,6 @@ func resourceSumologicMonitorsLibraryMonitorRead(d *schema.ResourceData, meta in
 				internalNotification["connection_type"] = "Webhook"
 			}
 		}
-		log.Printf("[ROHIT DEBUG] internalNotification after fixing: %v", internalNotification)
 		if internalNotification["connection_type"].(string) == "Email" {
 			// for backwards compatibility
 			internalNotification["action_type"] = "EmailAction"
@@ -409,17 +407,13 @@ func getNotifications(d *schema.ResourceData) []MonitorNotification {
 		notificationActionDict := rawNotificationAction[0].(map[string]interface{})
 		connectionType := ""
 		actionType := ""
-		log.Printf("[ROHIT DEBUG] notificationActionDict: %v", notificationActionDict)
 		if notificationActionDict["connection_type"] != nil &&
 			notificationActionDict["connection_type"] != "" {
 			connectionType = notificationActionDict["connection_type"].(string)
 			actionType = connectionType
-			log.Printf("[ROHIT DEBUG] actionType in if: %v", actionType)
-			log.Printf("[ROHIT DEBUG] connectionType in if: %v", connectionType)
 		} else {
 			// for backwards compatibility
 			actionType = notificationActionDict["action_type"].(string)
-			log.Printf("[ROHIT DEBUG] actionType in else: %v", actionType)
 			connectionType = actionType
 			// convert from old action_type name to new connection_type name if applicable
 			if connectionType == "EmailAction" {
@@ -428,10 +422,7 @@ func getNotifications(d *schema.ResourceData) []MonitorNotification {
 			if connectionType == "NamedConnectionAction" {
 				connectionType = "Webhook"
 			}
-			log.Printf("[ROHIT DEBUG] connectionType in else: %v", connectionType)
 		}
-		log.Printf("[ROHIT DEBUG] actionType: %v", actionType)
-		log.Printf("[ROHIT DEBUG] connectionType: %v", connectionType)
 		if connectionType == "Email" {
 			notificationAction := EmailNotification{}
 			actionType = "EmailAction"
@@ -452,7 +443,6 @@ func getNotifications(d *schema.ResourceData) []MonitorNotification {
 			n.Notification = notificationAction
 		}
 		n.RunForTriggerTypes = notificationDict["run_for_trigger_types"].([]interface{})
-		log.Printf("[ROHIT DEBUG] Notification object: %v", n.Notification)
 		notifications[i] = n
 	}
 	return notifications

--- a/sumologic/resource_sumologic_monitors_library_monitor.go
+++ b/sumologic/resource_sumologic_monitors_library_monitor.go
@@ -305,6 +305,8 @@ func resourceSumologicMonitorsLibraryMonitorRead(d *schema.ResourceData, meta in
 		schemaInternalNotification := make([]interface{}, 1)
 		internalNotification := make(map[string]interface{})
 		internalNotificationDict := n.Notification.(map[string]interface{})
+		log.Printf("internalNotificationDict %v", internalNotificationDict)
+		log.Printf("monitor.Notification %v", n.Notification)
 		if internalNotificationDict["connectionType"] != nil {
 			internalNotification["connection_type"] = internalNotificationDict["connectionType"].(string)
 		}
@@ -395,12 +397,13 @@ func getNotifications(d *schema.ResourceData) []MonitorNotification {
 		n := MonitorNotification{}
 		rawNotificationAction := notificationDict["notification"].([]interface{})
 		notificationActionDict := rawNotificationAction[0].(map[string]interface{})
+		log.Printf("[ROHIT DEBUG] notificationActionDict: %v", notificationActionDict)
 		if notificationActionDict["action_type"].(string) == "EmailAction" ||
 			notificationActionDict["action_type"].(string) == "Email" ||
 			notificationActionDict["connection_type"].(string) == "EmailAction" ||
 			notificationActionDict["connection_type"].(string) == "Email" {
 			notificationAction := EmailNotification{}
-			// notificationAction.ActionType = notificationActionDict["action_type"].(string)
+			notificationAction.ActionType = notificationActionDict["action_type"].(string)
 			notificationAction.ConnectionType = notificationActionDict["connection_type"].(string)
 			notificationAction.Subject = notificationActionDict["subject"].(string)
 			notificationAction.Recipients = notificationActionDict["recipients"].([]interface{})
@@ -409,7 +412,7 @@ func getNotifications(d *schema.ResourceData) []MonitorNotification {
 			n.Notification = notificationAction
 		} else {
 			notificationAction := WebhookNotificiation{}
-			// notificationAction.ActionType = notificationActionDict["action_type"].(string)
+			notificationAction.ActionType = notificationActionDict["action_type"].(string)
 			notificationAction.ConnectionType = notificationActionDict["connection_type"].(string)
 			notificationAction.ConnectionID = notificationActionDict["connection_id"].(string)
 			notificationAction.PayloadOverride = notificationActionDict["payload_override"].(string)

--- a/sumologic/resource_sumologic_monitors_library_monitor_test.go
+++ b/sumologic/resource_sumologic_monitors_library_monitor_test.go
@@ -74,17 +74,17 @@ func TestAccMonitorsLibraryMonitor_create(t *testing.T) {
 	for i, v := range recipients {
 		testRecipients[i] = v
 	}
-	triggerTypes := []string{"Critical"}
+	triggerTypes := []string{"Critical", "ResolvedCritical"}
 	testTriggerTypes := make([]interface{}, len(triggerTypes))
 	for i, v := range triggerTypes {
 		testTriggerTypes[i] = v
 	}
 	testNotificationAction := EmailNotification{
-		ActionType:  "EmailAction",
-		Recipients:  testRecipients,
-		Subject:     "test tf monitor",
-		TimeZone:    "PST",
-		MessageBody: "test",
+		ConnectionType: "Email",
+		Recipients:     testRecipients,
+		Subject:        "test tf monitor",
+		TimeZone:       "PST",
+		MessageBody:    "test",
 	}
 	testNotifications := []MonitorNotification{
 		{
@@ -111,7 +111,7 @@ func TestAccMonitorsLibraryMonitor_create(t *testing.T) {
 					resource.TestCheckResourceAttr("sumologic_monitor.test", "content_type", testContentType),
 					resource.TestCheckResourceAttr("sumologic_monitor.test", "queries.0.row_id", testQueries[0].RowID),
 					resource.TestCheckResourceAttr("sumologic_monitor.test", "triggers.0.trigger_type", testTriggers[0].TriggerType),
-					resource.TestCheckResourceAttr("sumologic_monitor.test", "notifications.0.notification.0.action_type", testNotifications[0].Notification.(EmailNotification).ActionType),
+					resource.TestCheckResourceAttr("sumologic_monitor.test", "notifications.0.notification.0.connection_type", testNotifications[0].Notification.(EmailNotification).ConnectionType),
 				),
 			},
 		},
@@ -165,11 +165,11 @@ func TestAccMonitorsLibraryMonitor_update(t *testing.T) {
 		testTriggerTypes[i] = v
 	}
 	testNotificationAction := EmailNotification{
-		ActionType:  "EmailAction",
-		Recipients:  testRecipients,
-		Subject:     "test tf monitor",
-		TimeZone:    "PST",
-		MessageBody: "test",
+		ConnectionType: "Email",
+		Recipients:     testRecipients,
+		Subject:        "test tf monitor",
+		TimeZone:       "PST",
+		MessageBody:    "test",
 	}
 	testNotifications := []MonitorNotification{
 		{
@@ -216,17 +216,17 @@ func TestAccMonitorsLibraryMonitor_update(t *testing.T) {
 	for i, v := range updatedRecipients {
 		testUpdatedRecipients[i] = v
 	}
-	updatedTriggerTypes := []string{"Critical"}
+	updatedTriggerTypes := []string{"Critical", "ResolvedCritical"}
 	testUpdatedTriggerTypes := make([]interface{}, len(updatedTriggerTypes))
 	for i, v := range updatedTriggerTypes {
 		testUpdatedTriggerTypes[i] = v
 	}
 	testUpdatedNotificationAction := EmailNotification{
-		ActionType:  "EmailAction",
-		Recipients:  testUpdatedRecipients,
-		Subject:     "test tf monitor",
-		TimeZone:    "PST",
-		MessageBody: "test",
+		ConnectionType: "Email",
+		Recipients:     testUpdatedRecipients,
+		Subject:        "test tf monitor",
+		TimeZone:       "PST",
+		MessageBody:    "test",
 	}
 	testUpdatedNotifications := []MonitorNotification{
 		{
@@ -253,7 +253,7 @@ func TestAccMonitorsLibraryMonitor_update(t *testing.T) {
 					resource.TestCheckResourceAttr("sumologic_monitor.test", "content_type", testContentType),
 					resource.TestCheckResourceAttr("sumologic_monitor.test", "queries.0.row_id", testQueries[0].RowID),
 					resource.TestCheckResourceAttr("sumologic_monitor.test", "triggers.0.trigger_type", testTriggers[0].TriggerType),
-					resource.TestCheckResourceAttr("sumologic_monitor.test", "notifications.0.notification.0.action_type", testNotifications[0].Notification.(EmailNotification).ActionType),
+					resource.TestCheckResourceAttr("sumologic_monitor.test", "notifications.0.notification.0.connection_type", testNotifications[0].Notification.(EmailNotification).ConnectionType),
 				),
 			},
 			{
@@ -267,7 +267,7 @@ func TestAccMonitorsLibraryMonitor_update(t *testing.T) {
 					resource.TestCheckResourceAttr("sumologic_monitor.test", "content_type", testUpdatedContentType),
 					resource.TestCheckResourceAttr("sumologic_monitor.test", "queries.0.row_id", testUpdatedQueries[0].RowID),
 					resource.TestCheckResourceAttr("sumologic_monitor.test", "triggers.0.trigger_type", testUpdatedTriggers[0].TriggerType),
-					resource.TestCheckResourceAttr("sumologic_monitor.test", "notifications.0.notification.0.action_type", testUpdatedNotifications[0].Notification.(EmailNotification).ActionType),
+					resource.TestCheckResourceAttr("sumologic_monitor.test", "notifications.0.notification.0.connection_type", testUpdatedNotifications[0].Notification.(EmailNotification).ConnectionType),
 				),
 			},
 		},
@@ -371,13 +371,13 @@ resource "sumologic_monitor" "test" {
 	  }
 	notifications {
 		notification {
-			action_type = "EmailAction"
+			connection_type = "Email"
 			recipients = ["abc@example.com"]
 			subject = "test tf monitor"
 			time_zone = "PST"
 			message_body = "test"
 		  }
-		run_for_trigger_types = ["Critical"]
+		run_for_trigger_types = ["Critical", "ResolvedCritical"]
 	  }
 }`, testName)
 }
@@ -415,13 +415,13 @@ resource "sumologic_monitor" "test" {
 	  }
 	notifications {
 		notification {
-			action_type = "EmailAction"
+			connection_type = "Email"
 			recipients = ["abc@example.com"]
 			subject = "test tf monitor"
 			time_zone = "PST"
 			message_body = "test"
 		}
-		run_for_trigger_types = ["Critical"]
+		run_for_trigger_types = ["Critical", "ResolvedCritical"]
 	  }
 }`, testName)
 }

--- a/sumologic/sumologic_monitors_library_monitor.go
+++ b/sumologic/sumologic_monitors_library_monitor.go
@@ -141,6 +141,12 @@ type MonitorNotification struct {
 	RunForTriggerTypes []interface{} `json:"runForTriggerTypes"`
 }
 
+type Notification struct {
+	ActionType     string `json:"actionType,omitempty"`
+	ConnectionType string `json:"connectionType,omitempty"`
+	ConnectionID   string `json:"connectionId"`
+}
+
 type EmailNotification struct {
 	ActionType     string        `json:"actionType,omitempty"`
 	ConnectionType string        `json:"connectionType,omitempty"`

--- a/sumologic/sumologic_monitors_library_monitor.go
+++ b/sumologic/sumologic_monitors_library_monitor.go
@@ -141,12 +141,6 @@ type MonitorNotification struct {
 	RunForTriggerTypes []interface{} `json:"runForTriggerTypes"`
 }
 
-type Notification struct {
-	ActionType     string `json:"actionType,omitempty"`
-	ConnectionType string `json:"connectionType,omitempty"`
-	ConnectionID   string `json:"connectionId"`
-}
-
 type EmailNotification struct {
 	ActionType     string        `json:"actionType,omitempty"`
 	ConnectionType string        `json:"connectionType,omitempty"`


### PR DESCRIPTION
A backwards-compatible fix for an API change that we made recently in monitors, which will roll out to prods this week.