### PR TITLE
remove mutexkv import

### DIFF
--- a/sumologic/provider.go
+++ b/sumologic/provider.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/go-errors/errors"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/mutexkv"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
@@ -88,8 +87,6 @@ func Provider() terraform.ResourceProvider {
 		ConfigureFunc: providerConfigure,
 	}
 }
-
-var SumoMutexKV = mutexkv.NewMutexKV()
 
 func resolveRedirectURL(accessId string, accessKey string) (string, error) {
 	req, err := http.NewRequest(http.MethodHead, "https://api.sumologic.com/api/v1/collectors", nil)

--- a/sumologic/sumologic_client.go
+++ b/sumologic/sumologic_client.go
@@ -186,9 +186,6 @@ func (s *Client) PostRawPayload(urlPath string, payload string) ([]byte, error) 
 }
 
 func (s *Client) Put(urlPath string, payload interface{}, isAdminMode bool) ([]byte, error) {
-	SumoMutexKV.Lock(urlPath)
-	defer SumoMutexKV.Unlock(urlPath)
-
 	relativeURL, _ := url.Parse(urlPath)
 	sumoURL := s.BaseURL.ResolveReference(relativeURL)
 


### PR DESCRIPTION
`mutexkv` is removed from v2 of the terraform plugin sdk
I don't think this lock was providing anything either since we wouldn't be modifying the `urlpath` elsewhere while doing the put. 