### PR TITLE
Reduced nesting level to fix formatting issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ BUG FIXES:
 
 * resource/sumologic_monitor: Removed deprecation warning for `triggers`.
 * seperated docs for sumologic_monitor_folder from docs for sumologic_monitor.
+* resource/sumologic_monitor: Fixed docs for `trigger_conditions`.
 
 ## 2.9.8 (July 30, 2021)
 

--- a/website/docs/r/monitor.html.markdown
+++ b/website/docs/r/monitor.html.markdown
@@ -264,8 +264,18 @@ trigger_conditions {
 }
 ```
 ### Arguments
-Here is a summary of the various condition types that are supported, and the arguments each of them takes (fields which are not marked as `Required` are optional):
-- `logs_static_condition`:
+A `trigger_conditions` block contains one or more subblocks of the following types:
+- `logs_static_condition`
+- `metrics_static_condition`
+- `logs_outlier_condition`
+- `metrics_outlier_condition`
+- `logs_missing_data_condition`
+- `metrics_missing_data_condition`
+
+Subblocks should be limited to at most 1 missing data condition and at most 1 static / outlier condition.
+
+Here is a summary of arguments for each condition type (fields which are not marked as `Required` are optional):
+#### logs_static_condition
   - `field`
   - `critical`
     - `time_range` (Required)
@@ -283,7 +293,7 @@ Here is a summary of the various condition types that are supported, and the arg
     - `resolution` (Required)
       - `threshold`
       - `threshold_type`
-- `metrics_static_condition`:
+#### metrics_static_condition
   - `critical`
     - `time_range` (Required)
     - `occurrence_type` (Required)
@@ -302,7 +312,7 @@ Here is a summary of the various condition types that are supported, and the arg
     - `resolution` (Required)
       - `threshold`
       - `threshold_type`
-- `logs_outlier_condition`:
+#### logs_outlier_condition
   - `field`
   - `direction`
   - `critical`
@@ -313,7 +323,7 @@ Here is a summary of the various condition types that are supported, and the arg
      - `window`
      - `consecutive`
      - `threshold`
-- `metrics_outlier_condition`:
+#### metrics_outlier_condition
   - `direction`
   - `critical`
      - `baseline_window`
@@ -321,21 +331,11 @@ Here is a summary of the various condition types that are supported, and the arg
   - `warning`
     - `baseline_window`
     - `threshold`
-- `logs_missing_data_condition`:
+#### logs_missing_data_condition
   - `time_range` (Required)
-- `metrics_missing_data_condition`:
+#### metrics_missing_data_condition
   - `time_range` (Required)
   - `trigger_source` (Required)
-
-A `trigger_conditions` block can contain at most 1 data condition:
- - `logs_static_condition`
- - `metrics_static_condition`
- - `logs_outlier_condition`
- - `metrics_outlier_condition`
- 
-and at most 1 missing-data condition:
-  - `logs_missing_data_condition`
-  - `metrics_missing_data_condition`
 
 ## Import
 


### PR DESCRIPTION
Terraform seems to have messed up indentation in arguments reference. The published [docs](https://registry.terraform.io/providers/SumoLogic/sumologic/latest/docs/resources/monitor):
![image](https://user-images.githubusercontent.com/2488456/128563291-238e40e1-26b6-4aa7-871c-a4168c2f54e8.png)
instead of 
![image](https://user-images.githubusercontent.com/2488456/128563321-922c218d-d164-4874-9899-95b61c2cb31b.png)

I suspect if this was caused as a result of the nesting depth in that argument list being one level too deep for Terraform? 
This PR reduces the nesting depth. Hopefully this will fix formatting and will come out like so:
![image](https://user-images.githubusercontent.com/2488456/128563718-8b105bb1-bcea-4c2b-967f-e2863f6ec833.png)
