### PR TITLE
Skip CSE related tests if SKIP_CSE_TESTS env var is set

### DIFF
--- a/sumologic/provider_test.go
+++ b/sumologic/provider_test.go
@@ -2,6 +2,7 @@ package sumologic
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -26,6 +27,12 @@ func TestProvider(t *testing.T) {
 
 func TestProvider_impl(t *testing.T) {
 	var _ terraform.ResourceProvider = Provider()
+}
+
+func SkipCseTest(t *testing.T) {
+	if strings.ToLower(os.Getenv("SKIP_CSE_TESTS")) == "true" {
+		t.Skip("Skipping CSE Test")
+	}
 }
 
 func testAccPreCheck(t *testing.T) {

--- a/sumologic/resource_sumologic_cse_aggregation_rule_test.go
+++ b/sumologic/resource_sumologic_cse_aggregation_rule_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccSumologicCSEAggregationRule_createAndUpdate(t *testing.T) {
+	SkipCseTest(t)
+
 	var AggregationRule CSEAggregationRule
 	aggregationFunctionName := "distinct_eventid_count"
 	aggregationFunction := "count_distinct"

--- a/sumologic/resource_sumologic_cse_chain_rule_test.go
+++ b/sumologic/resource_sumologic_cse_chain_rule_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccSumologicCSEChainRule_createAndUpdate(t *testing.T) {
+	SkipCseTest(t)
+
 	var ChainRule CSEChainRule
 	description := "Test description"
 	enabled := true

--- a/sumologic/resource_sumologic_cse_custom_entity_type_test.go
+++ b/sumologic/resource_sumologic_cse_custom_entity_type_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccSumologicSCECustomEntityType_create(t *testing.T) {
+	SkipCseTest(t)
+
 	var customEntityType CSECustomEntityType
 	nName := "New Custom Entity Type"
 	nIdentifier := "identifier"
@@ -32,6 +34,8 @@ func TestAccSumologicSCECustomEntityType_create(t *testing.T) {
 }
 
 func TestAccSumologicSCECustomEntityType_update(t *testing.T) {
+	SkipCseTest(t)
+
 	var customEntityType CSECustomEntityType
 	nName := "New Custom Entity Type"
 	nIdentifier := "identifier"

--- a/sumologic/resource_sumologic_cse_custom_insight.go
+++ b/sumologic/resource_sumologic_cse_custom_insight.go
@@ -41,8 +41,8 @@ func resourceSumologicCSECustomInsight() *schema.Resource {
 				},
 			},
 			"severity": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
 				ValidateFunc: validation.StringInSlice([]string{"HIGH", "MEDIUM", "LOW"}, false),
 			},
 			"signal_names": {

--- a/sumologic/resource_sumologic_cse_custom_insight_test.go
+++ b/sumologic/resource_sumologic_cse_custom_insight_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccSumologicCSECustomInsight_createAndUpdate(t *testing.T) {
+	SkipCseTest(t)
+
 	var CustomInsight CSECustomInsight
 	description := "Test description"
 	enabled := true

--- a/sumologic/resource_sumologic_cse_entity_criticality_config_test.go
+++ b/sumologic/resource_sumologic_cse_entity_criticality_config_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccSumologicSCEEntityCriticalityConfig_create(t *testing.T) {
+	SkipCseTest(t)
+
 	var entityCriticalityConfig CSEEntityCriticalityConfig
 	nName := "New Entity Criticality"
 	nSeverityExpression := "severity + 2"
@@ -31,6 +33,8 @@ func TestAccSumologicSCEEntityCriticalityConfig_create(t *testing.T) {
 }
 
 func TestAccSumologicSCEEntityCriticalityConfig_update(t *testing.T) {
+	SkipCseTest(t)
+
 	var entityCriticalityConfig CSEEntityCriticalityConfig
 	nName := "New Entity Criticality"
 	nSeverityExpression := "severity + 2"

--- a/sumologic/resource_sumologic_cse_insights_configuration_test.go
+++ b/sumologic/resource_sumologic_cse_insights_configuration_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccSumologicSCEInsightsConfiguration_create(t *testing.T) {
+	SkipCseTest(t)
+
 	var insightConfiguration CSEInsightsConfiguration
 	nLookbackDays := 10.0
 	nThreshold := 13.0

--- a/sumologic/resource_sumologic_cse_insights_resolution_test.go
+++ b/sumologic/resource_sumologic_cse_insights_resolution_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccSumologicSCEInsightsResolution_create(t *testing.T) {
+	SkipCseTest(t)
+
 	var insightResolution CSEInsightsResolutionGet
 	nName := "New Insights Resolution"
 	nDescription := "New Insights Resolution Description"

--- a/sumologic/resource_sumologic_cse_insights_status_test.go
+++ b/sumologic/resource_sumologic_cse_insights_status_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccSumologicSCEInsightsStatus_create(t *testing.T) {
+	SkipCseTest(t)
+
 	var insightStatus CSEInsightsStatusGet
 	nName := "New Test Status"
 	nDescription := "New Test Status Description"

--- a/sumologic/resource_sumologic_cse_log_mapping_test.go
+++ b/sumologic/resource_sumologic_cse_log_mapping_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccSumologicSCELogMapping_create(t *testing.T) {
+	SkipCseTest(t)
+
 	var logMapping CSELogMapping
 	lmName := "New Log Mapping"
 	lmRecordType := "Audit"
@@ -63,6 +65,8 @@ func TestAccSumologicSCELogMapping_create(t *testing.T) {
 }
 
 func TestAccSumologicSCELogMapping_update(t *testing.T) {
+	SkipCseTest(t)
+
 	var logMapping CSELogMapping
 	lmName := "New Log Mapping"
 	lmRecordType := "Audit"
@@ -187,7 +191,7 @@ resource "sumologic_cse_log_mapping" "log_mapping" {
 			event_id_pattern = "%s"
 			log_format = "%s"
 			product = "${data.sumologic_cse_log_mapping_vendor_product.web_gateway.product}"
-			vendor = "${data.sumologic_cse_log_mapping_vendor_product.web_gateway.vendor}"	
+			vendor = "${data.sumologic_cse_log_mapping_vendor_product.web_gateway.vendor}"
 	}
 }
 

--- a/sumologic/resource_sumologic_cse_match_rule_test.go
+++ b/sumologic/resource_sumologic_cse_match_rule_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccSumologicCSEMatchRule_createAndUpdate(t *testing.T) {
+	SkipCseTest(t)
+
 	var matchRule CSEMatchRule
 	descriptionExpression := "Test description"
 	enabled := true

--- a/sumologic/resource_sumologic_cse_network_block_test.go
+++ b/sumologic/resource_sumologic_cse_network_block_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccSumologicSCENetworkBlock_create(t *testing.T) {
+	SkipCseTest(t)
+
 	var networkBlock CSENetworkBlock
 	nAddressBlock := "10.0.1.0/26"
 	nLabel := "network block test"

--- a/sumologic/resource_sumologic_cse_rule_tuning_expression_test.go
+++ b/sumologic/resource_sumologic_cse_rule_tuning_expression_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccSumologicSCERuleTuningExpression_create(t *testing.T) {
+	SkipCseTest(t)
+
 	var ruleTuningExpression CSERuleTuningExpression
 	nName := "New Rule Tuning Name"
 	nDescription := "New Rule Tuning Description"

--- a/sumologic/resource_sumologic_cse_threshold_rule_test.go
+++ b/sumologic/resource_sumologic_cse_threshold_rule_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccSumologicCSEThresholdRule_createAndUpdate(t *testing.T) {
+	SkipCseTest(t)
+
 	var thresholdRule CSEThresholdRule
 	countDistinct := true
 	countField := "dstDevice_hostname"


### PR DESCRIPTION
CSE test will be skipped if `SKIP_CSE_TESTS` env var is set to "true". 

```
$ make testacc
...
=== RUN   TestAccSumologicCSEAggregationRule_createAndUpdate
    provider_test.go:40: SUMOLOGIC_ACCESSKEY must be set for acceptance tests
--- FAIL: TestAccSumologicCSEAggregationRule_createAndUpdate (0.00s)
=== RUN   TestAccSumologicCSEChainRule_createAndUpdate
    provider_test.go:40: SUMOLOGIC_ACCESSKEY must be set for acceptance tests
--- FAIL: TestAccSumologicCSEChainRule_createAndUpdate (0.00s)
=== RUN   TestAccSumologicSCECustomEntityType_create
    provider_test.go:40: SUMOLOGIC_ACCESSKEY must be set for acceptance tests
--- FAIL: TestAccSumologicSCECustomEntityType_create (0.00s)
...
```

with `SKIP_CSE_TESTS` set
```
$ SKIP_CSE_TESTS=true make testacc
...
=== RUN   TestAccSumologicCSEAggregationRule_createAndUpdate
    provider_test.go:34: Skipping CSE Test
--- SKIP: TestAccSumologicCSEAggregationRule_createAndUpdate (0.00s)
=== RUN   TestAccSumologicCSEChainRule_createAndUpdate
    provider_test.go:34: Skipping CSE Test
--- SKIP: TestAccSumologicCSEChainRule_createAndUpdate (0.00s)
=== RUN   TestAccSumologicSCECustomEntityType_create
    provider_test.go:34: Skipping CSE Test
--- SKIP: TestAccSumologicSCECustomEntityType_create (0.00s)
...
```