### PR TITLE
fix: int64 conversion for collector_id in datasource + add docs

### DIFF
--- a/sumologic/data_source_sumologic_http_source.go
+++ b/sumologic/data_source_sumologic_http_source.go
@@ -55,7 +55,7 @@ func dataSourceSumologicHTTPSourceRead(d *schema.ResourceData, meta interface{})
 	c := meta.(*Client)
 
 	id, _ := strconv.Atoi(d.Id())
-	source, err := c.GetSourceName(d.Get("collector_id").(int64), d.Get("name").(string))
+	source, err := c.GetSourceName(int64(d.Get("collector_id").(int)), d.Get("name").(string))
 
 	if err != nil {
 		return err

--- a/sumologic/data_source_sumologic_http_source.go
+++ b/sumologic/data_source_sumologic_http_source.go
@@ -55,7 +55,16 @@ func dataSourceSumologicHTTPSourceRead(d *schema.ResourceData, meta interface{})
 	c := meta.(*Client)
 
 	id, _ := strconv.Atoi(d.Id())
-	source, err := c.GetSourceName(int64(d.Get("collector_id").(int)), d.Get("name").(string))
+	var collectorId int64
+	switch cid := d.Get("collector_id").(type) {
+	case int:
+		collectorId = int64(cid)
+	case int64:
+		collectorId = cid
+	default:
+		return fmt.Errorf("unknown data type of collector_id: %T, value: %v", cid, cid)
+	}
+	source, err := c.GetSourceName(collectorId, d.Get("name").(string))
 
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR fixed int64 conversion related issue of collector_id field in the http_source datasource.

I started using this datasource and was running into an issue where usage of the http_source data block would cause panic and result int crash log. The relevant stack trace is below. I noticed that there was a conversion issue. I also noticed that the existing data source file already had one round of change which was geared towards this #177. however, it looks like the conversion strategy applied there does not fix it properly.  This fix here is to really address what #177 tried to do.

I've also added a minimal datasource doc to address #242 (which I raised a few days ago). 


```
2021-07-22T23:29:40.920-0700 [DEBUG] plugin.terraform-provider-sumologic_v2.9.7: panic: interface conversion: interface {} is int, not int64
2021-07-22T23:29:40.921-0700 [DEBUG] plugin.terraform-provider-sumologic_v2.9.7:
2021-07-22T23:29:40.921-0700 [DEBUG] plugin.terraform-provider-sumologic_v2.9.7: goroutine 43 [running]:
2021-07-22T23:29:40.921-0700 [DEBUG] plugin.terraform-provider-sumologic_v2.9.7: github.com/SumoLogic/terraform-provider-sumologic/sumologic.dataSourceSumologicHTTPSourceRead(0xc00047c380, 0x1a91ce0, 0xc00007f590, 0xc00047c380, 0x0)
2021-07-22T23:29:40.921-0700 [DEBUG] plugin.terraform-provider-sumologic_v2.9.7:        github.com/SumoLogic/terraform-provider-sumologic/sumologic/data_source_sumologic_http_source.go:58 +0x5b3
2021-07-22T23:29:40.921-0700 [DEBUG] plugin.terraform-provider-sumologic_v2.9.7: github.com/hashicorp/terraform-plugin-sdk/helper/schema.(*Resource).ReadDataApply(0xc0000ef400, 0xc0006ad020, 0x1a91ce0, 0xc00007f590, 0xc0004231b0, 0x1, 0x0)
2021-07-22T23:29:40.921-0700 [DEBUG] plugin.terraform-provider-sumologic_v2.9.7:        github.com/hashicorp/terraform-plugin-sdk@v1.7.0/helper/schema/resource.go:398 +0x91
2021-07-22T23:29:40.921-0700 [DEBUG] plugin.terraform-provider-sumologic_v2.9.7: github.com/hashicorp/terraform-plugin-sdk/helper/schema.(*Provider).ReadDataApply(0xc0000ef600, 0xc00049dad8, 0xc0006ad020, 0xc0006ad020, 0x0, 0x0)
2021-07-22T23:29:40.921-0700 [DEBUG] plugin.terraform-provider-sumologic_v2.9.7:        github.com/hashicorp/terraform-plugin-sdk@v1.7.0/helper/schema/provider.go:451 +0x8f
2021-07-22T23:29:40.921-0700 [DEBUG] plugin.terraform-provider-sumologic_v2.9.7: github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin.(*GRPCProviderServer).ReadDataSource(0xc00000e0d8, 0x1c1e130, 0xc000181800, 0xc000502bc0, 0xc00000e0d8, 0xc000181800, 0xc0002e4b80)
2021-07-22T23:29:40.921-0700 [DEBUG] plugin.terraform-provider-sumologic_v2.9.7:        github.com/hashicorp/terraform-plugin-sdk@v1.7.0/internal/helper/plugin/grpc_provider.go:1036 +0x42d
2021-07-22T23:29:40.921-0700 [DEBUG] plugin.terraform-provider-sumologic_v2.9.7: github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5._Provider_ReadDataSource_Handler(0x1a61300, 0xc00000e0d8, 0x1c1e130, 0xc000181800, 0xc00056c660, 0x0, 0x1c1e130, 0xc000181800, 0xc00054aa20, 0x84)
2021-07-22T23:29:40.921-0700 [DEBUG] plugin.terraform-provider-sumologic_v2.9.7:        github.com/hashicorp/terraform-plugin-sdk@v1.7.0/internal/tfplugin5/tfplugin5.pb.go:3225 +0x214
2021-07-22T23:29:40.921-0700 [DEBUG] plugin.terraform-provider-sumologic_v2.9.7: google.golang.org/grpc.(*Server).processUnaryRPC(0xc000093080, 0x1c257d8, 0xc000131500, 0xc00058a200, 0xc000469b30, 0x20ea070, 0x0, 0x0, 0x0)
2021-07-22T23:29:40.921-0700 [DEBUG] plugin.terraform-provider-sumologic_v2.9.7:        google.golang.org/grpc@v1.27.1/server.go:1024 +0x522
2021-07-22T23:29:40.921-0700 [DEBUG] plugin.terraform-provider-sumologic_v2.9.7: google.golang.org/grpc.(*Server).handleStream(0xc000093080, 0x1c257d8, 0xc000131500, 0xc00058a200, 0x0)
2021-07-22T23:29:40.921-0700 [DEBUG] plugin.terraform-provider-sumologic_v2.9.7:        google.golang.org/grpc@v1.27.1/server.go:1313 +0xd2c
2021-07-22T23:29:40.921-0700 [DEBUG] plugin.terraform-provider-sumologic_v2.9.7: google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc0000b41e0, 0xc000093080, 0x1c257d8, 0xc000131500, 0xc00058a200)
2021-07-22T23:29:40.921-0700 [DEBUG] plugin.terraform-provider-sumologic_v2.9.7:        google.golang.org/grpc@v1.27.1/server.go:722 +0xab
2021-07-22T23:29:40.921-0700 [DEBUG] plugin.terraform-provider-sumologic_v2.9.7: created by google.golang.org/grpc.(*Server).serveStreams.func1
2021-07-22T23:29:40.921-0700 [DEBUG] plugin.terraform-provider-sumologic_v2.9.7:        google.golang.org/grpc@v1.27.1/server.go:720 +0xa5
```

