### PR TITLE
Add missing resource config for GCP resource in test

### DIFF
--- a/sumologic/resource_sumologic_gcp_source_test.go
+++ b/sumologic/resource_sumologic_gcp_source_test.go
@@ -177,6 +177,13 @@ resource "sumologic_gcp_source" "gcp" {
 	message_per_request = false
 	category = "%s"
 	collector_id = "${sumologic_collector.test.id}"
+	authentication {
+	  type = "NoAuthentication"
+	}
+	
+	path {
+	  type = "NoPathExpression"
+	}
 }
 
 `, cName, cDescription, cCategory, sName, sDescription, sCategory)


### PR DESCRIPTION
Before: 
```
CREATE: sumologic_gcp_source.gcp
  authentication.#:             "" => "0"
  automatic_date_parsing:       "" => "true"
  category:                     "" => "tf-acc-test-5664428303939058944"
  collector_id:                 "" => "<computed>"
  content_type:                 "" => "GoogleCloudLogs"
  cutoff_timestamp:             "" => "0"
  default_date_formats.#:       "" => "0"
  description:                  "" => "tf-acc-test-8443656848804583885"
  filters.#:                    "" => "0"
  force_timezone:               "" => "false"
  id:                           "" => "<computed>"
  message_per_request:          "" => "false"
  multiline_processing_enabled: "" => "true"
  name:                         "" => "tf-acc-test-8516734583602804918"
  path.#:                       "" => "0"
  timezone:                     "" => "Etc/UTC"
  url:                          "" => "<computed>"
  use_autoline_matching:        "" => "true"
  ```
  After:
  ```
  CREATE: sumologic_gcp_source.gcp
  authentication.#:             "" => "1"
  authentication.0.type:        "" => "NoAuthentication"
  automatic_date_parsing:       "" => "true"
  category:                     "" => "tf-acc-test-3640516653296035088"
  collector_id:                 "" => "<computed>"
  content_type:                 "" => "GoogleCloudLogs"
  cutoff_timestamp:             "" => "0"
  default_date_formats.#:       "" => "0"
  description:                  "" => "tf-acc-test-8226798061707042154"
  filters.#:                    "" => "0"
  force_timezone:               "" => "false"
  id:                           "" => "<computed>"
  message_per_request:          "" => "false"
  multiline_processing_enabled: "" => "true"
  name:                         "" => "tf-acc-test-4949264387074228945"
  path.#:                       "" => "1"
  path.0.type:                  "" => "NoPathExpression"
  timezone:                     "" => "Etc/UTC"
  url:                          "" => "<computed>"
  use_autoline_matching:        "" => "true"
  ```