### PR TITLE
Use int64 where API returns a 64 bit wide integer

### DIFF
--- a/sumologic/data_source_sumologic_collector.go
+++ b/sumologic/data_source_sumologic_collector.go
@@ -73,7 +73,7 @@ func dataSourceSumologicCollectorRead(d *schema.ResourceData, meta interface{}) 
 		}
 	}
 
-	d.SetId(strconv.Itoa(collector.ID))
+	d.SetId(strconv.FormatInt(collector.ID, 10))
 	d.Set("name", collector.Name)
 	d.Set("description", collector.Description)
 	d.Set("category", collector.Category)

--- a/sumologic/data_source_sumologic_http_source.go
+++ b/sumologic/data_source_sumologic_http_source.go
@@ -2,8 +2,9 @@ package sumologic
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func dataSourceSumologicHTTPSource() *schema.Resource {
@@ -54,7 +55,7 @@ func dataSourceSumologicHTTPSourceRead(d *schema.ResourceData, meta interface{})
 	c := meta.(*Client)
 
 	id, _ := strconv.Atoi(d.Id())
-	source, err := c.GetSourceName(d.Get("collector_id").(int), d.Get("name").(string))
+	source, err := c.GetSourceName(d.Get("collector_id").(int64), d.Get("name").(string))
 
 	if err != nil {
 		return err

--- a/sumologic/sumologic_collectors.go
+++ b/sumologic/sumologic_collectors.go
@@ -49,7 +49,7 @@ func (s *Client) DeleteCollector(id int) error {
 	return err
 }
 
-func (s *Client) CreateCollector(collector Collector) (int, error) {
+func (s *Client) CreateCollector(collector Collector) (int64, error) {
 
 	request := CollectorRequest{
 		Collector: collector,
@@ -101,7 +101,7 @@ type CollectorLink struct {
 }
 
 type Collector struct {
-	ID               int                    `json:"id,omitempty"`
+	ID               int64                  `json:"id,omitempty"`
 	CollectorType    string                 `json:"collectorType,omitempty"`
 	Name             string                 `json:"name"`
 	Description      string                 `json:"description,omitempty"`
@@ -110,6 +110,6 @@ type Collector struct {
 	Fields           map[string]interface{} `json:"fields,omitempty"`
 	Links            []CollectorLink        `json:"links,omitempty"`
 	CollectorVersion string                 `json:"collectorVersion,omitempty"`
-	LastSeenAlive    int                    `json:"lastSeenAlive,omitempty"`
+	LastSeenAlive    int64                  `json:"lastSeenAlive,omitempty"`
 	Alive            bool                   `json:"alive,omitempty"`
 }

--- a/sumologic/sumologic_sources.go
+++ b/sumologic/sumologic_sources.go
@@ -335,7 +335,7 @@ func (s *Client) DestroySource(sourceID int, collectorID int) error {
 	return err
 }
 
-func (s *Client) GetSourceName(collectorID int, sourceName string) (*Source, error) {
+func (s *Client) GetSourceName(collectorID int64, sourceName string) (*Source, error) {
 
 	data, _, err := s.Get(
 		fmt.Sprintf("v1/collectors/%d/sources", collectorID),


### PR DESCRIPTION
Whenever the provider is built on a 32bit platform and a response from the API [1] is being unmarshalled, we get an error saying that an `int64` cannot be unmarshalled as `int`.

This comes from the fact that `Long` in Scala is a 64 bit wide integer and `int` in Go is platform dependent: being 32 bit wide integer on 32 bit platforms.

This PR addresses this problem in collector `struct` but there are other places in this repo where this needs addressing.

Thanks to @astencel-sumo for finding this!

[1]: https://help.sumologic.com/APIs/Collector-Management-API/Collector-API-Methods-and-Examples