### PR TITLE
Add Terraform support for hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 2.9.11 (Unreleased)
 
+FEATURES:
+
+* **New Resource:** sumologic_hierarchy (GH-260)
 
 ## 2.9.10 (August 24, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.9.11 (Unreleased)
+## 2.10.0 (Unreleased)
 
 FEATURES:
 

--- a/sumologic/provider.go
+++ b/sumologic/provider.go
@@ -75,6 +75,7 @@ func Provider() terraform.ResourceProvider {
 			"sumologic_kinesis_metrics_source":             resourceSumologicKinesisMetricsSource(),
 			"sumologic_token":                              resourceSumologicToken(),
 			"sumologic_policies":                           resourceSumologicPolicies(),
+			"sumologic_hierarchy":                          resourceSumologicHierarchy(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"sumologic_admin_recommended_folder": dataSourceSumologicAdminRecommendedFolder(),

--- a/sumologic/resource_sumologic_hierarchy.go
+++ b/sumologic/resource_sumologic_hierarchy.go
@@ -1,0 +1,326 @@
+package sumologic
+
+import (
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+var (
+	maxDepth            = 6
+	maxWidth            = 20
+	maxHierarchyNameLen = 256
+	maxFilterKeyLen     = 1024
+	maxFilterValueLen   = 1024
+	maxEntityTypeLen    = 1024
+)
+
+func resourceSumologicHierarchy() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceSumologicHierarchyCreate,
+		Read:   resourceSumologicHierarchyRead,
+		Update: resourceSumologicHierarchyUpdate,
+		Delete: resourceSumologicHierarchyDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringLenBetween(1, maxHierarchyNameLen),
+			},
+
+			"filter": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: getFilterSchema(),
+				},
+			},
+
+			"level": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: getLevelSchema(1),
+				},
+			},
+		},
+	}
+}
+
+func getFilterSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"key": {
+			Type:         schema.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringLenBetween(1, maxFilterKeyLen),
+		},
+		"value": {
+			Type:         schema.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringLenBetween(1, maxFilterValueLen),
+		},
+	}
+}
+
+func getLevelSchema(currentDepth int) map[string]*schema.Schema {
+	levelSchema := map[string]*schema.Schema{
+		"entity_type": {
+			Type:         schema.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringLenBetween(1, maxEntityTypeLen),
+		},
+	}
+
+	var nextLevelsWithConditionsSchema map[string]*schema.Schema
+	if currentDepth < maxDepth {
+		nextLevelsWithConditionsSchema = map[string]*schema.Schema{
+			"next_levels_with_conditions": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: maxWidth,
+				Elem: &schema.Resource{
+					Schema: getLevelWithConditionSchema(currentDepth + 1),
+				},
+			},
+		}
+	} else {
+		nextLevelsWithConditionsSchema = map[string]*schema.Schema{
+			"next_levels_with_conditions": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 0,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		}
+	}
+	for k, v := range nextLevelsWithConditionsSchema {
+		levelSchema[k] = v
+	}
+
+	if currentDepth < maxDepth {
+		nextLevelSchema := map[string]*schema.Schema{
+			"next_level": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: getLevelSchema(currentDepth + 1),
+				},
+			},
+		}
+		for k, v := range nextLevelSchema {
+			levelSchema[k] = v
+		}
+	}
+
+	return levelSchema
+}
+
+func getLevelWithConditionSchema(currentDepth int) map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"condition": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		"level": {
+			Type:     schema.TypeList,
+			Required: true,
+			MinItems: 1,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: getLevelSchema(currentDepth),
+			},
+		},
+	}
+}
+
+func resourceSumologicHierarchyCreate(d *schema.ResourceData, meta interface{}) error {
+	c := meta.(*Client)
+
+	if d.Id() == "" {
+		hierarchy := resourceToHierarchy(d)
+
+		log.Println("=====================================================================")
+		log.Printf("Creating hierarchy: %+v\n", hierarchy)
+		log.Println("=====================================================================")
+
+		id, err := c.CreateHierarchy(hierarchy)
+		if err != nil {
+			return err
+		}
+
+		d.SetId(id)
+	}
+
+	return resourceSumologicHierarchyRead(d, meta)
+}
+
+func resourceSumologicHierarchyRead(d *schema.ResourceData, meta interface{}) error {
+	c := meta.(*Client)
+
+	id := d.Id()
+	hierarchy, err := c.GetHierarchy(id)
+
+	log.Println("=====================================================================")
+	log.Printf("Read hierarchy: %+v\n", hierarchy)
+	log.Println("=====================================================================")
+
+	if err != nil {
+		return err
+	}
+
+	if hierarchy == nil {
+		log.Printf("[WARN] Hierarchy not found, removing from state: %v - %v", id, err)
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("name", hierarchy.Name)
+
+	filter := getTerraformFilter(hierarchy.Filter)
+	if err := d.Set("filter", filter); err != nil {
+		return err
+	}
+
+	level := getTerraformLevel(&hierarchy.Level)
+	if err := d.Set("level", level); err != nil {
+		return err
+	}
+
+	log.Println("=====================================================================")
+	log.Printf("name: %+v\n", d.Get("name"))
+	log.Printf("filter: %+v\n", d.Get("filter"))
+	log.Printf("level: %+v\n", d.Get("level"))
+	log.Println("=====================================================================")
+
+	return nil
+}
+
+func resourceSumologicHierarchyDelete(d *schema.ResourceData, meta interface{}) error {
+	c := meta.(*Client)
+
+	log.Printf("Deleting dashboard: %+v\n", d.Id())
+
+	return c.DeleteHierarchy(d.Id())
+}
+
+func resourceSumologicHierarchyUpdate(d *schema.ResourceData, meta interface{}) error {
+	c := meta.(*Client)
+
+	hierarchy := resourceToHierarchy(d)
+
+	log.Println("=====================================================================")
+	log.Printf("Updating hierarchy: %+v\n", hierarchy)
+	log.Println("=====================================================================")
+
+	err := c.UpdateHierarchy(hierarchy)
+	if err != nil {
+		return err
+	}
+
+	return resourceSumologicHierarchyRead(d, meta)
+}
+
+func resourceToHierarchy(d *schema.ResourceData) Hierarchy {
+	var filter HierarchyFilteringClause
+	if val, ok := d.GetOk("filter"); ok {
+		rawFilter := val.([]interface{})[0]
+		filter = getFilter(rawFilter.(map[string]interface{}))
+	}
+
+	rawLevel := d.Get("level").([]interface{})[0]
+	level := getLevel(rawLevel.(map[string]interface{}))
+
+	return Hierarchy{
+		Name:   d.Get("name").(string),
+		ID:     d.Id(),
+		Filter: &filter,
+		Level:  level,
+	}
+}
+
+func getFilter(rawFilter map[string]interface{}) HierarchyFilteringClause {
+	return HierarchyFilteringClause{
+		Key:   rawFilter["key"].(string),
+		Value: rawFilter["value"].(string),
+	}
+}
+
+func getLevel(rawLevel map[string]interface{}) Level {
+	level := Level{}
+	level.EntityType = rawLevel["entity_type"].(string)
+
+	rawNextLevelsWithConditions := rawLevel["next_levels_with_conditions"].([]interface{})
+	nextLevelsWithConditions := []LevelWithCondition{}
+	for _, rawLevelWithCondition := range rawNextLevelsWithConditions {
+		levelWithCondition := getLevelWithCondition(rawLevelWithCondition.(map[string]interface{}))
+		nextLevelsWithConditions = append(nextLevelsWithConditions, levelWithCondition)
+	}
+	level.NextLevelsWithConditions = nextLevelsWithConditions
+
+	rawNextLevels := rawLevel["next_level"].([]interface{})
+	if len(rawNextLevels) > 0 {
+		nextLevel := getLevel(rawNextLevels[0].(map[string]interface{}))
+		level.NextLevel = &nextLevel
+	}
+
+	return level
+}
+
+func getLevelWithCondition(rawLevelWithCondition map[string]interface{}) LevelWithCondition {
+	rawLevel := rawLevelWithCondition["level"].([]interface{})[0]
+	return LevelWithCondition{
+		Condition: rawLevelWithCondition["condition"].(string),
+		Level:     getLevel(rawLevel.(map[string]interface{})),
+	}
+}
+
+func getTerraformFilter(filter *HierarchyFilteringClause) []map[string]interface{} {
+	if filter == nil {
+		return nil
+	}
+
+	tfFilter := []map[string]interface{}{}
+	tfFilter = append(tfFilter, make(map[string]interface{}))
+
+	tfFilter[0]["key"] = filter.Key
+	tfFilter[0]["value"] = filter.Value
+
+	return tfFilter
+}
+
+func getTerraformLevel(level *Level) []map[string]interface{} {
+	if level == nil {
+		return nil
+	}
+
+	tfLevel := []map[string]interface{}{}
+	tfLevel = append(tfLevel, make(map[string]interface{}))
+
+	tfLevel[0]["entity_type"] = level.EntityType
+	tfLevel[0]["next_levels_with_conditions"] = getTerraformLevelsWithConditions(level.NextLevelsWithConditions)
+	tfLevel[0]["next_level"] = getTerraformLevel(level.NextLevel)
+
+	return tfLevel
+}
+
+func getTerraformLevelsWithConditions(levelsWithConditions []LevelWithCondition) []map[string]interface{} {
+	tfLevelsWithConditions := []map[string]interface{}{}
+
+	for _, levelWithCondition := range levelsWithConditions {
+		tfLevelWithCondition := make(map[string]interface{})
+		tfLevelWithCondition["condition"] = levelWithCondition.Condition
+		tfLevelWithCondition["level"] = getTerraformLevel(&levelWithCondition.Level)
+		tfLevelsWithConditions = append(tfLevelsWithConditions, tfLevelWithCondition)
+	}
+
+	return tfLevelsWithConditions
+}

--- a/sumologic/resource_sumologic_hierarchy_test.go
+++ b/sumologic/resource_sumologic_hierarchy_test.go
@@ -1,0 +1,261 @@
+package sumologic
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func getRandomizedParamsForHierarchy() (string, HierarchyFilteringClause, Level) {
+	testNextLevel := Level{
+		EntityType:               "node",
+		NextLevelsWithConditions: []LevelWithCondition{},
+	}
+
+	name := acctest.RandomWithPrefix("tf-acc-test")
+	filter := HierarchyFilteringClause{
+		Key:   acctest.RandomWithPrefix("tf-acc-test"),
+		Value: acctest.RandomWithPrefix("tf-acc-test"),
+	}
+	level := Level{
+		EntityType: "cluster",
+		NextLevelsWithConditions: []LevelWithCondition{
+			{
+				Condition: acctest.RandomWithPrefix("tf-acc-test"),
+				Level: Level{
+					EntityType:               "namespace",
+					NextLevelsWithConditions: []LevelWithCondition{},
+				},
+			},
+		},
+		NextLevel: &testNextLevel,
+	}
+
+	return name, filter, level
+}
+
+func TestAccSumologicHierarchy_basic(t *testing.T) {
+	var hierarchy Hierarchy
+
+	testName, testFilter, testLevel := getRandomizedParamsForHierarchy()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckHierarchyDestroy(hierarchy),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckSumologicHierarchyConfigImported(testName, testFilter, testLevel),
+			},
+			{
+				ResourceName:      "sumologic_hierarchy.test",
+				ImportState:       true,
+				ImportStateVerify: false,
+			},
+		},
+	})
+}
+
+func TestAccSumologicHierarchy_create(t *testing.T) {
+	var hierarchy Hierarchy
+	testName, testFilter, testLevel := getRandomizedParamsForHierarchy()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckHierarchyDestroy(hierarchy),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSumologicHierarchy(testName, testFilter, testLevel),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckHierarchyExists("sumologic_hierarchy.test", &hierarchy, t),
+					resource.TestCheckResourceAttrSet("sumologic_hierarchy.test", "id"),
+					resource.TestCheckResourceAttr("sumologic_hierarchy.test", "name", testName),
+					resource.TestCheckResourceAttr("sumologic_hierarchy.test", "filter.0.key", testFilter.Key),
+					resource.TestCheckResourceAttr("sumologic_hierarchy.test", "filter.0.value", testFilter.Value),
+					resource.TestCheckResourceAttr("sumologic_hierarchy.test",
+						"level.0.next_levels_with_conditions.0.condition",
+						testLevel.NextLevelsWithConditions[0].Condition),
+					resource.TestCheckResourceAttr("sumologic_hierarchy.test",
+						"level.0.next_levels_with_conditions.0.level.0.entity_type",
+						testLevel.NextLevelsWithConditions[0].Level.EntityType),
+					resource.TestCheckResourceAttr("sumologic_hierarchy.test",
+						"level.0.next_level.0.entity_type",
+						testLevel.NextLevel.EntityType),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckHierarchyDestroy(hierarchy Hierarchy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*Client)
+		for _, r := range s.RootModule().Resources {
+			id := r.Primary.ID
+			u, err := client.GetHierarchy(id)
+			if err != nil {
+				return fmt.Errorf("Encountered an error: " + err.Error())
+			}
+			if u != nil {
+				return fmt.Errorf("Hierarchy %s still exists", id)
+			}
+		}
+		return nil
+	}
+}
+
+func testAccCheckHierarchyExists(name string, hierarchy *Hierarchy, t *testing.T) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			//need this so that we don't get an unused import error for strconv in some cases
+			return fmt.Errorf("Error = %s. Hierarchy not found: %s", strconv.FormatBool(ok), name)
+		}
+
+		//need this so that we don't get an unused import error for strings in some cases
+		if strings.EqualFold(rs.Primary.ID, "") {
+			return fmt.Errorf("Hierarchy ID is not set")
+		}
+
+		id := rs.Primary.ID
+		c := testAccProvider.Meta().(*Client)
+		newHierarchy, err := c.GetHierarchy(id)
+		if err != nil {
+			return fmt.Errorf("Hierarchy %s not found", id)
+		}
+		hierarchy = newHierarchy
+		return nil
+	}
+}
+
+func TestAccSumologicHierarchy_update(t *testing.T) {
+	var hierarchy Hierarchy
+	testName, testFilter, testLevel := getRandomizedParamsForHierarchy()
+
+	testUpdatedName, testUpdatedFilter, testUpdatedLevel := getRandomizedParamsForHierarchy()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckHierarchyDestroy(hierarchy),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSumologicHierarchy(testName, testFilter, testLevel),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckHierarchyExists("sumologic_hierarchy.test", &hierarchy, t),
+					resource.TestCheckResourceAttrSet("sumologic_hierarchy.test", "id"),
+					resource.TestCheckResourceAttr("sumologic_hierarchy.test", "name", testName),
+					resource.TestCheckResourceAttr("sumologic_hierarchy.test", "filter.0.key", testFilter.Key),
+					resource.TestCheckResourceAttr("sumologic_hierarchy.test", "filter.0.value", testFilter.Value),
+					resource.TestCheckResourceAttr("sumologic_hierarchy.test",
+						"level.0.next_levels_with_conditions.0.condition",
+						testLevel.NextLevelsWithConditions[0].Condition),
+					resource.TestCheckResourceAttr("sumologic_hierarchy.test",
+						"level.0.next_levels_with_conditions.0.level.0.entity_type",
+						testLevel.NextLevelsWithConditions[0].Level.EntityType),
+					resource.TestCheckResourceAttr("sumologic_hierarchy.test",
+						"level.0.next_level.0.entity_type",
+						testLevel.NextLevel.EntityType),
+				),
+			},
+			{
+				Config: testAccSumologicHierarchyUpdate(testUpdatedName, testUpdatedFilter, testUpdatedLevel),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckHierarchyExists("sumologic_hierarchy.test", &hierarchy, t),
+					resource.TestCheckResourceAttrSet("sumologic_hierarchy.test", "id"),
+					resource.TestCheckResourceAttr("sumologic_hierarchy.test", "name", testUpdatedName),
+					resource.TestCheckResourceAttr("sumologic_hierarchy.test", "filter.0.key", testUpdatedFilter.Key),
+					resource.TestCheckResourceAttr("sumologic_hierarchy.test", "filter.0.value", testUpdatedFilter.Value),
+					resource.TestCheckResourceAttr("sumologic_hierarchy.test",
+						"level.0.next_levels_with_conditions.0.condition",
+						testUpdatedLevel.NextLevelsWithConditions[0].Condition),
+					resource.TestCheckResourceAttr("sumologic_hierarchy.test",
+						"level.0.next_levels_with_conditions.0.level.0.entity_type",
+						testUpdatedLevel.NextLevelsWithConditions[0].Level.EntityType),
+					resource.TestCheckResourceAttr("sumologic_hierarchy.test",
+						"level.0.next_level.0.entity_type",
+						testUpdatedLevel.NextLevel.EntityType),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckSumologicHierarchyConfigImported(name string, filter HierarchyFilteringClause, level Level) string {
+	return fmt.Sprintf(`
+        resource "sumologic_hierarchy" "test" {
+            name = "%s"
+            filter {
+                key = "%s"
+                value = "%s"
+            }
+            level {
+                entity_type = "cluster"
+                next_levels_with_conditions {
+                    condition = "%s"
+                    level {
+                        entity_type = "namespace"
+                    }
+                }
+                next_level {
+                    entity_type = "node"
+                }
+            }
+        }`, name, filter.Key, filter.Value, level.NextLevelsWithConditions[0].Condition)
+}
+
+func testAccSumologicHierarchy(name string, filter HierarchyFilteringClause, level Level) string {
+	return fmt.Sprintf(`
+        resource "sumologic_hierarchy" "test" {
+            name = "%s"
+            filter {
+                key = "%s"
+                value = "%s"
+            }
+            level {
+                entity_type = "%s"
+                next_levels_with_conditions {
+                    condition = "%s"
+                    level {
+                        entity_type = "%s"
+                    }
+                }
+                next_level {
+                    entity_type = "%s"
+                }
+            }
+        }`,
+		name, filter.Key, filter.Value, level.EntityType, level.NextLevelsWithConditions[0].Condition,
+		level.NextLevelsWithConditions[0].Level.EntityType, level.NextLevel.EntityType)
+}
+
+func testAccSumologicHierarchyUpdate(name string, filter HierarchyFilteringClause, level Level) string {
+	return fmt.Sprintf(`
+        resource "sumologic_hierarchy" "test" {
+            name = "%s"
+            filter {
+                key = "%s"
+                value = "%s"
+            }
+            level {
+                entity_type = "%s"
+                next_levels_with_conditions {
+                    condition = "%s"
+                    level {
+                        entity_type = "%s"
+                    }
+                }
+                next_level {
+                    entity_type = "%s"
+                }
+            }
+        }`,
+		name, filter.Key, filter.Value, level.EntityType, level.NextLevelsWithConditions[0].Condition,
+		level.NextLevelsWithConditions[0].Level.EntityType, level.NextLevel.EntityType)
+}

--- a/sumologic/sumologic_hierarchy.go
+++ b/sumologic/sumologic_hierarchy.go
@@ -1,0 +1,104 @@
+package sumologic
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+func (s *Client) CreateHierarchy(hierarchy Hierarchy) (string, error) {
+	urlWithoutParams := "v1/entities/hierarchies"
+
+	data, err := s.Post(urlWithoutParams, hierarchy, false)
+	if err != nil {
+		return "", err
+	}
+
+	var createdHierarchy Hierarchy
+
+	err = json.Unmarshal(data, &createdHierarchy)
+	if err != nil {
+		return "", err
+	}
+
+	return createdHierarchy.ID, nil
+
+}
+
+func (s *Client) GetHierarchy(id string) (*Hierarchy, error) {
+	urlWithoutParams := "v1/entities/hierarchies/%s"
+	paramString := ""
+	sprintfArgs := []interface{}{}
+	sprintfArgs = append(sprintfArgs, id)
+
+	urlWithParams := fmt.Sprintf(urlWithoutParams+paramString, sprintfArgs...)
+
+	data, _, err := s.Get(urlWithParams, false)
+	if err != nil {
+		return nil, err
+	}
+	if data == nil {
+		return nil, nil
+	}
+
+	var hierarchy Hierarchy
+
+	err = json.Unmarshal(data, &hierarchy)
+	if err != nil {
+		return nil, err
+	}
+
+	return &hierarchy, nil
+
+}
+
+func (s *Client) DeleteHierarchy(id string) error {
+	urlWithoutParams := "v1/entities/hierarchies/%s"
+	paramString := ""
+	sprintfArgs := []interface{}{}
+	sprintfArgs = append(sprintfArgs, id)
+
+	urlWithParams := fmt.Sprintf(urlWithoutParams+paramString, sprintfArgs...)
+
+	_, err := s.Delete(urlWithParams)
+
+	return err
+}
+
+func (s *Client) UpdateHierarchy(hierarchy Hierarchy) error {
+	urlWithoutParams := "v1/entities/hierarchies/%s"
+	paramString := ""
+	sprintfArgs := []interface{}{}
+	sprintfArgs = append(sprintfArgs, hierarchy.ID)
+
+	urlWithParams := fmt.Sprintf(urlWithoutParams+paramString, sprintfArgs...)
+
+	hierarchy.ID = ""
+
+	_, err := s.Put(urlWithParams, hierarchy, false)
+
+	return err
+
+}
+
+type Hierarchy struct {
+	Name   string                    `json:"name"`
+	ID     string                    `json:"id,omitempty"`
+	Filter *HierarchyFilteringClause `json:"filter"`
+	Level  Level                     `json:"level"`
+}
+
+type HierarchyFilteringClause struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+type Level struct {
+	EntityType               string               `json:"entityType"`
+	NextLevelsWithConditions []LevelWithCondition `json:"nextLevelsWithConditions"`
+	NextLevel                *Level               `json:"nextLevel,omitempty"`
+}
+
+type LevelWithCondition struct {
+	Condition string `json:"condition"`
+	Level     Level  `json:"level"`
+}

--- a/website/docs/r/hierarchy.html.markdown
+++ b/website/docs/r/hierarchy.html.markdown
@@ -1,0 +1,60 @@
+---
+layout: "sumologic"
+page_title: "SumoLogic: sumologic_hierarchy"
+description: |-
+  Provides a Sumologic Hierarchy
+---
+
+# sumologic_hierarchy
+Provides a [Sumologic Hierarchy][1].
+
+## Example Usage
+```hcl
+resource "sumologic_hierarchy" "example_hierarchy" {
+  name = "testK8sHierarchy"
+  filter {
+    key   = "_origin"
+    value = "kubernetes" 
+  }
+  level {
+    entity_type = "cluster"
+    next_levels_with_conditions {
+      condition = "testCondition"
+      level {
+        entity_type = "namespace"
+      }
+    }
+    next_level {
+      entity_type = "node"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `name` - (Required) Name of the hierarchy.
+- `filter` - (Optional) An optional clause that a hierarchy requires to be matched.
+  + `key` - (Required) Filtering key.
+  + `value` - (Required) Value required for the filtering key.
+- `level` - (Required) A hierarchy of entities. The order is up-down, left to right levels with condition, then level without condition. 
+  + `entity_type` - (Required) Indicates the name and type for all entities at this hierarchy level, e.g. service or pod in case of kubernetes entities.
+  + `next_levels_with_conditions` - (Optional) Zero or more next levels with conditions.
+    + `condition` - (Required) Condition to be checked against for level.entityType value, for now full string match.
+    + `level` - (Required)
+  + `next_level` - (Optional) Next level without a condition.
+  
+The following attributes are exported:
+
+- `id` - The internal ID of the hierarchy.
+
+## Import
+Hierarchies can be imported using the id, e.g.:
+
+```hcl
+terraform import sumologic_hierarchy.test id
+```
+
+[1]: https://help.sumologic.com/Visualizations-and-Alerts/Explore

--- a/website/docs/r/hierarchy.html.markdown
+++ b/website/docs/r/hierarchy.html.markdown
@@ -39,7 +39,7 @@ The following arguments are supported:
 - `filter` - (Optional) An optional clause that a hierarchy requires to be matched.
   + `key` - (Required) Filtering key.
   + `value` - (Required) Value required for the filtering key.
-- `level` - (Required) A hierarchy of entities. The order is up-down, left to right levels with condition, then level without condition. 
+- `level` - (Required) A hierarchy of entities. The order is up-down, left to right levels with condition, then level without condition. Maximum supported total depth is 6.
   + `entity_type` - (Required) Indicates the name and type for all entities at this hierarchy level, e.g. service or pod in case of kubernetes entities.
   + `next_levels_with_conditions` - (Optional) Zero or more next levels with conditions.
     + `condition` - (Required) Condition to be checked against for level.entityType value, for now full string match.


### PR DESCRIPTION
Add Terraform support for entities hierarchies

Hierarchies API uses recursively defined structures, as a workaround TF schemas are defined through those recursions expanded to some set depth.