### PR TITLE
SUMO-176361: add capability names to the doc

### DIFF
--- a/website/docs/r/role.html.markdown
+++ b/website/docs/r/role.html.markdown
@@ -27,57 +27,7 @@ The following arguments are supported:
 - `name` - (Required) The name of the role.
 - `description` - (Optional) The description of the role.
 - `filter_predicate` - (Optional) A search filter to restrict access to specific logs.
-- `capabilities` - (Optional) List of capabilities associated with this role. Valid Values are:  
-  - Data Management:  
-    - viewCollectors
-    - manageCollectors
-    - manageBudgets
-    - manageDataVolumeFeed
-    - viewFieldExtraction
-    - manageFieldExtractionRules
-    - manageS3DataForwarding
-    - manageContent
-    - dataVolumeIndex
-    - manageConnections
-    - viewScheduledViews
-    - manageScheduledViews
-    - viewPartitions
-    - managePartitions
-    - viewFields
-    - manageFields
-    - viewAccountOverview
-    - manageTokens
-  - Entity management:
-    - manageEntityTypeConfig
-  - Metrics:
-    - metricsTransformation
-    - metricsExtraction
-    - metricsRules
-  - Security:
-    - managePasswordPolicy
-    - ipAllowlisting
-    - createAccessKeys
-    - manageAccessKeys
-    - manageSupportAccountAccess
-    - manageAuditDataFeed
-    - manageSaml
-    - shareDashboardOutsideOrg
-    - manageOrgSettings
-    - changeDataAccessLevel
-  - Dashboards:
-    - shareDashboardWorld
-    - shareDashboardAllowlist
-  - UserManagement:
-    - manageUsersAndRoles
-  - Observability:
-    - searchAuditIndex
-    - auditEventIndex
-  - Cloud SIEM Enterprise:
-    - viewCse
-  - Alerting:
-    - viewMonitorsV2
-    - manageMonitorsV2
-    - viewAlerts
+- `capabilities` - (Optional) List of capabilities associated with this role. For a complete list of capability names, please see `capabilities` field in the request of [CreateRole][2] endpoint.
     
 The following attributes are exported:
 
@@ -91,3 +41,4 @@ terraform import sumologic_role.role 1234567890
 ```
 
 [1]: https://help.sumologic.com/Manage/Users-and-Roles/Manage-Roles
+[2]: https://api.sumologic.com/docs/#operation/createRole


### PR DESCRIPTION
Modified the doc to include all capability names from the page https://api.sumologic.com/docs/#operation/createRole. 