### PR TITLE
Add custom diff function for "parse_expression" field

### DIFF
--- a/sumologic/resource_sumologic_extraction_rule.go
+++ b/sumologic/resource_sumologic_extraction_rule.go
@@ -13,6 +13,7 @@ package sumologic
 
 import (
 	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
@@ -39,6 +40,12 @@ func resourceSumologicFieldExtractionRule() *schema.Resource {
 			"parse_expression": {
 				Type:     schema.TypeString,
 				Required: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if strings.Trim(old, "\n ") == strings.Trim(new, "\n ") {
+						return true
+					}
+					return false
+				},
 			},
 			"enabled": {
 				Type:     schema.TypeBool,


### PR DESCRIPTION
Add a custom diff function for `parse_expression` field. 

The field returned in api response is trimmed to remove leading and trailing whitespace and newline chars and is stored in `tfstate` file. This leads to a diff every time `plan` command is run as the configuration has a trailing(or leading) newline or whitespace chars while the state file doesn't.

Fixes #89.

