### PR TITLE
Relaxed validation for monitor time range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 BUG FIXES:
  
 * Fix occurrence_type for metrics resolution conditions (GH-297)
+* Relaxed validation for monitor time range (GH-306)
 
 ## 2.11.0 (October 19, 2021)
 

--- a/sumologic/resource_sumologic_monitors_library_monitor.go
+++ b/sumologic/resource_sumologic_monitors_library_monitor.go
@@ -107,7 +107,7 @@ func resourceSumologicMonitorsLibraryMonitor() *schema.Resource {
 						"time_range": {
 							Type:         schema.TypeString,
 							Optional:     true,
-							ValidateFunc: validation.StringInSlice([]string{"5m", "-5m", "10m", "-10m", "15m", "-15m", "30m", "-30m", "60m", "-60m", "1h", "-1h", "3h", "-3h", "6h", "-6h", "12h", "-12h", "24h", "-24h", "1d", "-1d"}, false),
+							ValidateFunc: validation.StringMatch(regexp.MustCompile(`-?(\d)+[smhd]`), "Time range must be in the format '-?\\d+[smhd]'. Examples: -15m, 1d, etc."),
 						},
 						"trigger_source": {
 							Type:         schema.TypeString,
@@ -463,7 +463,7 @@ var consecutiveSchema = schema.Schema{
 var timeRangeSchema = schema.Schema{
 	Type:         schema.TypeString,
 	Required:     true,
-	ValidateFunc: validation.StringInSlice([]string{"5m", "-5m", "10m", "-10m", "15m", "-15m", "30m", "-30m", "60m", "-60m", "1h", "-1h", "3h", "-3h", "6h", "-6h", "12h", "-12h", "24h", "-24h", "1d", "-1d"}, false),
+	ValidateFunc: validation.StringMatch(regexp.MustCompile(`-?(\d)+[smhd]`), "Time range must be in the format '-?\\d+[smhd]'. Examples: -15m, 1d, etc."),
 }
 
 var thresholdSchema = schema.Schema{


### PR DESCRIPTION
Relaxed validation for monitors time range.
The provider will ensure well-formedness of the field, ie. it follows the correct format, but will not enforce what specific values are allowed. The latter is a runtime check now on the backend, and is no longer enforceable at the API layer.