### PR TITLE
Increase delay to 120 sec for C2C update test

### DIFF
--- a/sumologic/resource_sumologic_cloud_to_cloud_source_test.go
+++ b/sumologic/resource_sumologic_cloud_to_cloud_source_test.go
@@ -65,7 +65,7 @@ func TestAccSumologicCloudToCloudSource_update(t *testing.T) {
 func testAccWaitCloudToCloudSource() resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		//lintignore:R018
-		time.Sleep(90 * time.Second)
+		time.Sleep(120 * time.Second)
 		return nil
 	}
 }


### PR DESCRIPTION
The test seems to be failing sometimes with 90 sec delay as well.  Increasing the delay to 120 sec.

```RUN   TestAccSumologicCloudToCloudSource_update\n    TestAccSumologicCloudToCloudSource_update: testing.go:654: Step 1 error: errors during apply:\n        \n        Error: {\n          "status" : 409,\n          "id" : "27NAG-YJ61H-HNIUQ",\n          "code" : "collectors.source.update.blocked",\n          "message" : "Cannot update source while source is in the current state: \'state=Pending\'."\n        }\n        \n          on /tmp/tf-test061306712/main.tf line 8:\n          (source code not available)\n        \n        \n--- FAIL: TestAccSumologicCloudToCloudSource_update (94.72s)\n=== RUN```