### PR TITLE
Monitors: Support for new detection methods

### DIFF
--- a/sumologic/sumologic_monitors_library_monitor.go
+++ b/sumologic/sumologic_monitors_library_monitor.go
@@ -151,6 +151,11 @@ type TriggerCondition struct {
 	OccurrenceType  string  `json:"occurrenceType"`
 	TriggerSource   string  `json:"triggerSource"`
 	DetectionMethod string  `json:"detectionMethod"`
+	Field           string  `json:"field,omitempty"`
+	Window          int     `json:"window,omitempty"`
+	BaselineWindow  string  `json:"baselineWindow,omitempty"`
+	Consecutive     int     `json:"consecutive,omitempty"`
+	Direction       string  `json:"direction,omitempty"`
 }
 
 type MonitorNotification struct {


### PR DESCRIPTION
This PR implements support for new detection methods. 

Here's a summary of the changes on the HCL side:
1. The `triggers` block supports 7 new arguments. These arguments, named like `logs_outlier_condition`, represent each of the new detection methods.  
2. Each of these arguments has its own schema with validations.
2. The original `triggers` arguments, such as `time_range` etc., continue to be supported, but are marked deprecated. The intent is that users should move their trigger properties inside an appropriate detection method block instead of specifying them directly under `triggers`.

On the JSON side:
1. The `TriggerCondition` object is extended with additional fields, such as `baseline_window` etc., that are required by the new detection methods. 
    Note that this means that at the JSON level, the trigger condition is represented in a _flattened_ form, in contrast to the block-structured form in HCL. This ensures compatibility with infrastructure APIs.

Here's how a typical `triggers` configuration might look like:
```
triggers {
   logs_outlier_condition {
      trigger_type = "Critical"
      threshold = 3.0
      field = "field"
      window = 5
      consecutive = 1
      direction = "Both"
   }
}

triggers {
   logs_outlier_condition {
      trigger_type = "ResolvedCritical"
      threshold = 3.0
      field = "field"
      window = 5
      consecutive = 1
      direction = "Both"
   }
}
```

#### Preserving legacy arguments in plan after apply 
TF requires that `apply`ing a plan should create no significant changes to the plan, i.e., post-apply, we should be able to "read back" the resource and it should agree on all fields with the configuration. 

Since `triggers` configuration can exist in 2 different forms--flattened (legacy) and block-structured--we need to make sure that a plan in the legacy format does not get converted to a block-structured one. We needed to add some logic to `..Read` method for this. 

### Tests performed
- [x] Unit and acceptance tests
- [ ] Acceptance tests for updates for new detection methods
- [ ] Manual testing: state compatibility with current version 2.9.6
- [ ] Manual testing: import for new detection methods

### Other TODOs
- [ ] Mark old arguments deprecated
- [ ] Docs