### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.3 (Unreleased)
+
+FEATURES:
+
 ## 2.3.2 (October 15, 2020)
 
 DEPRECATIONS:


### PR DESCRIPTION
Looking at previous release history, I think this should trigger the github action bot to release a new version for 2.3.2 with monitors fixes for action_type -> connection_type? 