### PR TITLE
Make all policies required in policies resource

### DIFF
--- a/sumologic/resource_sumologic_policies.go
+++ b/sumologic/resource_sumologic_policies.go
@@ -26,39 +26,33 @@ func resourceSumologicPolicies() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"audit": {
 				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  DefaultPolicies.Audit.Enabled,
+				Required: true,
 			},
 			"data_access_level": {
 				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  DefaultPolicies.DataAccessLevel.Enabled,
+				Required: true,
 			},
 			"max_user_session_timeout": {
 				Type:     schema.TypeString,
-				Optional: true,
-				Default:  DefaultPolicies.MaxUserSessionTimeout.MaxUserSessionTimeout,
+				Required: true,
 			},
 			"search_audit": {
 				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  DefaultPolicies.SearchAudit.Enabled,
+				Required: true,
 			},
 			"share_dashboards_outside_organization": {
 				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  DefaultPolicies.ShareDashboardsOutsideOrganization.Enabled,
+				Required: true,
 			},
 			"user_concurrent_sessions_limit": {
 				Type:     schema.TypeList,
-				Optional: true,
+				Required: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"enabled": {
 							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  DefaultPolicies.UserConcurrentSessionsLimit.Enabled,
+							Required: true,
 						},
 						"max_concurrent_sessions": {
 							Type:     schema.TypeInt,

--- a/website/docs/r/policies.html.markdown
+++ b/website/docs/r/policies.html.markdown
@@ -36,15 +36,15 @@ resource "sumologic_policies" "example_policies" {
 
 The following arguments are supported:
 
-- `audit` - (Optional) Whether the [Audit Policy][1] is enabled. Defaults to `false`.
-- `data_access_level` - (Optional) Whether the [Data Access Level Policy][2] is enabled. Defaults to `false`.
-- `max_user_session_timeout` - (Optional) The [maximum web session timeout][3] users are able to configure within their user preferences. Defaults to `7d`.
-- `search_audit` - (Optional) Whether the [Search Audit Policy][4] is enabled. Defaults to `false`.
-- `share_dashboards_outside_organization` - (Optional) Whether the [Share a Dashboard Outside Organization Policy][5] is enabled. Defaults to `false`.
-- `user_concurrent_sessions_limit` - (Block List, Max: 1, Optional) The [User Concurrent Sessions Limit Policy][6]. See [user_concurrent_sessions_limit schema](#user_concurrent_sessions_limit) for details.
+- `audit` - (Required) Whether the [Audit Policy][1] is enabled.
+- `data_access_level` - (Required) Whether the [Data Access Level Policy][2] is enabled.
+- `max_user_session_timeout` - (Required) The [maximum web session timeout][3] users are able to configure within their user preferences.
+- `search_audit` - (Required) Whether the [Search Audit Policy][4] is enabled.
+- `share_dashboards_outside_organization` - (Required) Whether the [Share a Dashboard Outside Organization Policy][5] is enabled.
+- `user_concurrent_sessions_limit` - (Block List, Max: 1, Required) The [User Concurrent Sessions Limit Policy][6]. See [user_concurrent_sessions_limit schema](#user_concurrent_sessions_limit) for details.
 
 ### Schema for `user_concurrent_sessions_limit`
-- `enabled` - (Optional) Whether the [User Concurrent Sessions Limit Policy][6] is enabled. Defaults to `false`.
+- `enabled` - (Required) Whether the [User Concurrent Sessions Limit Policy][6] is enabled.
 - `max_concurrent_sessions` - (Optional) Maximum number of concurrent sessions a user may have. Defaults to `100`.
 
 ## Import


### PR DESCRIPTION
Make all policies required in the policies resource in order to make it more explicit and minimize unintended behavior. This is a breaking change but since this resource was released very recently, it's currently only used by a couple of clients.