### PR TITLE
Update monitors documentation to use AnyTimeSeries instead of AllTimeSeries

### DIFF
--- a/website/docs/r/connection.html.markdown
+++ b/website/docs/r/connection.html.markdown
@@ -41,7 +41,7 @@ JSON
 
 The following arguments are supported:
 
-- `type` - (Required) Type of connection. Only `WebhookDefinition` is implimented right now.
+- `type` - (Required) Type of connection. Only `WebhookDefinition` is implemented right now.
 - `name` - (Required) Name of connection. Name should be a valid alphanumeric value.
 - `description` - (Optional) Description of the connection.
 - `url` - (Required) URL for the webhook connection.

--- a/website/docs/r/monitor.html.markdown
+++ b/website/docs/r/monitor.html.markdown
@@ -82,7 +82,7 @@ resource "sumologic_monitor" "tf_metrics_monitor_1" {
       threshold = 40.0
       time_range = "15m"
       occurrence_type = "Always"
-      trigger_source = "AllTimeSeries"
+      trigger_source = "AnyTimeSeries"
       trigger_type = "Critical"
       detection_method = "StaticCondition"
     }
@@ -91,7 +91,7 @@ resource "sumologic_monitor" "tf_metrics_monitor_1" {
     threshold = 30.0
     time_range = "15m"
     occurrence_type = "Always"
-    trigger_source = "AllTimeSeries"
+    trigger_source = "AnyTimeSeries"
     trigger_type = "ResolvedCritical"
     detection_method = "StaticCondition"
     }


### PR DESCRIPTION
This should resolve #117.

It looks like there are other PRs open to update the `monitors` docs that might need this fix as well!