### PR TITLE
KinesisMetric TF provider test

### DIFF
--- a/sumologic/resource_sumologic_http_source_test.go
+++ b/sumologic/resource_sumologic_http_source_test.go
@@ -63,7 +63,7 @@ func TestAccSumologicHTTPSource_create(t *testing.T) {
 					resource.TestCheckResourceAttr(kinesisResourceName, "name", kName),
 					resource.TestCheckResourceAttr(kinesisResourceName, "description", kDescription),
 					resource.TestCheckResourceAttr(kinesisResourceName, "category", kCategory),
-					resource.TestCheckResourceAttr(kinesisResourceName, "content_type", "KinesisLog"),
+					resource.TestCheckResourceAttr(kinesisResourceName, "content_type", "KinesisMetric"),
 				),
 			},
 		},
@@ -123,7 +123,7 @@ func TestAccSumologicHTTPSource_update(t *testing.T) {
 					resource.TestCheckResourceAttr(kinesisResourceName, "name", kName),
 					resource.TestCheckResourceAttr(kinesisResourceName, "description", kDescription),
 					resource.TestCheckResourceAttr(kinesisResourceName, "category", kCategory),
-					resource.TestCheckResourceAttr(kinesisResourceName, "content_type", "KinesisLog"),
+					resource.TestCheckResourceAttr(kinesisResourceName, "content_type", "KinesisMetric"),
 				),
 			},
 			{
@@ -137,7 +137,7 @@ func TestAccSumologicHTTPSource_update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", sDescriptionUpdated),
 					resource.TestCheckResourceAttr(resourceName, "category", sCategoryUpdated),
 					resource.TestCheckResourceAttr(tracingResourceName, "content_type", "Zipkin"),
-					resource.TestCheckResourceAttr(kinesisResourceName, "content_type", "KinesisLog"),
+					resource.TestCheckResourceAttr(kinesisResourceName, "content_type", "KinesisMetric"),
 				),
 			},
 		},
@@ -253,7 +253,7 @@ resource "sumologic_http_source" "kinesisLog" {
 	name = "%s"
 	description = "%s"
 	category = "%s"
-	content_type = "KinesisLog"
+	content_type = "KinesisMetric"
 	collector_id = "${sumologic_collector.test.id}"
 }
 `, cName, cDescription, cCategory, sName, sDescription, sCategory, tName, tDescription, tCategory, kName, kDescription, kCategory)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10107180/102973487-ccac9880-4522-11eb-94ce-9692d970c17c.png)

The source was successfully created. Should be good to test from QE side. Exactly like the HTTP source except for the fact that the contentType should be `KinesisMetric`.