### PR TITLE
Remove references to GCP domain verification

### DIFF
--- a/sumologic/resource_sumologic_gcp_source.go
+++ b/sumologic/resource_sumologic_gcp_source.go
@@ -1,7 +1,6 @@
 package sumologic
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"strconv"
@@ -39,7 +38,7 @@ func resourceSumologicGCPSource() *schema.Resource {
 		Type:     schema.TypeList,
 		Optional: true,
 		ForceNew: true,
-		MinItems: 1,
+		MinItems: 0,
 		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
@@ -56,7 +55,7 @@ func resourceSumologicGCPSource() *schema.Resource {
 		Type:     schema.TypeList,
 		Optional: true,
 		ForceNew: true,
-		MinItems: 1,
+		MinItems: 0,
 		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
@@ -144,74 +143,11 @@ func resourceToGCPSource(d *schema.ResourceData) (GCPSource, error) {
 		MessagePerRequest: d.Get("message_per_request").(bool),
 	}
 
-	authSettings, errAuthSettings := getGCPAuthentication(d)
-	if errAuthSettings != nil {
-		return gcpSource, errAuthSettings
-	}
-
-	pathSettings, errPathSettings := getGCPPathSettings(d)
-	if errPathSettings != nil {
-		return gcpSource, errPathSettings
-	}
-
 	GCPResource := GCPResource{
-		ServiceType:    d.Get("content_type").(string),
-		Authentication: authSettings,
-		Path:           pathSettings,
+		ServiceType: d.Get("content_type").(string),
 	}
 
 	gcpSource.ThirdPartyRef.Resources = append(gcpSource.ThirdPartyRef.Resources, GCPResource)
 
 	return gcpSource, nil
-}
-
-func getGCPThirdPartyPathAttributes(GCPResource []GCPResource) []map[string]interface{} {
-
-	var s []map[string]interface{}
-
-	for _, t := range GCPResource {
-		mapping := map[string]interface{}{
-			"type": t.Path.Type,
-		}
-		s = append(s, mapping)
-	}
-	return s
-}
-
-func getGCPAuthentication(d *schema.ResourceData) (GCPAuthentication, error) {
-	auths := d.Get("authentication").([]interface{})
-	authSettings := GCPAuthentication{}
-
-	if len(auths) > 0 {
-		auth := auths[0].(map[string]interface{})
-		switch authType := auth["type"].(string); authType {
-		case "NoAuthentication":
-			authSettings.Type = "NoAuthentication"
-		default:
-			errorMessage := fmt.Sprintf("[ERROR] Unknown authType: %v", authType)
-			log.Print(errorMessage)
-			return authSettings, errors.New(errorMessage)
-		}
-	}
-
-	return authSettings, nil
-}
-
-func getGCPPathSettings(d *schema.ResourceData) (GCPPath, error) {
-	pathSettings := GCPPath{}
-	paths := d.Get("path").([]interface{})
-
-	if len(paths) > 0 {
-		path := paths[0].(map[string]interface{})
-		switch pathType := path["type"].(string); pathType {
-		case "NoPathExpression":
-			pathSettings.Type = "NoPathExpression"
-		default:
-			errorMessage := fmt.Sprintf("[ERROR] Unknown resourceType in path: %v", pathType)
-			log.Print(errorMessage)
-			return pathSettings, errors.New(errorMessage)
-		}
-	}
-
-	return pathSettings, nil
 }

--- a/sumologic/resource_sumologic_gcp_source_test.go
+++ b/sumologic/resource_sumologic_gcp_source_test.go
@@ -10,6 +10,16 @@ import (
 )
 
 func TestAccSumologicGCPSource_create(t *testing.T) {
+	testGCPSourceCreate(t, testAccSumologicGCPSourceConfig)
+	testGCPSourceCreate(t, testAccSumologicGCPSourceConfigDeprecated)
+}
+
+func TestAccSumologicGCPSource_update(t *testing.T) {
+	testGCPSourceUpdate(t, testAccSumologicGCPSourceConfig)
+	testGCPSourceUpdate(t, testAccSumologicGCPSourceConfigDeprecated)
+}
+
+func testGCPSourceCreate(t *testing.T, getConfig func(string, string, string, string, string, string) string) {
 	var gcpSource GCPSource
 	var collector Collector
 	cName, cDescription, cCategory := getRandomizedParams()
@@ -21,7 +31,7 @@ func TestAccSumologicGCPSource_create(t *testing.T) {
 		CheckDestroy: testAccCheckGCPSourceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSumologicGCPSourceConfig(cName, cDescription, cCategory, sName, sDescription, sCategory),
+				Config: getConfig(cName, cDescription, cCategory, sName, sDescription, sCategory),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGCPSourceExists(resourceName, &gcpSource),
 					testAccCheckGCPSourceValues(&gcpSource, sName, sDescription, sCategory),
@@ -40,7 +50,7 @@ func TestAccSumologicGCPSource_create(t *testing.T) {
 	})
 }
 
-func TestAccSumologicGCPSource_update(t *testing.T) {
+func testGCPSourceUpdate(t *testing.T, getConfig func(string, string, string, string, string, string) string) {
 	var gcpSource GCPSource
 	cName, cDescription, cCategory := getRandomizedParams()
 	sName, sDescription, sCategory := getRandomizedParams()
@@ -52,7 +62,7 @@ func TestAccSumologicGCPSource_update(t *testing.T) {
 		CheckDestroy: testAccCheckGCPSourceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSumologicGCPSourceConfig(cName, cDescription, cCategory, sName, sDescription, sCategory),
+				Config: getConfig(cName, cDescription, cCategory, sName, sDescription, sCategory),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGCPSourceExists(resourceName, &gcpSource),
 					testAccCheckGCPSourceValues(&gcpSource, sName, sDescription, sCategory),
@@ -66,7 +76,7 @@ func TestAccSumologicGCPSource_update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccSumologicGCPSourceConfig(cName, cDescription, cCategory, sNameUpdated, sDescriptionUpdated, sCategoryUpdated),
+				Config: getConfig(cName, cDescription, cCategory, sNameUpdated, sDescriptionUpdated, sCategoryUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGCPSourceExists(resourceName, &gcpSource),
 					testAccCheckGCPSourceValues(&gcpSource, sNameUpdated, sDescriptionUpdated, sCategoryUpdated),
@@ -163,28 +173,35 @@ func testAccCheckGCPSourceValues(gcpSource *GCPSource, name, description, catego
 	}
 }
 
-func testAccSumologicGCPSourceConfig(cName, cDescription, cCategory, sName, sDescription, sCategory string) string {
+func testGCPSourceTemplate(cName, cDescription, cCategory, sName, sDescription, sCategory, thirdPartyRef string) string {
 	return fmt.Sprintf(`
 resource "sumologic_collector" "test" {
 	name = "%s"
 	description = "%s"
 	category = "%s"
 }
-	
+
 resource "sumologic_gcp_source" "gcp" {
 	name = "%s"
 	description = "%s"
 	message_per_request = false
 	category = "%s"
-	collector_id = "${sumologic_collector.test.id}"
+	collector_id = "${sumologic_collector.test.id}"%s
+}
+`, cName, cDescription, cCategory, sName, sDescription, sCategory, thirdPartyRef)
+}
+
+func testAccSumologicGCPSourceConfig(cName, cDescription, cCategory, sName, sDescription, sCategory string) string {
+	return testGCPSourceTemplate(cName, cDescription, cCategory, sName, sDescription, sCategory, "")
+}
+
+func testAccSumologicGCPSourceConfigDeprecated(cName, cDescription, cCategory, sName, sDescription, sCategory string) string {
+	deprecatedTPR := `
 	authentication {
 	  type = "NoAuthentication"
 	}
-	
 	path {
 	  type = "NoPathExpression"
-	}
-}
-
-`, cName, cDescription, cCategory, sName, sDescription, sCategory)
+	}`
+	return testGCPSourceTemplate(cName, cDescription, cCategory, sName, sDescription, sCategory, deprecatedTPR)
 }

--- a/sumologic/sumologic_gcp_source.go
+++ b/sumologic/sumologic_gcp_source.go
@@ -17,17 +17,17 @@ type GCPThirdPartyRef struct {
 }
 
 type GCPResource struct {
-	ServiceType    string            `json:"serviceType"`
-	Authentication GCPAuthentication `json:"authentication,omitempty"`
-	Path           GCPPath           `json:"path,omitempty"`
+	ServiceType    string             `json:"serviceType"`
+	Authentication *GCPAuthentication `json:"authentication"`
+	Path           *GCPPath           `json:"path"`
 }
 
 type GCPAuthentication struct {
-	Type string `json:"type"`
+	Type string `json:"type,omitempty"`
 }
 
 type GCPPath struct {
-	Type string `json:"type"`
+	Type string `json:"type,omitempty"`
 }
 
 func (s *Client) CreateGCPSource(gcpSource GCPSource, collectorID int) (int, error) {

--- a/sumologic/sumologic_gcp_source.go
+++ b/sumologic/sumologic_gcp_source.go
@@ -18,16 +18,16 @@ type GCPThirdPartyRef struct {
 
 type GCPResource struct {
 	ServiceType    string             `json:"serviceType"`
-	Authentication *GCPAuthentication `json:"authentication"`
-	Path           *GCPPath           `json:"path"`
+	Authentication *GCPAuthentication `json:"authentication,omitempty"`
+	Path           *GCPPath           `json:"path,omitempty"`
 }
 
 type GCPAuthentication struct {
-	Type string `json:"type,omitempty"`
+	Type string `json:"type"`
 }
 
 type GCPPath struct {
-	Type string `json:"type,omitempty"`
+	Type string `json:"type"`
 }
 
 func (s *Client) CreateGCPSource(gcpSource GCPSource, collectorID int) (int, error) {

--- a/website/docs/r/gcp_source.html.markdown
+++ b/website/docs/r/gcp_source.html.markdown
@@ -8,6 +8,8 @@ description: |-
 # sumologic_gcp_source
 Provides a [Sumo Logic Google Cloud Platform Source][2].
 
+***Note:*** Google no longer requires a pub/sub domain to be [verified][3]. You no longer have to set up domain verification with your GCP Source endpoint.
+
 ## Example Usage
 ```hcl
 
@@ -16,13 +18,6 @@ resource "sumologic_gcp_source" "terraform_gcp_source" {
   description   = "My description"
   category      = "gcp"
   collector_id  = "${sumologic_collector.collector.id}"
-  authentication {
-    type = "NoAuthentication"
-  }
-
-  path {
-    type = "NoPathExpression"
-  }
 }
 
 resource "sumologic_collector" "collector" {
@@ -55,3 +50,4 @@ terraform import sumologic_gcp_source.test my-test-collector/my-test-source
 
 [1]: https://help.sumologic.com/Send_Data/Sources/03Use_JSON_to_Configure_Sources/JSON_Parameters_for_Hosted_Sources
 [2]: https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/Google-Cloud-Platform-Source
+[3]: https://cloud.google.com/pubsub/docs/push


### PR DESCRIPTION
### Description
The placeholder values for `path` and `authentication` are no longer required by Sumo's backend. We can safely remove all references to it in the terraform provider. We still accept the deprecated behavior with placeholders, so this is a backwards compatible change.

### Testing performed
- [x] `TESTARGS="-run TestAccSumologicGCPSource" make testacc`
- [x] Test the new behavior: Ran `terraform apply` with
```
resource "sumologic_collector" "test" {
  name = "ssong-gcp-tf"
  description = "ssong-gcp-tf"
  category = "ssong-gcp-tf"
}
	
resource "sumologic_gcp_source" "gcp" {
  name = "ssong-gcp-tf-test-source"
  description = "ssong-gcp-tf-test-source"
  message_per_request = false
  category = "ssong-gcp-tf-test-source"
  collector_id = "${sumologic_collector.test.id}"
}
```
Verified that the source was created correctly, and that the `path` and `authentication` portions are empty as expected in both UI and API response
- [x] Test deprecated behavior: Ran `terraform apply` with
```
resource "sumologic_collector" "test" {
  name = "ssong-gcp-tf"
  description = "ssong-gcp-tf"
  category = "ssong-gcp-tf"
}
	
resource "sumologic_gcp_source" "gcp" {
  name = "ssong-gcp-tf-test-source"
  description = "ssong-gcp-tf-test-source"
  message_per_request = false
  category = "ssong-gcp-tf-test-source"
  collector_id = "${sumologic_collector.test.id}"
  authentication {
    type = "NoAuthentication"
  }
  path {
    type = "NoPathExpression"
  }
}
```
Verified that the source was created correctly, and that the `path` and `authentication` portions are empty as expected in both UI and API response