### PR TITLE
Add isActive field to handle decommissioned partitions

### DIFF
--- a/sumologic/resource_sumologic_partition.go
+++ b/sumologic/resource_sumologic_partition.go
@@ -56,6 +56,10 @@ func resourceSumologicPartition() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"is_active": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -99,6 +103,7 @@ func resourceSumologicPartitionRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("retention_period", spartition.RetentionPeriod)
 	d.Set("is_compliant", spartition.IsCompliant)
 	d.Set("data_forwarding_id", spartition.DataForwardingId)
+	d.Set("is_active", spartition.IsActive)
 
 	return nil
 }
@@ -128,5 +133,6 @@ func resourceToPartition(d *schema.ResourceData) Partition {
 		RetentionPeriod:   d.Get("retention_period").(int),
 		IsCompliant:       d.Get("is_compliant").(bool),
 		DataForwardingId:  d.Get("data_forwarding_id").(string),
+		IsActive:          d.Get("is_active").(bool),
 	}
 }

--- a/sumologic/sumologic_partition.go
+++ b/sumologic/sumologic_partition.go
@@ -26,6 +26,8 @@ func (s *Client) GetPartition(id string) (*Partition, error) {
 	err = json.Unmarshal(data, &spartition)
 	if err != nil {
 		return nil, err
+	} else if spartition.IsActive == false {
+		return nil, nil
 	}
 
 	return &spartition, nil
@@ -70,4 +72,5 @@ type Partition struct {
 	RetentionPeriod   int    `json:"retentionPeriod"`
 	IsCompliant       bool   `json:"isCompliant"`
 	DataForwardingId  string `json:"dataForwardingId"`
+	IsActive          bool   `json:"isActive"`
 }


### PR DESCRIPTION
The new way to look for decommissioned partitions is via the `isActive` field. Adding it to the resource to handle decommissioned partitions.