### PR TITLE
Add encodedTokenAndUrl for tokens

### DIFF
--- a/sumologic/resource_sumologic_token.go
+++ b/sumologic/resource_sumologic_token.go
@@ -44,6 +44,11 @@ func resourceSumologicToken() *schema.Resource {
 				Required:     true,
 				ValidateFunc: validation.StringInSlice([]string{"CollectorRegistration", "CollectorRegistrationTokenResponse"}, false),
 			},
+
+			"encoded_token_and_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -59,6 +64,7 @@ func resourceSumologicTokenCreate(d *schema.ResourceData, meta interface{}) erro
 		}
 
 		d.SetId(id)
+		d.Set("encoded_token_and_url", token.EncodedTokenAndUrl)
 	}
 
 	return resourceSumologicTokenRead(d, meta)
@@ -83,6 +89,7 @@ func resourceSumologicTokenRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("status", token.Status)
 	d.Set("description", token.Description)
 	d.Set("version", token.Version)
+	d.Set("encoded_token_and_url", token.EncodedTokenAndUrl)
 
 	return nil
 }
@@ -108,11 +115,12 @@ func resourceSumologicTokenUpdate(d *schema.ResourceData, meta interface{}) erro
 func resourceToToken(d *schema.ResourceData) Token {
 
 	return Token{
-		Name:        d.Get("name").(string),
-		ID:          d.Id(),
-		Description: d.Get("description").(string),
-		Version:     d.Get("version").(int),
-		Type:        d.Get("type").(string),
-		Status:      d.Get("status").(string),
+		Name:               d.Get("name").(string),
+		ID:                 d.Id(),
+		Description:        d.Get("description").(string),
+		Version:            d.Get("version").(int),
+		Type:               d.Get("type").(string),
+		Status:             d.Get("status").(string),
+		EncodedTokenAndUrl: d.Get("encoded_token_and_url").(string),
 	}
 }

--- a/sumologic/resource_sumologic_token_test.go
+++ b/sumologic/resource_sumologic_token_test.go
@@ -180,11 +180,13 @@ resource "sumologic_token" "test" {
 func testAccCheckTokenAttributes(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		f := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttrSet(name, "id"),
 			resource.TestCheckResourceAttrSet(name, "name"),
 			resource.TestCheckResourceAttrSet(name, "description"),
 			resource.TestCheckResourceAttrSet(name, "status"),
 			resource.TestCheckResourceAttrSet(name, "type"),
 			resource.TestCheckResourceAttrSet(name, "version"),
+			resource.TestCheckResourceAttrSet(name, "encoded_token_and_url"),
 		)
 		return f(s)
 	}

--- a/sumologic/sumologic_token.go
+++ b/sumologic/sumologic_token.go
@@ -81,10 +81,11 @@ func (s *Client) UpdateToken(token Token) error {
 }
 
 type Token struct {
-	Name        string `json:"name"`
-	Status      string `json:"status"`
-	ID          string `json:"id,omitempty"`
-	Description string `json:"description"`
-	Type        string `json:"type"`
-	Version     int    `json:"version"`
+	Name               string `json:"name"`
+	Status             string `json:"status"`
+	ID                 string `json:"id,omitempty"`
+	Description        string `json:"description"`
+	Type               string `json:"type"`
+	Version            int    `json:"version"`
+	EncodedTokenAndUrl string `json:"encodedTokenAndUrl"`
 }


### PR DESCRIPTION
Added the missing field `encodedTokenAndUrl` for installation tokens.