### PR TITLE
Read provider version info during compile time

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,7 +5,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/plugin"
 )
 
+var version string // provider version is passed as compile time argument
+var defaultVersion = "unknown"
+
 func main() {
+	if version == "" {
+		sumologic.ProviderVersion = defaultVersion
+	} else {
+		sumologic.ProviderVersion = version
+	}
 	plugin.Serve(&plugin.ServeOpts{
 		ProviderFunc: sumologic.Provider,
 	})

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 )
 
 var version string // provider version is passed as compile time argument
-var defaultVersion = "unknown"
+var defaultVersion = "dev"
 
 func main() {
 	if version == "" {

--- a/sumologic/provider.go
+++ b/sumologic/provider.go
@@ -14,6 +14,7 @@ import (
 )
 
 func Provider() terraform.ResourceProvider {
+	log.Printf("Sumo Logic Terraform Provider Version=%s\n", ProviderVersion)
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
 			"access_id": {

--- a/sumologic/sumologic_client.go
+++ b/sumologic/sumologic_client.go
@@ -24,6 +24,8 @@ type Client struct {
 	httpClient  HttpClient
 }
 
+var ProviderVersion string
+
 var endpoints = map[string]string{
 	"us1": "https://api.sumologic.com/api/",
 	"us2": "https://api.us2.sumologic.com/api/",
@@ -44,7 +46,7 @@ func createNewRequest(method, url string, body io.Reader, accessID string, acces
 		return nil, err
 	}
 	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("User-Agent", "SumoLogicTerraformProvider/2.3.4")
+	req.Header.Add("User-Agent", "SumoLogicTerraformProvider/"+ProviderVersion)
 	req.SetBasicAuth(accessID, accessKey)
 	return req, nil
 }


### PR DESCRIPTION
Use provider version info passed via `ldflags` instead of hard coded value. `goreleaser` passes in provider version via `ldflags` when making a new release.