### PR TITLE
Add authentication and path params in gcp example

### DIFF
--- a/website/docs/r/gcp_source.html.markdown
+++ b/website/docs/r/gcp_source.html.markdown
@@ -16,6 +16,13 @@ resource "sumologic_gcp_source" "terraform_gcp_source" {
   description   = "My description"
   category      = "gcp"
   collector_id  = "${sumologic_collector.collector.id}"
+  authentication {
+    type = "NoAuthentication"
+  }
+
+  path {
+    type = "NoPathExpression"
+  }
 }
 
 resource "sumologic_collector" "collector" {


### PR DESCRIPTION
Looks like when the optional fields are not specified, they are set to `null` even though we have a default value for them in code. So modifying the example to explicitly set the fields.