### PR TITLE
Avijit remove triggers deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 2.9.9 (Unreleased)
 
+BUG FIXES:
+
+* resource/sumologic_monitor: Removed deprecation warning for `triggers`.
+
 ## 2.9.8 (July 30, 2021)
 
 FEATURES:

--- a/sumologic/resource_sumologic_monitors_library_monitor.go
+++ b/sumologic/resource_sumologic_monitors_library_monitor.go
@@ -84,9 +84,8 @@ func resourceSumologicMonitorsLibraryMonitor() *schema.Resource {
 			},
 
 			"triggers": {
-				Type:       schema.TypeList,
-				Optional:   true,
-				Deprecated: "The field `triggers` is deprecated and will be removed in a future release of the provider -- please use `trigger_conditions` instead.",
+				Type:     schema.TypeList,
+				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"trigger_type": {


### PR DESCRIPTION
Removing the deprecation warning around `triggers`, which was introduced in https://github.com/SumoLogic/terraform-provider-sumologic/pull/239. The warning is premature because deprecating the `triggers` argument requires new monitor types to be made GA first.