### PR TITLE
add snsTopicArn field in polling sources

### DIFF
--- a/sumologic/resource_sumologic_generic_polling_source.go
+++ b/sumologic/resource_sumologic_generic_polling_source.go
@@ -130,7 +130,7 @@ func resourceSumologicGenericPollingSource() *schema.Resource {
 						},
 					},
 				},
-				"sns_topic_arn": {
+				"sns_topic_or_subscription_arn": {
 					Type:     schema.TypeList,
 					MaxItems: 1,
 					Computed: true,
@@ -269,13 +269,13 @@ func getPollingThirdPartyPathAttributes(pollingResource []PollingResource) []map
 
 	for _, t := range pollingResource {
 		mapping := map[string]interface{}{
-			"type":                t.Path.Type,
-			"bucket_name":         t.Path.BucketName,
-			"path_expression":     t.Path.PathExpression,
-			"limit_to_regions":    t.Path.LimitToRegions,
-			"limit_to_namespaces": t.Path.LimitToNamespaces,
-			"tag_filters":         flattenPollingTagFilters(t.Path.TagFilters),
-			"sns_topic_arn":       flattenPollingSnsTopicArn(t.Path.SnsTopicOrSubscriptionArn),
+			"type":                          t.Path.Type,
+			"bucket_name":                   t.Path.BucketName,
+			"path_expression":               t.Path.PathExpression,
+			"limit_to_regions":              t.Path.LimitToRegions,
+			"limit_to_namespaces":           t.Path.LimitToNamespaces,
+			"tag_filters":                   flattenPollingTagFilters(t.Path.TagFilters),
+			"sns_topic_or_subscription_arn": flattenPollingSnsTopicArn(t.Path.SnsTopicOrSubscriptionArn),
 		}
 		s = append(s, mapping)
 	}
@@ -350,7 +350,7 @@ func flattenPollingSnsTopicArn(v SnsTopicArn) []map[string]interface{} {
 func getPollingSnsTopicArn(d *schema.ResourceData) SnsTopicArn {
 	paths := d.Get("path").([]interface{})
 	path := paths[0].(map[string]interface{})
-	snsConfig := path["sns_topic_arn"].([]interface{})
+	snsConfig := path["sns_topic_or_subscription_arn"].([]interface{})
 	snsTopicArn := SnsTopicArn{}
 
 	if len(snsConfig) > 0 {

--- a/sumologic/resource_sumologic_generic_polling_source.go
+++ b/sumologic/resource_sumologic_generic_polling_source.go
@@ -132,7 +132,6 @@ func resourceSumologicGenericPollingSource() *schema.Resource {
 				},
 				"sns_topic_or_subscription_arn": {
 					Type:     schema.TypeList,
-					MaxItems: 1,
 					Computed: true,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{

--- a/sumologic/resource_sumologic_generic_polling_source.go
+++ b/sumologic/resource_sumologic_generic_polling_source.go
@@ -275,7 +275,7 @@ func getPollingThirdPartyPathAttributes(pollingResource []PollingResource) []map
 			"limit_to_regions":              t.Path.LimitToRegions,
 			"limit_to_namespaces":           t.Path.LimitToNamespaces,
 			"tag_filters":                   flattenPollingTagFilters(t.Path.TagFilters),
-			"sns_topic_or_subscription_arn": flattenPollingSnsTopicArn(t.Path.SnsTopicOrSubscriptionArn),
+			"sns_topic_or_subscription_arn": flattenPollingSnsSubscriptionOrTopicArn(t.Path.SnsTopicOrSubscriptionArn),
 		}
 		s = append(s, mapping)
 	}
@@ -337,30 +337,30 @@ func getPollingTagFilters(d *schema.ResourceData) []TagFilter {
 	return filters
 }
 
-func flattenPollingSnsTopicArn(v SnsTopicArn) []map[string]interface{} {
-	var snsTopicArn []map[string]interface{}
+func flattenPollingSnsSubscriptionOrTopicArn(v SnsSubscriptionOrTopicArn) []map[string]interface{} {
+	var snsSubscriptionOrTopicArn []map[string]interface{}
 	snsTopic := map[string]interface{}{
 		"is_success": v.IsSuccess,
 		"arn":        v.Arn,
 	}
-	snsTopicArn = append(snsTopicArn, snsTopic)
-	return snsTopicArn
+	snsSubscriptionOrTopicArn = append(snsSubscriptionOrTopicArn, snsTopic)
+	return snsSubscriptionOrTopicArn
 }
 
-func getPollingSnsTopicArn(d *schema.ResourceData) SnsTopicArn {
+func getPollingSnsSubscriptionOrTopicArn(d *schema.ResourceData) SnsSubscriptionOrTopicArn {
 	paths := d.Get("path").([]interface{})
 	path := paths[0].(map[string]interface{})
 	snsConfig := path["sns_topic_or_subscription_arn"].([]interface{})
-	snsTopicArn := SnsTopicArn{}
+	snsSubscriptionOrTopicArn := SnsSubscriptionOrTopicArn{}
 
 	if len(snsConfig) > 0 {
 		for _, rawConfig := range snsConfig {
 			config := rawConfig.(map[string]interface{})
-			snsTopicArn.IsSuccess = config["is_success"].(bool)
-			snsTopicArn.Arn = config["arn"].(string)
+			snsSubscriptionOrTopicArn.IsSuccess = config["is_success"].(bool)
+			snsSubscriptionOrTopicArn.Arn = config["arn"].(string)
 		}
 	}
-	return snsTopicArn
+	return snsSubscriptionOrTopicArn
 }
 
 func getPollingAuthentication(d *schema.ResourceData) (PollingAuthentication, error) {
@@ -408,7 +408,7 @@ func getPollingPathSettings(d *schema.ResourceData) (PollingPath, error) {
 			pathSettings.Type = "S3BucketPathExpression"
 			pathSettings.BucketName = path["bucket_name"].(string)
 			pathSettings.PathExpression = path["path_expression"].(string)
-			pathSettings.SnsTopicOrSubscriptionArn = getPollingSnsTopicArn(d)
+			pathSettings.SnsTopicOrSubscriptionArn = getPollingSnsSubscriptionOrTopicArn(d)
 		case "CloudWatchPath", "AwsInventoryPath":
 			pathSettings.Type = pathType
 			rawLimitToRegions := path["limit_to_regions"].([]interface{})

--- a/sumologic/resource_sumologic_generic_polling_source.go
+++ b/sumologic/resource_sumologic_generic_polling_source.go
@@ -274,7 +274,7 @@ func getPollingThirdPartyPathAttributes(pollingResource []PollingResource) []map
 			"limit_to_regions":              t.Path.LimitToRegions,
 			"limit_to_namespaces":           t.Path.LimitToNamespaces,
 			"tag_filters":                   flattenPollingTagFilters(t.Path.TagFilters),
-			"sns_topic_or_subscription_arn": flattenPollingSnsSubscriptionOrTopicArn(t.Path.SnsTopicOrSubscriptionArn),
+			"sns_topic_or_subscription_arn": flattenPollingSnsTopicOrSubscriptionArn(t.Path.SnsTopicOrSubscriptionArn),
 		}
 		s = append(s, mapping)
 	}
@@ -336,30 +336,30 @@ func getPollingTagFilters(d *schema.ResourceData) []TagFilter {
 	return filters
 }
 
-func flattenPollingSnsSubscriptionOrTopicArn(v SnsSubscriptionOrTopicArn) []map[string]interface{} {
-	var snsSubscriptionOrTopicArn []map[string]interface{}
+func flattenPollingSnsTopicOrSubscriptionArn(v PollingSnsTopicOrSubscriptionArn) []map[string]interface{} {
+	var snsTopicOrSubscriptionArn []map[string]interface{}
 	snsTopic := map[string]interface{}{
 		"is_success": v.IsSuccess,
 		"arn":        v.Arn,
 	}
-	snsSubscriptionOrTopicArn = append(snsSubscriptionOrTopicArn, snsTopic)
-	return snsSubscriptionOrTopicArn
+	snsTopicOrSubscriptionArn = append(snsTopicOrSubscriptionArn, snsTopic)
+	return snsTopicOrSubscriptionArn
 }
 
-func getPollingSnsSubscriptionOrTopicArn(d *schema.ResourceData) SnsSubscriptionOrTopicArn {
+func getPollingSnsTopicOrSubscriptionArn(d *schema.ResourceData) PollingSnsTopicOrSubscriptionArn {
 	paths := d.Get("path").([]interface{})
 	path := paths[0].(map[string]interface{})
 	snsConfig := path["sns_topic_or_subscription_arn"].([]interface{})
-	snsSubscriptionOrTopicArn := SnsSubscriptionOrTopicArn{}
+	snsTopicOrSubscriptionArn := PollingSnsTopicOrSubscriptionArn{}
 
 	if len(snsConfig) > 0 {
 		for _, rawConfig := range snsConfig {
 			config := rawConfig.(map[string]interface{})
-			snsSubscriptionOrTopicArn.IsSuccess = config["is_success"].(bool)
-			snsSubscriptionOrTopicArn.Arn = config["arn"].(string)
+			snsTopicOrSubscriptionArn.IsSuccess = config["is_success"].(bool)
+			snsTopicOrSubscriptionArn.Arn = config["arn"].(string)
 		}
 	}
-	return snsSubscriptionOrTopicArn
+	return snsTopicOrSubscriptionArn
 }
 
 func getPollingAuthentication(d *schema.ResourceData) (PollingAuthentication, error) {
@@ -407,7 +407,7 @@ func getPollingPathSettings(d *schema.ResourceData) (PollingPath, error) {
 			pathSettings.Type = "S3BucketPathExpression"
 			pathSettings.BucketName = path["bucket_name"].(string)
 			pathSettings.PathExpression = path["path_expression"].(string)
-			pathSettings.SnsTopicOrSubscriptionArn = getPollingSnsSubscriptionOrTopicArn(d)
+			pathSettings.SnsTopicOrSubscriptionArn = getPollingSnsTopicOrSubscriptionArn(d)
 		case "CloudWatchPath", "AwsInventoryPath":
 			pathSettings.Type = pathType
 			rawLimitToRegions := path["limit_to_regions"].([]interface{})

--- a/sumologic/sumologic_polling_source.go
+++ b/sumologic/sumologic_polling_source.go
@@ -33,13 +33,13 @@ type PollingAuthentication struct {
 }
 
 type PollingPath struct {
-	Type                      string                    `json:"type"`
-	BucketName                string                    `json:"bucketName,omitempty"`
-	PathExpression            string                    `json:"pathExpression,omitempty"`
-	LimitToRegions            []string                  `json:"limitToRegions,omitempty"`
-	LimitToNamespaces         []string                  `json:"limitToNamespaces,omitempty"`
-	TagFilters                []TagFilter               `json:"tagFilters,omitempty"`
-	SnsTopicOrSubscriptionArn SnsSubscriptionOrTopicArn `json:"snsTopicOrSubscriptionArn,omitempty"`
+	Type                      string                           `json:"type"`
+	BucketName                string                           `json:"bucketName,omitempty"`
+	PathExpression            string                           `json:"pathExpression,omitempty"`
+	LimitToRegions            []string                         `json:"limitToRegions,omitempty"`
+	LimitToNamespaces         []string                         `json:"limitToNamespaces,omitempty"`
+	TagFilters                []TagFilter                      `json:"tagFilters,omitempty"`
+	SnsTopicOrSubscriptionArn PollingSnsTopicOrSubscriptionArn `json:"snsTopicOrSubscriptionArn,omitempty"`
 }
 
 type TagFilter struct {
@@ -48,7 +48,7 @@ type TagFilter struct {
 	Tags      []string `json:"tags"`
 }
 
-type SnsSubscriptionOrTopicArn struct {
+type PollingSnsTopicOrSubscriptionArn struct {
 	IsSuccess bool   `json:"isSuccess"`
 	Arn       string `json:"arn"`
 }

--- a/sumologic/sumologic_polling_source.go
+++ b/sumologic/sumologic_polling_source.go
@@ -33,18 +33,24 @@ type PollingAuthentication struct {
 }
 
 type PollingPath struct {
-	Type              string      `json:"type"`
-	BucketName        string      `json:"bucketName,omitempty"`
-	PathExpression    string      `json:"pathExpression,omitempty"`
-	LimitToRegions    []string    `json:"limitToRegions,omitempty"`
-	LimitToNamespaces []string    `json:"limitToNamespaces,omitempty"`
-	TagFilters        []TagFilter `json:"tagFilters,omitempty"`
+	Type                      string      `json:"type"`
+	BucketName                string      `json:"bucketName,omitempty"`
+	PathExpression            string      `json:"pathExpression,omitempty"`
+	LimitToRegions            []string    `json:"limitToRegions,omitempty"`
+	LimitToNamespaces         []string    `json:"limitToNamespaces,omitempty"`
+	TagFilters                []TagFilter `json:"tagFilters,omitempty"`
+	SnsTopicOrSubscriptionArn SnsTopicArn `json:"snsTopicOrSubscriptionArn,omitempty"`
 }
 
 type TagFilter struct {
 	Type      string   `json:"type"`
 	Namespace string   `json:"namespace"`
 	Tags      []string `json:"tags"`
+}
+
+type SnsTopicArn struct {
+	IsSuccess bool   `json:"isSuccess"`
+	Arn       string `json:"arn"`
 }
 
 func (s *Client) CreatePollingSource(source PollingSource, collectorID int) (int, error) {

--- a/sumologic/sumologic_polling_source.go
+++ b/sumologic/sumologic_polling_source.go
@@ -33,13 +33,13 @@ type PollingAuthentication struct {
 }
 
 type PollingPath struct {
-	Type                      string      `json:"type"`
-	BucketName                string      `json:"bucketName,omitempty"`
-	PathExpression            string      `json:"pathExpression,omitempty"`
-	LimitToRegions            []string    `json:"limitToRegions,omitempty"`
-	LimitToNamespaces         []string    `json:"limitToNamespaces,omitempty"`
-	TagFilters                []TagFilter `json:"tagFilters,omitempty"`
-	SnsTopicOrSubscriptionArn SnsTopicArn `json:"snsTopicOrSubscriptionArn,omitempty"`
+	Type                      string                    `json:"type"`
+	BucketName                string                    `json:"bucketName,omitempty"`
+	PathExpression            string                    `json:"pathExpression,omitempty"`
+	LimitToRegions            []string                  `json:"limitToRegions,omitempty"`
+	LimitToNamespaces         []string                  `json:"limitToNamespaces,omitempty"`
+	TagFilters                []TagFilter               `json:"tagFilters,omitempty"`
+	SnsTopicOrSubscriptionArn SnsSubscriptionOrTopicArn `json:"snsTopicOrSubscriptionArn,omitempty"`
 }
 
 type TagFilter struct {
@@ -48,7 +48,7 @@ type TagFilter struct {
 	Tags      []string `json:"tags"`
 }
 
-type SnsTopicArn struct {
+type SnsSubscriptionOrTopicArn struct {
 	IsSuccess bool   `json:"isSuccess"`
 	Arn       string `json:"arn"`
 }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -130,4 +130,20 @@ The following properties are common to ALL sources and can be used to configure 
 - `cutoff_relative_time` - (Optional) Can be specified instead of cutoffTimestamp to provide a relative offset with respect to the current time. Example: use -1h, -1d, or -1w to collect data that's less than one hour, one day, or one week old, respectively.
 - `fields` - (Optional) Map containing key/value pairs.
 
+## Configuring SNS Subscription
+This is supported in the following resources.
+ - `sumologic_cloudfront_source`
+ - `sumologic_cloudtrail_source`
+ - `sumologic_elb_source`
+ - `sumologic_s3_audit_source`
+ - `sumologic_s3_source`
+
+Steps to configure SNS subscription and sync the state in terrform:
+     - Step 1: Create the source via terraform.
+     - Step 2: Setup [SNS subscription][3] outside of terraform on Sumologic UI.
+     - Step 3: Run `terraform plan -refresh-only` to review the changes and verify the state with the SNS subscription information. Make sure only `sns_topic_or_subscription_arn` is updated. If SNS has been successfully configured and has received a subscription confirmation request `isSuccess` parameter will be true.
+     - Step 4: Apply the changes with `terraform apply -refresh-only`.
+
 [2]: https://en.wikipedia.org/wiki/Tz_database
+[3]: https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/Amazon-Web-Services/AWS_Sources#set-up-sns-in-aws-highly-recommended
+

--- a/website/docs/r/cloudfront_source.html.markdown
+++ b/website/docs/r/cloudfront_source.html.markdown
@@ -58,10 +58,11 @@ In addition to the common properties, the following arguments are supported:
      + `type` - (Required) type of polling source. This has to be `S3BucketPathExpression` for `CloudFront` source.
      + `bucket_name` - (Required) The name of the bucket. This is needed if using type `S3BucketPathExpression`. 
      + `path_expression` - (Required) The path to the data. This is needed if using type `S3BucketPathExpression`.
-     + `sns_topic_or_subscription_arn` - (Optional) This is a computed field for SNS topic/subscription ARN. After creating the source via terraform, you can setup [SNS subscription][3] on Sumologic UI and run the terraform apply with the `-refresh-only` flag to update the state with the actual state of the infrastructure. If SNS has been successfully configured and has received a subscription confirmation request `isSuccess` will be true.
+     + `sns_topic_or_subscription_arn` - (Computed) This is a computed field for SNS topic/subscription ARN.
 
 ### See also
    * [Common Source Properties](https://registry.terraform.io/providers/SumoLogic/sumologic/latest/docs#common-source-properties)
+   * [Configuring SNS Subscription](https://registry.terraform.io/providers/SumoLogic/sumologic/latest/docs#configuring-sns-subscription)
 
 ## Attributes Reference
 The following attributes are exported:
@@ -84,4 +85,3 @@ terraform import sumologic_cloudfront_source.test my-test-collector/my-test-sour
 
 [1]: https://help.sumologic.com/Send_Data/Sources/03Use_JSON_to_Configure_Sources/JSON_Parameters_for_Hosted_Sources
 [2]: https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/Amazon-Web-Services/Amazon-CloudFront-Source
-[3]: https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/Amazon-Web-Services/AWS_Sources#set-up-sns-in-aws-highly-recommended

--- a/website/docs/r/cloudfront_source.html.markdown
+++ b/website/docs/r/cloudfront_source.html.markdown
@@ -58,6 +58,7 @@ In addition to the common properties, the following arguments are supported:
      + `type` - (Required) type of polling source. This has to be `S3BucketPathExpression` for `CloudFront` source.
      + `bucket_name` - (Required) The name of the bucket. This is needed if using type `S3BucketPathExpression`. 
      + `path_expression` - (Required) The path to the data. This is needed if using type `S3BucketPathExpression`.
+     + `sns_topic_or_subscription_arn` - (Optional) This is a computed field for SNS topic/subscription ARN. After creating the source via terraform, you can setup [SNS subscription][3] on Sumologic UI and run the terraform apply with the `-refresh-only` flag to update the state with the actual state of the infrastructure. If SNS has been successfully configured and has received a subscription confirmation request `isSuccess` will be true.
 
 ### See also
    * [Common Source Properties](https://registry.terraform.io/providers/SumoLogic/sumologic/latest/docs#common-source-properties)
@@ -83,3 +84,4 @@ terraform import sumologic_cloudfront_source.test my-test-collector/my-test-sour
 
 [1]: https://help.sumologic.com/Send_Data/Sources/03Use_JSON_to_Configure_Sources/JSON_Parameters_for_Hosted_Sources
 [2]: https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/Amazon-Web-Services/Amazon-CloudFront-Source
+[3]: https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/Amazon-Web-Services/AWS_Sources#set-up-sns-in-aws-highly-recommended

--- a/website/docs/r/cloudtrail_source.html.markdown
+++ b/website/docs/r/cloudtrail_source.html.markdown
@@ -58,6 +58,7 @@ In addition to the common properties, the following arguments are supported:
      + `type` - (Required) type of polling source. This has to be `S3BucketPathExpression` for `CloudTrail` source.
      + `bucket_name` - (Required) The name of the bucket.
      + `path_expression` - (Required) The path to the data.
+     + `sns_topic_or_subscription_arn` - (Optional) This is a computed field for SNS topic/subscription ARN. After creating the source via terraform, you can setup [SNS subscription][3] on Sumologic UI and run the terraform apply with the `-refresh-only` flag to update the state with the actual state of the infrastructure. If SNS has been successfully configured and has received a subscription confirmation request `isSuccess` will be true.
 
 ### See also
    * [Common Source Properties](https://registry.terraform.io/providers/SumoLogic/sumologic/latest/docs#common-source-properties)
@@ -83,3 +84,4 @@ terraform import sumologic_cloudtrail_source.test my-test-collector/my-test-sour
 
 [1]: https://help.sumologic.com/Send_Data/Sources/03Use_JSON_to_Configure_Sources/JSON_Parameters_for_Hosted_Sources
 [2]: https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/Amazon-Web-Services/AWS-CloudTrail-Source
+[3]: https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/Amazon-Web-Services/AWS_Sources#set-up-sns-in-aws-highly-recommended

--- a/website/docs/r/cloudtrail_source.html.markdown
+++ b/website/docs/r/cloudtrail_source.html.markdown
@@ -58,10 +58,12 @@ In addition to the common properties, the following arguments are supported:
      + `type` - (Required) type of polling source. This has to be `S3BucketPathExpression` for `CloudTrail` source.
      + `bucket_name` - (Required) The name of the bucket.
      + `path_expression` - (Required) The path to the data.
-     + `sns_topic_or_subscription_arn` - (Optional) This is a computed field for SNS topic/subscription ARN. After creating the source via terraform, you can setup [SNS subscription][3] on Sumologic UI and run the terraform apply with the `-refresh-only` flag to update the state with the actual state of the infrastructure. If SNS has been successfully configured and has received a subscription confirmation request `isSuccess` will be true.
+     + `sns_topic_or_subscription_arn` - (Computed) This is a computed field for SNS topic/subscription ARN.
+     
 
 ### See also
    * [Common Source Properties](https://registry.terraform.io/providers/SumoLogic/sumologic/latest/docs#common-source-properties)
+   * [Configuring SNS Subscription](https://registry.terraform.io/providers/SumoLogic/sumologic/latest/docs#configuring-sns-subscription)
 
 ## Attributes Reference
 The following attributes are exported:
@@ -84,4 +86,3 @@ terraform import sumologic_cloudtrail_source.test my-test-collector/my-test-sour
 
 [1]: https://help.sumologic.com/Send_Data/Sources/03Use_JSON_to_Configure_Sources/JSON_Parameters_for_Hosted_Sources
 [2]: https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/Amazon-Web-Services/AWS-CloudTrail-Source
-[3]: https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/Amazon-Web-Services/AWS_Sources#set-up-sns-in-aws-highly-recommended

--- a/website/docs/r/elb_source.html.markdown
+++ b/website/docs/r/elb_source.html.markdown
@@ -58,6 +58,7 @@ In addition to the common properties, the following arguments are supported:
      + `type` - (Required) type of polling source. This has to be `S3BucketPathExpression` for `ELB` source.
      + `bucket_name` - (Required) The name of the bucket.
      + `path_expression` - (Required) The path to the data.
+     + `sns_topic_or_subscription_arn` - (Optional) This is a computed field for SNS topic/subscription ARN. After creating the source via terraform, you can setup [SNS subscription][3] on Sumologic UI and run the terraform apply with the `-refresh-only` flag to update the state with the actual state of the infrastructure. If SNS has been successfully configured and has received a subscription confirmation request `isSuccess` will be true.
 
 ### See also
    * [Common Source Properties](https://registry.terraform.io/providers/SumoLogic/sumologic/latest/docs#common-source-properties)
@@ -83,3 +84,4 @@ terraform import sumologic_elb_source.test my-test-collector/my-test-source
 
 [1]: https://help.sumologic.com/Send_Data/Sources/03Use_JSON_to_Configure_Sources/JSON_Parameters_for_Hosted_Sources
 [2]: https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/Amazon-Web-Services/AWS-Elastic-Load-Balancing-Source
+[3]: https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/Amazon-Web-Services/AWS_Sources#set-up-sns-in-aws-highly-recommended

--- a/website/docs/r/elb_source.html.markdown
+++ b/website/docs/r/elb_source.html.markdown
@@ -58,10 +58,11 @@ In addition to the common properties, the following arguments are supported:
      + `type` - (Required) type of polling source. This has to be `S3BucketPathExpression` for `ELB` source.
      + `bucket_name` - (Required) The name of the bucket.
      + `path_expression` - (Required) The path to the data.
-     + `sns_topic_or_subscription_arn` - (Optional) This is a computed field for SNS topic/subscription ARN. After creating the source via terraform, you can setup [SNS subscription][3] on Sumologic UI and run the terraform apply with the `-refresh-only` flag to update the state with the actual state of the infrastructure. If SNS has been successfully configured and has received a subscription confirmation request `isSuccess` will be true.
+     + `sns_topic_or_subscription_arn` - (Computed) This is a computed field for SNS topic/subscription ARN.
 
 ### See also
    * [Common Source Properties](https://registry.terraform.io/providers/SumoLogic/sumologic/latest/docs#common-source-properties)
+   * [Configuring SNS Subscription](https://registry.terraform.io/providers/SumoLogic/sumologic/latest/docs#configuring-sns-subscription)
 
 ## Attributes Reference
 The following attributes are exported:
@@ -84,4 +85,3 @@ terraform import sumologic_elb_source.test my-test-collector/my-test-source
 
 [1]: https://help.sumologic.com/Send_Data/Sources/03Use_JSON_to_Configure_Sources/JSON_Parameters_for_Hosted_Sources
 [2]: https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/Amazon-Web-Services/AWS-Elastic-Load-Balancing-Source
-[3]: https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/Amazon-Web-Services/AWS_Sources#set-up-sns-in-aws-highly-recommended

--- a/website/docs/r/s3_audit_source.markdown
+++ b/website/docs/r/s3_audit_source.markdown
@@ -58,10 +58,11 @@ In addition to the common properties, the following arguments are supported:
      + `type` - (Required) type of polling source. This has to be `S3BucketPathExpression` for `S3 Audit source`.
      + `bucket_name` - (Required) The name of the bucket. 
      + `path_expression` - (Required) The path to the data.
-     + `sns_topic_or_subscription_arn` - (Optional) This is a computed field for SNS topic/subscription ARN. After creating the source via terraform, you can setup [SNS subscription][3] on Sumologic UI and run the terraform apply with the `-refresh-only` flag to update the state with the actual state of the infrastructure. If SNS has been successfully configured and has received a subscription confirmation request `isSuccess` will be true.
+     + `sns_topic_or_subscription_arn` - (Computed) This is a computed field for SNS topic/subscription ARN.
 
 ### See also
    * [Common Source Properties](https://registry.terraform.io/providers/SumoLogic/sumologic/latest/docs#common-source-properties)
+   * [Configuring SNS Subscription](https://registry.terraform.io/providers/SumoLogic/sumologic/latest/docs#configuring-sns-subscription)
 
 ## Attributes Reference
 The following attributes are exported:
@@ -84,4 +85,3 @@ terraform import sumologic_s3_audit_source.test my-test-collector/my-test-source
 
 [1]: https://help.sumologic.com/Send_Data/Sources/03Use_JSON_to_Configure_Sources/JSON_Parameters_for_Hosted_Sources
 [2]: https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/Amazon-Web-Services/Amazon-S3-Audit-Source
-[3]: https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/Amazon-Web-Services/AWS_Sources#set-up-sns-in-aws-highly-recommended

--- a/website/docs/r/s3_audit_source.markdown
+++ b/website/docs/r/s3_audit_source.markdown
@@ -58,6 +58,7 @@ In addition to the common properties, the following arguments are supported:
      + `type` - (Required) type of polling source. This has to be `S3BucketPathExpression` for `S3 Audit source`.
      + `bucket_name` - (Required) The name of the bucket. 
      + `path_expression` - (Required) The path to the data.
+     + `sns_topic_or_subscription_arn` - (Optional) This is a computed field for SNS topic/subscription ARN. After creating the source via terraform, you can setup [SNS subscription][3] on Sumologic UI and run the terraform apply with the `-refresh-only` flag to update the state with the actual state of the infrastructure. If SNS has been successfully configured and has received a subscription confirmation request `isSuccess` will be true.
 
 ### See also
    * [Common Source Properties](https://registry.terraform.io/providers/SumoLogic/sumologic/latest/docs#common-source-properties)
@@ -83,3 +84,4 @@ terraform import sumologic_s3_audit_source.test my-test-collector/my-test-source
 
 [1]: https://help.sumologic.com/Send_Data/Sources/03Use_JSON_to_Configure_Sources/JSON_Parameters_for_Hosted_Sources
 [2]: https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/Amazon-Web-Services/Amazon-S3-Audit-Source
+[3]: https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/Amazon-Web-Services/AWS_Sources#set-up-sns-in-aws-highly-recommended

--- a/website/docs/r/s3_source.html.markdown
+++ b/website/docs/r/s3_source.html.markdown
@@ -58,6 +58,7 @@ In addition to the common properties, the following arguments are supported:
      + `type` - (Required) type of polling source. This has to be `S3BucketPathExpression` for `S3 source`.
      + `bucket_name` - (Required) The name of the bucket. 
      + `path_expression` - (Required) The path to the data.
+     + `sns_topic_or_subscription_arn` - (Optional) This is a computed field for SNS topic/subscription ARN. After creating the source via terraform, you can setup [SNS subscription][3] on Sumologic UI and run the terraform apply with the `-refresh-only` flag to update the state with the actual state of the infrastructure. If SNS has been successfully configured and has received a subscription confirmation request `isSuccess` will be true.
 
 ### See also
   * [Common Source Properties](https://github.com/SumoLogic/tree/master/website#common-source-properties)
@@ -83,3 +84,4 @@ terraform import sumologic_s3_source.test my-test-collector/my-test-source
 
 [1]: https://help.sumologic.com/Send_Data/Sources/03Use_JSON_to_Configure_Sources/JSON_Parameters_for_Hosted_Sources
 [2]: https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/Amazon-Web-Services/AWS-S3-Source
+[3]: https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/Amazon-Web-Services/AWS_Sources#set-up-sns-in-aws-highly-recommended

--- a/website/docs/r/s3_source.html.markdown
+++ b/website/docs/r/s3_source.html.markdown
@@ -58,10 +58,11 @@ In addition to the common properties, the following arguments are supported:
      + `type` - (Required) type of polling source. This has to be `S3BucketPathExpression` for `S3 source`.
      + `bucket_name` - (Required) The name of the bucket. 
      + `path_expression` - (Required) The path to the data.
-     + `sns_topic_or_subscription_arn` - (Optional) This is a computed field for SNS topic/subscription ARN. After creating the source via terraform, you can setup [SNS subscription][3] on Sumologic UI and run the terraform apply with the `-refresh-only` flag to update the state with the actual state of the infrastructure. If SNS has been successfully configured and has received a subscription confirmation request `isSuccess` will be true.
+     + `sns_topic_or_subscription_arn` - (Computed) This is a computed field for SNS topic/subscription ARN.
 
 ### See also
   * [Common Source Properties](https://github.com/SumoLogic/tree/master/website#common-source-properties)
+  * [Configuring SNS Subscription](https://registry.terraform.io/providers/SumoLogic/sumologic/latest/docs#configuring-sns-subscription)
 
 ## Attributes Reference
 The following attributes are exported:
@@ -84,4 +85,3 @@ terraform import sumologic_s3_source.test my-test-collector/my-test-source
 
 [1]: https://help.sumologic.com/Send_Data/Sources/03Use_JSON_to_Configure_Sources/JSON_Parameters_for_Hosted_Sources
 [2]: https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/Amazon-Web-Services/AWS-S3-Source
-[3]: https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/Amazon-Web-Services/AWS_Sources#set-up-sns-in-aws-highly-recommended


### PR DESCRIPTION
Currently, we do not store the sns topic SRN in the TF schema, therefore when an existing source with a SNS subscription is updated(for eg. source name change), the SNS config is wiped off and the green checkbox for SNS configuration setup turns to red. 

This PR adds this new field as a computed field to resolve the issue. 

```
"path": [
              {
                "bucket_name": "<bucket_name>",
                "limit_to_namespaces": [],
                "limit_to_regions": [],
                "path_expression": "*",
                "sns_topic_arn": [
                  {
                    "arn": "<arn>",
                    "is_success": true
                  }
                ],
                "tag_filters": [],
                "type": "S3BucketPathExpression"
              }
            ]
```            