### PR TITLE
Fixing doc page title for field_extraction_rule

### DIFF
--- a/website/docs/README.md
+++ b/website/docs/README.md
@@ -26,7 +26,7 @@
 ##### Content
   + [sumologic_scheduled_view][40]
   + [sumologic_partition][41]
-  + [sumologic_extraction_rule][42]
+  + [sumologic_field_extraction_rule][42]
   + [sumologic_folder][43]
   + [sumologic_content][44]
   + [sumologic_connection][45]
@@ -71,7 +71,7 @@ The following properties are common to ALL sources and can be used to configure 
 [31]: r/user.html.markdown
 [40]: r/scheduled_view.html.markdown
 [41]: r/partition.html.markdown
-[42]: r/extraction_rule.html.markdown
+[42]: r/field_extraction_rule.html.markdown
 [43]: r/folder.html.markdown
 [44]: r/content.html.markdown
 [45]: r/connection.html.markdown

--- a/website/docs/r/field_extraction_rule.html.markdown
+++ b/website/docs/r/field_extraction_rule.html.markdown
@@ -1,11 +1,11 @@
 ---
 layout: "sumologic"
-page_title: "SumoLogic: sumologic_extraction_rule"
+page_title: "SumoLogic: sumologic_field_extraction_rule"
 description: |-
   Provides a Sumologic Field Extraction Rule
 ---
 
-# sumologic_extraction_rule
+# sumologic_field_extraction_rule
 Provides a [Sumologic Field Extraction Rule][1].
 
 ## Example Usage

--- a/website/sumologic.erb
+++ b/website/sumologic.erb
@@ -65,7 +65,7 @@
               <a href="/docs/providers/sumologic/r/partition.html">sumologic_partition</a>
             </li>
             <li>
-              <a href="/docs/providers/sumologic/r/extraction_rule.html">sumologic_extraction_rule</a>
+              <a href="/docs/providers/sumologic/r/field_extraction_rule.html">sumologic_field_extraction_rule</a>
             </li>
             <li>
               <a href="/docs/providers/sumologic/r/connection.html">sumologic_connection</a>


### PR DESCRIPTION
I find it confusing that the docs list FERs under "extraction_rule" and not "field_extraction_rule".

No changes to actual provider code in this PR, just the docs.

![image](https://user-images.githubusercontent.com/762437/107209859-aaec6f80-6a03-11eb-90ec-ee742311fad0.png)

