### PR TITLE
Issue 297 sumologic monitor metrics resolution occurrence type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 2.11.1 (Unreleased)
 
+BUG FIXES:
+ 
+* Fix occurrence_type for metrics resolution conditions (GH-297)
+
 ## 2.11.0 (October 19, 2021)
 
 FEATURES:

--- a/sumologic/resource_sumologic_monitors_library_monitor.go
+++ b/sumologic/resource_sumologic_monitors_library_monitor.go
@@ -765,7 +765,13 @@ func metricsStaticConditionBlockToJson(block map[string]interface{}) []TriggerCo
 	base := TriggerCondition{
 		DetectionMethod: metricsStaticConditionDetectionMethod,
 	}
-	return base.cloneReadingFromNestedBlocks(block)
+	triggerConditions := base.cloneReadingFromNestedBlocks(block)
+	for i, _ := range triggerConditions {
+		if triggerConditions[i].TriggerType == "ResolvedCritical" || triggerConditions[i].TriggerType == "ResolvedWarning" {
+			triggerConditions[i].OccurrenceType = "Always"
+		}
+	}
+	return triggerConditions
 }
 
 func logsOutlierConditionBlockToJson(block map[string]interface{}) []TriggerCondition {
@@ -935,7 +941,11 @@ func jsonToMetricsStaticConditionBlock(conditions []TriggerCondition) map[string
 		case "ResolvedCritical":
 			hasCritical = true
 			criticalDict["time_range"] = condition.PositiveTimeRange()
-			criticalDict["occurrence_type"] = condition.OccurrenceType
+			// Issue 297: Do not set parent block's occurrence_type from resolution triggers.
+			// Resolution triggers have either the same occurrence_type as their alert counterparts,
+			// or, in case of MetricsStaticCondition, are always set to "Always".
+			// In either case, the parent's occurrence_type will be set when visiting the alert trigger.
+			// criticalDict["occurrence_type"] = condition.OccurrenceType
 			criticalRslv["threshold"] = condition.Threshold
 			criticalRslv["threshold_type"] = condition.ThresholdType
 		case "Warning":
@@ -947,7 +957,11 @@ func jsonToMetricsStaticConditionBlock(conditions []TriggerCondition) map[string
 		case "ResolvedWarning":
 			hasWarning = true
 			warningDict["time_range"] = condition.PositiveTimeRange()
-			warningDict["occurrence_type"] = condition.OccurrenceType
+			// Issue 297: Do not set parent block's occurrence_type from resolution triggers.
+			// Resolution triggers have either the same occurrence_type as their alert counterparts,
+			// or, in case of MetricsStaticCondition, are always set to "Always".
+			// In either case, the parent's occurrence_type will be set when visiting the alert trigger.
+			// warningDict["occurrence_type"] = condition.OccurrenceType
 			warningRslv["threshold"] = condition.Threshold
 			warningRslv["threshold_type"] = condition.ThresholdType
 		}

--- a/sumologic/resource_sumologic_monitors_library_monitor.go
+++ b/sumologic/resource_sumologic_monitors_library_monitor.go
@@ -941,11 +941,6 @@ func jsonToMetricsStaticConditionBlock(conditions []TriggerCondition) map[string
 		case "ResolvedCritical":
 			hasCritical = true
 			criticalDict["time_range"] = condition.PositiveTimeRange()
-			// Issue 297: Do not set parent block's occurrence_type from resolution triggers.
-			// Resolution triggers have either the same occurrence_type as their alert counterparts,
-			// or, in case of MetricsStaticCondition, are always set to "Always".
-			// In either case, the parent's occurrence_type will be set when visiting the alert trigger.
-			// criticalDict["occurrence_type"] = condition.OccurrenceType
 			criticalRslv["threshold"] = condition.Threshold
 			criticalRslv["threshold_type"] = condition.ThresholdType
 		case "Warning":
@@ -957,11 +952,6 @@ func jsonToMetricsStaticConditionBlock(conditions []TriggerCondition) map[string
 		case "ResolvedWarning":
 			hasWarning = true
 			warningDict["time_range"] = condition.PositiveTimeRange()
-			// Issue 297: Do not set parent block's occurrence_type from resolution triggers.
-			// Resolution triggers have either the same occurrence_type as their alert counterparts,
-			// or, in case of MetricsStaticCondition, are always set to "Always".
-			// In either case, the parent's occurrence_type will be set when visiting the alert trigger.
-			// warningDict["occurrence_type"] = condition.OccurrenceType
 			warningRslv["threshold"] = condition.Threshold
 			warningRslv["threshold_type"] = condition.ThresholdType
 		}

--- a/sumologic/resource_sumologic_monitors_library_monitor_test.go
+++ b/sumologic/resource_sumologic_monitors_library_monitor_test.go
@@ -617,7 +617,23 @@ var exampleLogsStaticTriggerConditionBlock = `
      field = "field"
    }`
 
-var exampleMetricsStaticTriggerConditionBlock = `
+var exampleMetricsStaticTriggerConditionBlock1 = `
+   metrics_static_condition {
+     critical {
+       time_range = "30m"
+       occurrence_type = "AtLeastOnce"
+       alert {
+         threshold = 100.0
+         threshold_type = "GreaterThan"
+       }
+       resolution {
+         threshold = 90
+         threshold_type = "LessThanOrEqual"
+       }
+     }
+   }`
+
+var exampleMetricsStaticTriggerConditionBlock2 = `
    metrics_static_condition {
      critical {
        time_range = "30m"
@@ -670,10 +686,16 @@ func exampleLogsStaticMonitor(testName string) string {
 		exampleLogsStaticTriggerConditionBlock, []string{"Critical", "ResolvedCritical"})
 }
 
-func exampleMetricsStaticMonitor(testName string) string {
+func exampleMetricsStaticMonitor1(testName string) string {
 	query := "error _sourceCategory=category"
 	return exampleMonitorWithTriggerCondition(testName, "Metrics", query,
-		exampleMetricsStaticTriggerConditionBlock, []string{"Critical", "ResolvedCritical"})
+		exampleMetricsStaticTriggerConditionBlock1, []string{"Critical", "ResolvedCritical"})
+}
+
+func exampleMetricsStaticMonitor2(testName string) string {
+	query := "error _sourceCategory=category"
+	return exampleMonitorWithTriggerCondition(testName, "Metrics", query,
+		exampleMetricsStaticTriggerConditionBlock2, []string{"Critical", "ResolvedCritical"})
 }
 
 func exampleLogsOutlierMonitor(testName string) string {
@@ -702,7 +724,8 @@ func exampleMetricsMissingDataMonitor(testName string) string {
 
 var allExampleMonitors = []func(testName string) string{
 	exampleLogsStaticMonitor,
-	exampleMetricsStaticMonitor,
+	exampleMetricsStaticMonitor1,
+	exampleMetricsStaticMonitor2,
 	exampleLogsOutlierMonitor,
 	exampleMetricsOutlierMonitor,
 	exampleLogsMissingDataMonitor,


### PR DESCRIPTION
This fixes https://github.com/SumoLogic/terraform-provider-sumologic/issues/297

* Block -> JSON: Hardcode `occurrence_type = "Always"` in resolution triggers for Metrics static conditions
* JSON -> Block: Disregard occurrence_type from resolution blocks while setting `OccurrenceType` field in the parent block. Since resolution triggers are always accompanied by alert triggers, and alert triggers have the correct occurrence type, the parent's `OccurrenceType` gets set using the alert trigger's value.

Also added a test case.