### PR TITLE
SUMO-172660 Add terraform support for kinesis log sources

### DIFF
--- a/sumologic/provider.go
+++ b/sumologic/provider.go
@@ -91,6 +91,7 @@ func Provider() terraform.ResourceProvider {
 			"sumologic_password_policy":                    resourceSumologicPasswordPolicy(),
 			"sumologic_saml_configuration":                 resourceSumologicSamlConfiguration(),
 			"sumologic_kinesis_metrics_source":             resourceSumologicKinesisMetricsSource(),
+			"sumologic_kinesis_log_source":                 resourceSumologicKinesisLogSource(),
 			"sumologic_token":                              resourceSumologicToken(),
 			"sumologic_policies":                           resourceSumologicPolicies(),
 			"sumologic_hierarchy":                          resourceSumologicHierarchy(),

--- a/sumologic/resource_sumologic_kinesis_log_source.go
+++ b/sumologic/resource_sumologic_kinesis_log_source.go
@@ -11,7 +11,7 @@ import (
 )
 
 func resourceSumologicKinesisLogSource() *schema.Resource {
-    kinesisLogSource := resourceSumologicSource()
+	kinesisLogSource := resourceSumologicSource()
 	kinesisLogSource.Create = resourceSumologicKinesisLogSourceCreate
 	kinesisLogSource.Read = resourceSumologicKinesisLogSourceRead
 	kinesisLogSource.Update = resourceSumologicKinesisLogSourceUpdate
@@ -76,14 +76,14 @@ func resourceSumologicKinesisLogSource() *schema.Resource {
 					Type:     schema.TypeString,
 					Optional: true,
 				},
-                "path_expression": {
+				"path_expression": {
 					Type:     schema.TypeString,
 					Optional: true,
 				},
 				"scan_interval": {
-				    Type:         schema.TypeInt,
-					Optional:     true,
-				    Default:      300000,
+					Type:     schema.TypeInt,
+					Optional: true,
+					Default:  300000,
 				},
 			},
 		},
@@ -202,12 +202,12 @@ func getKinesisLogPathSettings(d *schema.ResourceData) (KinesisLogPath, error) {
 		path := paths[0].(map[string]interface{})
 		switch pathType := path["type"].(string); pathType {
 		case "KinesisLogPath":
-		    pathSettings.Type = pathType
-		    pathSettings.BucketName = path["bucket_name"].(string)
-		    pathSettings.PathExpression = path["path_expression"].(string)
-		    pathSettings.ScanInterval = path["scan_interval"].(int)
+			pathSettings.Type = pathType
+			pathSettings.BucketName = path["bucket_name"].(string)
+			pathSettings.PathExpression = path["path_expression"].(string)
+			pathSettings.ScanInterval = path["scan_interval"].(int)
 		case "NoPathExpression":
-		    pathSettings.Type = pathType
+			pathSettings.Type = pathType
 		default:
 			errorMessage := fmt.Sprintf("[ERROR] Unknown resourceType in path: %v", pathType)
 			log.Print(errorMessage)
@@ -240,7 +240,7 @@ func getKinesisLogAuthentication(d *schema.ResourceData) (PollingAuthentication,
 				authSettings.Region = auth["region"].(string)
 			}
 		case "NoAuthentication":
-		    authSettings.Type = "NoAuthentication"
+			authSettings.Type = "NoAuthentication"
 		default:
 			errorMessage := fmt.Sprintf("[ERROR] Unknown authType: %v", authType)
 			log.Print(errorMessage)
@@ -257,10 +257,10 @@ func getKinesisLogThirdPartyPathAttributes(kinesisLogResource []KinesisLogResour
 
 	for _, t := range kinesisLogResource {
 		mapping := map[string]interface{}{
-			"type":             t.Path.Type,
-			"bucket_name":      t.Path.BucketName,
-			"path_expression":  t.Path.PathExpression,
-			"scan_interval":    t.Path.ScanInterval,
+			"type":            t.Path.Type,
+			"bucket_name":     t.Path.BucketName,
+			"path_expression": t.Path.PathExpression,
+			"scan_interval":   t.Path.ScanInterval,
 		}
 		s = append(s, mapping)
 	}

--- a/sumologic/resource_sumologic_kinesis_log_source.go
+++ b/sumologic/resource_sumologic_kinesis_log_source.go
@@ -1,0 +1,268 @@
+package sumologic
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func resourceSumologicKinesisLogSource() *schema.Resource {
+    kinesisLogSource := resourceSumologicSource()
+	kinesisLogSource.Create = resourceSumologicKinesisLogSourceCreate
+	kinesisLogSource.Read = resourceSumologicKinesisLogSourceRead
+	kinesisLogSource.Update = resourceSumologicKinesisLogSourceUpdate
+	kinesisLogSource.Importer = &schema.ResourceImporter{
+		State: resourceSumologicSourceImport,
+	}
+
+	kinesisLogSource.Schema["content_type"] = &schema.Schema{
+		Type:         schema.TypeString,
+		Required:     true,
+		ValidateFunc: validation.StringInSlice([]string{"KinesisLog"}, false),
+	}
+
+	kinesisLogSource.Schema["message_per_request"] = &schema.Schema{
+		Type:     schema.TypeBool,
+		Optional: true,
+		Default:  false,
+	}
+	kinesisLogSource.Schema["url"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Computed: true,
+	}
+	kinesisLogSource.Schema["authentication"] = &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"type": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice([]string{"S3BucketAuthentication", "AWSRoleBasedAuthentication"}, false),
+				},
+				"access_key": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"secret_key": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"role_arn": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+			},
+		},
+	}
+
+	kinesisLogSource.Schema["path"] = &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"type": {
+					Type:         schema.TypeString,
+					Required:     true,
+					ValidateFunc: validation.StringInSlice([]string{"KinesisLogPath"}, false),
+				},
+				"bucket_name": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+                "path_expression": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"scan_interval": {
+				    Type:         schema.TypeInt,
+					Optional:     true,
+				    Default:      300000,
+				},
+			},
+		},
+	}
+
+	return kinesisLogSource
+}
+
+func resourceSumologicKinesisLogSourceCreate(d *schema.ResourceData, meta interface{}) error {
+	c := meta.(*Client)
+
+	if d.Id() == "" {
+		source, err := resourceToKinesisLogSource(d)
+		if err != nil {
+			return err
+		}
+
+		id, err := c.CreateKinesisLogSource(source, d.Get("collector_id").(int))
+
+		if err != nil {
+			return err
+		}
+
+		d.SetId(strconv.Itoa(id))
+	}
+
+	return resourceSumologicKinesisLogSourceRead(d, meta)
+}
+
+func resourceSumologicKinesisLogSourceUpdate(d *schema.ResourceData, meta interface{}) error {
+	c := meta.(*Client)
+
+	source, err := resourceToKinesisLogSource(d)
+	if err != nil {
+		return err
+	}
+
+	err = c.UpdateKinesisLogSource(source, d.Get("collector_id").(int))
+
+	if err != nil {
+		return err
+	}
+
+	return resourceSumologicKinesisLogSourceRead(d, meta)
+}
+
+func resourceSumologicKinesisLogSourceRead(d *schema.ResourceData, meta interface{}) error {
+	c := meta.(*Client)
+
+	id, _ := strconv.Atoi(d.Id())
+	source, err := c.GetKinesisLogSource(d.Get("collector_id").(int), id)
+
+	if err != nil {
+		return err
+	}
+
+	if source == nil {
+		log.Printf("[WARN] KinesisLog source not found, removing from state: %v - %v", id, err)
+		d.SetId("")
+
+		return nil
+	}
+
+	kinesisLogResources := source.ThirdPartyRef.Resources
+	path := getKinesisLogThirdPartyPathAttributes(kinesisLogResources)
+
+	if err := d.Set("path", path); err != nil {
+		return err
+	}
+
+	if err := resourceSumologicSourceRead(d, source.Source); err != nil {
+		return fmt.Errorf("%s", err)
+	}
+	d.Set("content_type", source.ContentType)
+	d.Set("message_per_request", source.MessagePerRequest)
+	d.Set("url", source.URL)
+
+	return nil
+}
+
+func resourceToKinesisLogSource(d *schema.ResourceData) (KinesisLogSource, error) {
+	source := resourceToSource(d)
+	source.Type = "HTTP"
+
+	kinesisLogSource := KinesisLogSource{
+		Source:            source,
+		MessagePerRequest: d.Get("message_per_request").(bool),
+		URL:               d.Get("url").(string),
+	}
+
+	authSettings, errAuthSettings := getKinesisLogAuthentication(d)
+	if errAuthSettings != nil {
+		return kinesisLogSource, errAuthSettings
+	}
+
+	pathSettings, errPathSettings := getKinesisLogPathSettings(d)
+	if errPathSettings != nil {
+		return kinesisLogSource, errPathSettings
+	}
+
+	kinesisLogResource := KinesisLogResource{
+		ServiceType:    d.Get("content_type").(string),
+		Authentication: authSettings,
+		Path:           pathSettings,
+	}
+
+	kinesisLogSource.ThirdPartyRef.Resources = append(kinesisLogSource.ThirdPartyRef.Resources, kinesisLogResource)
+
+	return kinesisLogSource, nil
+}
+
+func getKinesisLogPathSettings(d *schema.ResourceData) (KinesisLogPath, error) {
+	pathSettings := KinesisLogPath{}
+	paths := d.Get("path").([]interface{})
+	if len(paths) > 0 {
+		path := paths[0].(map[string]interface{})
+		switch pathType := path["type"].(string); pathType {
+		case "KinesisLogPath":
+		    pathSettings.Type = pathType
+		    pathSettings.BucketName = path["bucket_name"].(string)
+		    pathSettings.PathExpression = path["path_expression"].(string)
+		    pathSettings.ScanInterval = path["scan_interval"].(int)
+		case "NoPathExpression"
+		}
+
+	} else {
+		return pathSettings, errors.New(fmt.Sprintf("[ERROR] no path specification in kinesis log Soruce"))
+	}
+	return pathSettings, nil
+}
+
+func getKinesisLogAuthentication(d *schema.ResourceData) (PollingAuthentication, error) {
+	auths := d.Get("authentication").([]interface{})
+	authSettings := PollingAuthentication{}
+
+	if len(auths) > 0 {
+		auth := auths[0].(map[string]interface{})
+		switch authType := auth["type"].(string); authType {
+		case "S3BucketAuthentication":
+			if d.Get("content_type").(string) == "AwsInventory" {
+				return authSettings, errors.New(
+					fmt.Sprintf("[ERROR] Unsupported authType: %v for AwsInventory source", authType))
+			}
+			authSettings.Type = "S3BucketAuthentication"
+			authSettings.AwsID = auth["access_key"].(string)
+			authSettings.AwsKey = auth["secret_key"].(string)
+			if auth["region"] != nil {
+				authSettings.Region = auth["region"].(string)
+			}
+		case "AWSRoleBasedAuthentication":
+			authSettings.Type = "AWSRoleBasedAuthentication"
+			authSettings.RoleARN = auth["role_arn"].(string)
+			if auth["region"] != nil {
+				authSettings.Region = auth["region"].(string)
+			}
+		case "NoAuthentication":
+		    authSettings.Type = "NoAuthentication"
+		default:
+			errorMessage := fmt.Sprintf("[ERROR] Unknown authType: %v", authType)
+			log.Print(errorMessage)
+			return authSettings, errors.New(errorMessage)
+		}
+	}
+
+	return authSettings, nil
+}
+
+func getKinesisLogThirdPartyPathAttributes(kinesisLogResource []KinesisLogResource) []map[string]interface{} {
+
+	var s []map[string]interface{}
+
+	for _, t := range kinesisLogResource {
+		mapping := map[string]interface{}{
+			"type":             t.Path.Type,
+			"bucket_name":      t.Path.BucketName,
+			"path_expression":  t.Path.PathExpression,
+			"scan_interval":    t.Path.ScanInterval,
+		}
+		s = append(s, mapping)
+	}
+	return s
+}

--- a/sumologic/resource_sumologic_kinesis_log_source_test.go
+++ b/sumologic/resource_sumologic_kinesis_log_source_test.go
@@ -1,179 +1,179 @@
 package sumologic
 
 import (
-	"fmt"
-	"os"
-	"strconv"
-	"testing"
+    "fmt"
+    "os"
+    "strconv"
+    "testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+    "github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+    "github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 func TestAccSumologicKinesisLogSource_create(t *testing.T) {
-	var kinesisLogSource KinesisLogSource
-	var collector Collector
-	cName, cDescription, cCategory := getRandomizedParams()
-	sName, sDescription, sCategory := getRandomizedParams()
-	kinesisLogResourceName := "sumologic_kinesis_log_source.kinesisLog"
-	testAwsRoleArn := os.Getenv("SUMOLOGIC_TEST_ROLE_ARN")
-	testAwsBucket := os.Getenv("SUMOLOGIC_TEST_BUCKET_NAME")
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckWithAWS(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckKinesisLogSourceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccSumologicKinesisLogSourceConfig(cName, cDescription, cCategory, sName, sDescription, sCategory, testAwsRoleArn, testAwsBucket),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKinesisLogSourceExists(kinesisLogResourceName, &kinesisLogSource),
-					testAccCheckKinesisLogSourceValues(&kinesisLogSource, sName, sDescription, sCategory),
-					testAccCheckCollectorExists("sumologic_collector.test", &collector),
-					testAccCheckCollectorValues(&collector, cName, cDescription, cCategory, "Etc/UTC", ""),
-					resource.TestCheckResourceAttrSet(kinesisLogResourceName, "id"),
-					resource.TestCheckResourceAttr(kinesisLogResourceName, "name", sName),
-					resource.TestCheckResourceAttr(kinesisLogResourceName, "description", sDescription),
-					resource.TestCheckResourceAttr(kinesisLogResourceName, "category", sCategory),
-					resource.TestCheckResourceAttr(kinesisLogResourceName, "content_type", "KinesisLog"),
-					resource.TestCheckResourceAttr(kinesisLogResourceName, "path.0.type", "KinesisLogPath"),
-				),
-			},
-		},
-	})
+    var kinesisLogSource KinesisLogSource
+    var collector Collector
+    cName, cDescription, cCategory := getRandomizedParams()
+    sName, sDescription, sCategory := getRandomizedParams()
+    kinesisLogResourceName := "sumologic_kinesis_log_source.kinesisLog"
+    testAwsRoleArn := os.Getenv("SUMOLOGIC_TEST_ROLE_ARN")
+    testAwsBucket := os.Getenv("SUMOLOGIC_TEST_BUCKET_NAME")
+    resource.Test(t, resource.TestCase{
+        PreCheck:     func() { testAccPreCheckWithAWS(t) },
+        Providers:    testAccProviders,
+        CheckDestroy: testAccCheckKinesisLogSourceDestroy,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccSumologicKinesisLogSourceConfig(cName, cDescription, cCategory, sName, sDescription, sCategory, testAwsRoleArn, testAwsBucket),
+                Check: resource.ComposeTestCheckFunc(
+                    testAccCheckKinesisLogSourceExists(kinesisLogResourceName, &kinesisLogSource),
+                    testAccCheckKinesisLogSourceValues(&kinesisLogSource, sName, sDescription, sCategory),
+                    testAccCheckCollectorExists("sumologic_collector.test", &collector),
+                    testAccCheckCollectorValues(&collector, cName, cDescription, cCategory, "Etc/UTC", ""),
+                    resource.TestCheckResourceAttrSet(kinesisLogResourceName, "id"),
+                    resource.TestCheckResourceAttr(kinesisLogResourceName, "name", sName),
+                    resource.TestCheckResourceAttr(kinesisLogResourceName, "description", sDescription),
+                    resource.TestCheckResourceAttr(kinesisLogResourceName, "category", sCategory),
+                    resource.TestCheckResourceAttr(kinesisLogResourceName, "content_type", "KinesisLog"),
+                    resource.TestCheckResourceAttr(kinesisLogResourceName, "path.0.type", "KinesisLogPath"),
+                ),
+            },
+        },
+    })
 }
 func TestAccSumologicKinesisLogSource_update(t *testing.T) {
-	var kinesisLogSource KinesisLogSource
-	cName, cDescription, cCategory := getRandomizedParams()
-	sName, sDescription, sCategory := getRandomizedParams()
-	sNameUpdated, sDescriptionUpdated, sCategoryUpdated := getRandomizedParams()
-	kinesisLogResourceName := "sumologic_kinesis_log_source.kinesisLog"
-	testAwsRoleArn := os.Getenv("SUMOLOGIC_TEST_ROLE_ARN")
-	testAwsBucket := os.Getenv("SUMOLOGIC_TEST_BUCKET_NAME")
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckWithAWS(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckHTTPSourceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccSumologicKinesisLogSourceConfig(cName, cDescription, cCategory, sName, sDescription, sCategory, testAwsRoleArn, testAwsBucket),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKinesisLogSourceExists(kinesisLogResourceName, &kinesisLogSource),
-					testAccCheckKinesisLogSourceValues(&kinesisLogSource, sName, sDescription, sCategory),
-					resource.TestCheckResourceAttrSet(kinesisLogResourceName, "id"),
-					resource.TestCheckResourceAttr(kinesisLogResourceName, "name", sName),
-					resource.TestCheckResourceAttr(kinesisLogResourceName, "description", sDescription),
-					resource.TestCheckResourceAttr(kinesisLogResourceName, "category", sCategory),
-					resource.TestCheckResourceAttr(kinesisLogResourceName, "content_type", "KinesisLog"),
-					resource.TestCheckResourceAttr(kinesisLogResourceName, "path.0.type", "KinesisLogPath"),
-				),
-			},
-			{
-				Config: testAccSumologicKinesisLogSourceConfig(cName, cDescription, cCategory, sNameUpdated, sDescriptionUpdated, sCategoryUpdated, testAwsRoleArn, testAwsBucket),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckKinesisLogSourceExists(kinesisLogResourceName, &kinesisLogSource),
-					testAccCheckKinesisLogSourceValues(&kinesisLogSource, sNameUpdated, sDescriptionUpdated, sCategoryUpdated),
-					resource.TestCheckResourceAttrSet(kinesisLogResourceName, "id"),
-					resource.TestCheckResourceAttr(kinesisLogResourceName, "name", sNameUpdated),
-					resource.TestCheckResourceAttr(kinesisLogResourceName, "description", sDescriptionUpdated),
-					resource.TestCheckResourceAttr(kinesisLogResourceName, "category", sCategoryUpdated),
-					resource.TestCheckResourceAttr(kinesisLogResourceName, "content_type", "KinesisLog"),
-					resource.TestCheckResourceAttr(kinesisLogResourceName, "path.0.type", "KinesisLogPath"),
-				),
-			},
-		},
-	})
+    var kinesisLogSource KinesisLogSource
+    cName, cDescription, cCategory := getRandomizedParams()
+    sName, sDescription, sCategory := getRandomizedParams()
+    sNameUpdated, sDescriptionUpdated, sCategoryUpdated := getRandomizedParams()
+    kinesisLogResourceName := "sumologic_kinesis_log_source.kinesisLog"
+    testAwsRoleArn := os.Getenv("SUMOLOGIC_TEST_ROLE_ARN")
+    testAwsBucket := os.Getenv("SUMOLOGIC_TEST_BUCKET_NAME")
+    resource.Test(t, resource.TestCase{
+        PreCheck:     func() { testAccPreCheckWithAWS(t) },
+        Providers:    testAccProviders,
+        CheckDestroy: testAccCheckHTTPSourceDestroy,
+        Steps: []resource.TestStep{
+            {
+                Config: testAccSumologicKinesisLogSourceConfig(cName, cDescription, cCategory, sName, sDescription, sCategory, testAwsRoleArn, testAwsBucket),
+                Check: resource.ComposeTestCheckFunc(
+                  testAccCheckKinesisLogSourceExists(kinesisLogResourceName, &kinesisLogSource),
+                  testAccCheckKinesisLogSourceValues(&kinesisLogSource, sName, sDescription, sCategory),
+                  resource.TestCheckResourceAttrSet(kinesisLogResourceName, "id"),
+                  resource.TestCheckResourceAttr(kinesisLogResourceName, "name", sName),
+                  resource.TestCheckResourceAttr(kinesisLogResourceName, "description", sDescription),
+                  resource.TestCheckResourceAttr(kinesisLogResourceName, "category", sCategory),
+                  resource.TestCheckResourceAttr(kinesisLogResourceName, "content_type", "KinesisLog"),
+                  resource.TestCheckResourceAttr(kinesisLogResourceName, "path.0.type", "KinesisLogPath"),
+                ),
+            },
+            {
+                Config: testAccSumologicKinesisLogSourceConfig(cName, cDescription, cCategory, sNameUpdated, sDescriptionUpdated, sCategoryUpdated, testAwsRoleArn, testAwsBucket),
+                Check: resource.ComposeTestCheckFunc(
+                  testAccCheckKinesisLogSourceExists(kinesisLogResourceName, &kinesisLogSource),
+                  testAccCheckKinesisLogSourceValues(&kinesisLogSource, sNameUpdated, sDescriptionUpdated, sCategoryUpdated),
+                  resource.TestCheckResourceAttrSet(kinesisLogResourceName, "id"),
+                  resource.TestCheckResourceAttr(kinesisLogResourceName, "name", sNameUpdated),
+                  resource.TestCheckResourceAttr(kinesisLogResourceName, "description", sDescriptionUpdated),
+                  resource.TestCheckResourceAttr(kinesisLogResourceName, "category", sCategoryUpdated),
+                  resource.TestCheckResourceAttr(kinesisLogResourceName, "content_type", "KinesisLog"),
+                  resource.TestCheckResourceAttr(kinesisLogResourceName, "path.0.type", "KinesisLogPath"),
+                ),
+            },
+        },
+    })
 }
 func testAccCheckKinesisLogSourceDestroy(s *terraform.State) error {
-	client := testAccProvider.Meta().(*Client)
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "sumologic_kinesis_log_source" {
-			continue
-		}
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("HTTP Source destruction check: HTTP Source ID is not set")
-		}
-		id, err := strconv.Atoi(rs.Primary.ID)
-		if err != nil {
-			return fmt.Errorf("Encountered an error: " + err.Error())
-		}
-		collectorID, err := strconv.Atoi(rs.Primary.Attributes["collector_id"])
-		if err != nil {
-			return fmt.Errorf("Encountered an error: " + err.Error())
-		}
-		s, err := client.GetKinesisLogSource(collectorID, id)
-		if err != nil {
-			return fmt.Errorf("Encountered an error: " + err.Error())
-		}
-		if s != nil {
-			return fmt.Errorf("KinesisLog Source still exists")
-		}
-	}
-	return nil
+    client := testAccProvider.Meta().(*Client)
+    for _, rs := range s.RootModule().Resources {
+        if rs.Type != "sumologic_kinesis_log_source" {
+            continue
+        }
+        if rs.Primary.ID == "" {
+            return fmt.Errorf("HTTP Source destruction check: HTTP Source ID is not set")
+        }
+        id, err := strconv.Atoi(rs.Primary.ID)
+        if err != nil {
+            return fmt.Errorf("Encountered an error: " + err.Error())
+        }
+        collectorID, err := strconv.Atoi(rs.Primary.Attributes["collector_id"])
+        if err != nil {
+            return fmt.Errorf("Encountered an error: " + err.Error())
+        }
+        s, err := client.GetKinesisLogSource(collectorID, id)
+        if err != nil {
+            return fmt.Errorf("Encountered an error: " + err.Error())
+        }
+        if s != nil {
+            return fmt.Errorf("KinesisLog Source still exists")
+        }
+    }
+    return nil
 }
 func testAccCheckKinesisLogSourceExists(n string, kinesisLogSource *KinesisLogSource) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("not found: %s", n)
-		}
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("KinesisLog Source ID is not set")
-		}
-		id, err := strconv.Atoi(rs.Primary.ID)
-		if err != nil {
-			return fmt.Errorf("KinesisLog Source id should be int; got %s", rs.Primary.ID)
-		}
-		collectorID, err := strconv.Atoi(rs.Primary.Attributes["collector_id"])
-		if err != nil {
-			return fmt.Errorf("Encountered an error: " + err.Error())
-		}
-		c := testAccProvider.Meta().(*Client)
-		kinesisLogSourceResp, err := c.GetKinesisLogSource(collectorID, id)
-		if err != nil {
-			return err
-		}
-		*kinesisLogSource = *kinesisLogSourceResp
-		return nil
-	}
+    return func(s *terraform.State) error {
+        rs, ok := s.RootModule().Resources[n]
+        if !ok {
+            return fmt.Errorf("not found: %s", n)
+        }
+        if rs.Primary.ID == "" {
+            return fmt.Errorf("KinesisLog Source ID is not set")
+        }
+        id, err := strconv.Atoi(rs.Primary.ID)
+        if err != nil {
+            return fmt.Errorf("KinesisLog Source id should be int; got %s", rs.Primary.ID)
+        }
+        collectorID, err := strconv.Atoi(rs.Primary.Attributes["collector_id"])
+        if err != nil {
+            return fmt.Errorf("Encountered an error: " + err.Error())
+        }
+        c := testAccProvider.Meta().(*Client)
+        kinesisLogSourceResp, err := c.GetKinesisLogSource(collectorID, id)
+        if err != nil {
+            return err
+        }
+        *kinesisLogSource = *kinesisLogSourceResp
+        return nil
+    }
 }
 func testAccCheckKinesisLogSourceValues(kinesisLogSource *KinesisLogSource, name, description, category string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if kinesisLogSource.Name != name {
-			return fmt.Errorf("bad name, expected \"%s\", got: %#v", name, kinesisLogSource.Name)
-		}
-		if kinesisLogSource.Description != description {
-			return fmt.Errorf("bad description, expected \"%s\", got: %#v", description, kinesisLogSource.Description)
-		}
-		if kinesisLogSource.Category != category {
-			return fmt.Errorf("bad category, expected \"%s\", got: %#v", category, kinesisLogSource.Category)
-		}
-		return nil
-	}
+    return func(s *terraform.State) error {
+        if kinesisLogSource.Name != name {
+            return fmt.Errorf("bad name, expected \"%s\", got: %#v", name, kinesisLogSource.Name)
+        }
+        if kinesisLogSource.Description != description {
+            return fmt.Errorf("bad description, expected \"%s\", got: %#v", description, kinesisLogSource.Description)
+        }
+        if kinesisLogSource.Category != category {
+            return fmt.Errorf("bad category, expected \"%s\", got: %#v", category, kinesisLogSource.Category)
+        }
+        return nil
+    }
 }
 func testAccSumologicKinesisLogSourceConfig(cName, cDescription, cCategory, sName, sDescription, sCategory, testAwsRoleArn, testAwsBucket string) string {
-	return fmt.Sprintf(`
+    return fmt.Sprintf(`
 resource "sumologic_collector" "test" {
-	name = "%s"
-	description = "%s"
-	category = "%s"
+    name = "%s"
+    description = "%s"
+    category = "%s"
 }
 
 resource "sumologic_kinesis_log_source" "kinesisLog" {
-	name = "%s"
-	description = "%s"
-	category = "%s"
-	content_type  = "KinesisLog"
-	collector_id = "${sumologic_collector.test.id}"
-	authentication {
-    type = "AWSRoleBasedAuthentication"
-    role_arn = "%s"
-  }
-	path {
-		type = "KinesisLogPath"
-    bucket_name     = "%s"
-    path_expression = "http-endpoint-failed/*"
-    scan_interval   = 30000
-	}
+    name = "%s"
+    description = "%s"
+    category = "%s"
+    content_type  = "KinesisLog"
+    collector_id = "${sumologic_collector.test.id}"
+    authentication {
+        type = "AWSRoleBasedAuthentication"
+        role_arn = "%s"
+    }
+    path {
+        type = "KinesisLogPath"
+        bucket_name     = "%s"
+        path_expression = "http-endpoint-failed/*"
+        scan_interval   = 30000
+    }
 }
 `, cName, cDescription, cCategory, sName, sDescription, sCategory, testAwsRoleArn, testAwsBucket)
 }
@@ -181,23 +181,23 @@ resource "sumologic_kinesis_log_source" "kinesisLog" {
 func testAccSumologicKinesisLogSourceNoAuthConfig(cName, cDescription, cCategory, sName, sDescription, sCategory string) string {
 	return fmt.Sprintf(`
 resource "sumologic_collector" "test" {
-	name = "%s"
-	description = "%s"
-	category = "%s"
+    name = "%s"
+    description = "%s"
+    category = "%s"
 }
 
 resource "sumologic_kinesis_log_source" "kinesisLog" {
-	name = "%s"
-	description = "%s"
-	category = "%s"
-	content_type  = "KinesisLog"
-	collector_id = "${sumologic_collector.test.id}"
-	authentication {
-    type = "NoAuthentication"
-  }
-	path {
-		type = "NoPathExpression"
-	}
+    name = "%s"
+    description = "%s"
+    category = "%s"
+    content_type  = "KinesisLog"
+    collector_id = "${sumologic_collector.test.id}"
+    authentication {
+        type = "NoAuthentication"
+    }
+    path {
+        type = "NoPathExpression"
+    }
 }
 `, cName, cDescription, cCategory, sName, sDescription, sCategory)
 }

--- a/sumologic/resource_sumologic_kinesis_log_source_test.go
+++ b/sumologic/resource_sumologic_kinesis_log_source_test.go
@@ -170,12 +170,9 @@ resource "sumologic_kinesis_log_source" "kinesisLog" {
 	  }
 	path {
 		type = "KinesisLogPath"
-		path {
-			type            = "TagFilters"
-		    bucket_name     = "%s"
-		    path_expression = "*"
-		    scan_interval   = 30000
-		}
+        bucket_name     = "%s"
+        path_expression = "*"
+        scan_interval   = 30000
 	  }
 }
 `, cName, cDescription, cCategory, sName, sDescription, sCategory, testAwsRoleArn, testAwsBucket)

--- a/sumologic/resource_sumologic_kinesis_log_source_test.go
+++ b/sumologic/resource_sumologic_kinesis_log_source_test.go
@@ -171,7 +171,7 @@ resource "sumologic_kinesis_log_source" "kinesisLog" {
 	path {
 		type = "KinesisLogPath"
     bucket_name     = "%s"
-    path_expression = "*"
+    path_expression = "http-endpoint-failed/*"
     scan_interval   = 30000
 	}
 }

--- a/sumologic/resource_sumologic_kinesis_log_source_test.go
+++ b/sumologic/resource_sumologic_kinesis_log_source_test.go
@@ -1,0 +1,207 @@
+package sumologic
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccSumologicKinesisLogSource_create(t *testing.T) {
+	var kinesisLogSource KinesisLogSource
+	var collector Collector
+	cName, cDescription, cCategory := getRandomizedParams()
+	sName, sDescription, sCategory := getRandomizedParams()
+	kinesisLogResourceName := "sumologic_kinesis_log_source.kinesisLog"
+	testAwsRoleArn := os.Getenv("SUMOLOGIC_TEST_ROLE_ARN")
+	testAwsBucket := os.Getenv("SUMOLOGIC_TEST_BUCKET_NAME")
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckWithAWS(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKinesisLogSourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSumologicKinesisLogSourceConfig(cName, cDescription, cCategory, sName, sDescription, sCategory, testAwsRoleArn, testAwsBucket),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisLogSourceExists(kinesisLogResourceName, &kinesisLogSource),
+					testAccCheckKinesisLogSourceValues(&kinesisLogSource, sName, sDescription, sCategory),
+					testAccCheckCollectorExists("sumologic_collector.test", &collector),
+					testAccCheckCollectorValues(&collector, cName, cDescription, cCategory, "Etc/UTC", ""),
+					resource.TestCheckResourceAttrSet(kinesisLogResourceName, "id"),
+					resource.TestCheckResourceAttr(kinesisLogResourceName, "name", sName),
+					resource.TestCheckResourceAttr(kinesisLogResourceName, "description", sDescription),
+					resource.TestCheckResourceAttr(kinesisLogResourceName, "category", sCategory),
+					resource.TestCheckResourceAttr(kinesisLogResourceName, "content_type", "KinesisLog"),
+					resource.TestCheckResourceAttr(kinesisLogResourceName, "path.0.type", "KinesisLogPath"),
+				),
+			},
+		},
+	})
+}
+func TestAccSumologicKinesisLogSource_update(t *testing.T) {
+	var kinesisLogSource KinesisLogSource
+	cName, cDescription, cCategory := getRandomizedParams()
+	sName, sDescription, sCategory := getRandomizedParams()
+	sNameUpdated, sDescriptionUpdated, sCategoryUpdated := getRandomizedParams()
+	kinesisLogResourceName := "sumologic_kinesis_Log_source.kinesisLog"
+	testAwsRoleArn := os.Getenv("SUMOLOGIC_TEST_ROLE_ARN")
+	testAwsBucket := os.Getenv("SUMOLOGIC_TEST_BUCKET_NAME")
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckWithAWS(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckHTTPSourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSumologicKinesisLogSourceConfig(cName, cDescription, cCategory, sName, sDescription, sCategory, testAwsRoleArn, testAwsBucket),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisLogSourceExists(kinesisLogResourceName, &kinesisLogSource),
+					testAccCheckKinesisLogSourceValues(&kinesisLogSource, sName, sDescription, sCategory),
+					resource.TestCheckResourceAttrSet(kinesisLogResourceName, "id"),
+					resource.TestCheckResourceAttr(kinesisLogResourceName, "name", sName),
+					resource.TestCheckResourceAttr(kinesisLogResourceName, "description", sDescription),
+					resource.TestCheckResourceAttr(kinesisLogResourceName, "category", sCategory),
+					resource.TestCheckResourceAttr(kinesisLogResourceName, "content_type", "KinesisLog"),
+					resource.TestCheckResourceAttr(kinesisLogResourceName, "path.0.type", "KinesisLogPath"),
+				),
+			},
+			{
+				Config: testAccSumologicKinesisLogSourceConfig(cName, cDescription, cCategory, sNameUpdated, sDescriptionUpdated, sCategoryUpdated, testAwsRoleArn, testAwsBucket),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisLogSourceExists(kinesisLogResourceName, &kinesisLogSource),
+					testAccCheckKinesisLogSourceValues(&kinesisLogSource, sNameUpdated, sDescriptionUpdated, sCategoryUpdated),
+					resource.TestCheckResourceAttrSet(kinesisLogResourceName, "id"),
+					resource.TestCheckResourceAttr(kinesisLogResourceName, "name", sNameUpdated),
+					resource.TestCheckResourceAttr(kinesisLogResourceName, "description", sDescriptionUpdated),
+					resource.TestCheckResourceAttr(kinesisLogResourceName, "category", sCategoryUpdated),
+					resource.TestCheckResourceAttr(kinesisLogResourceName, "content_type", "KinesisLog"),
+					resource.TestCheckResourceAttr(kinesisLogResourceName, "path.0.type", "KinesisLogPath"),
+				),
+			},
+		},
+	})
+}
+func testAccCheckKinesisLogSourceDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "sumologic_kinesis_log_source" {
+			continue
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("HTTP Source destruction check: HTTP Source ID is not set")
+		}
+		id, err := strconv.Atoi(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("Encountered an error: " + err.Error())
+		}
+		collectorID, err := strconv.Atoi(rs.Primary.Attributes["collector_id"])
+		if err != nil {
+			return fmt.Errorf("Encountered an error: " + err.Error())
+		}
+		s, err := client.GetKinesisLogSource(collectorID, id)
+		if err != nil {
+			return fmt.Errorf("Encountered an error: " + err.Error())
+		}
+		if s != nil {
+			return fmt.Errorf("KinesisLog Source still exists")
+		}
+	}
+	return nil
+}
+func testAccCheckKinesisLogSourceExists(n string, kinesisLogSource *KinesisLogSource) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("KinesisLog Source ID is not set")
+		}
+		id, err := strconv.Atoi(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("KinesisLog Source id should be int; got %s", rs.Primary.ID)
+		}
+		collectorID, err := strconv.Atoi(rs.Primary.Attributes["collector_id"])
+		if err != nil {
+			return fmt.Errorf("Encountered an error: " + err.Error())
+		}
+		c := testAccProvider.Meta().(*Client)
+		kinesisLogSourceResp, err := c.GetKinesisLogSource(collectorID, id)
+		if err != nil {
+			return err
+		}
+		*kinesisLogSource = *kinesisLogSourceResp
+		return nil
+	}
+}
+func testAccCheckKinesisLogSourceValues(kinesisLogSource *KinesisLogSource, name, description, category string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if kinesisLogSource.Name != name {
+			return fmt.Errorf("bad name, expected \"%s\", got: %#v", name, kinesisLogSource.Name)
+		}
+		if kinesisLogSource.Description != description {
+			return fmt.Errorf("bad description, expected \"%s\", got: %#v", description, kinesisLogSource.Description)
+		}
+		if kinesisLogSource.Category != category {
+			return fmt.Errorf("bad category, expected \"%s\", got: %#v", category, kinesisLogSource.Category)
+		}
+		return nil
+	}
+}
+func testAccSumologicKinesisLogSourceConfig(cName, cDescription, cCategory, sName, sDescription, sCategory, testAwsRoleArn, testAwsBucket string) string {
+	return fmt.Sprintf(`
+resource "sumologic_collector" "test" {
+	name = "%s"
+	description = "%s"
+	category = "%s"
+}
+
+resource "sumologic_kinesis_log_source" "kinesisLog" {
+	name = "%s"
+	description = "%s"
+	category = "%s"
+	content_type  = "KinesisLog"
+	collector_id = "${sumologic_collector.test.id}"
+	authentication {
+		type = "AWSRoleBasedAuthentication"
+		role_arn = "%s"
+	  }
+	path {
+		type = "KinesisLogPath"
+		path {
+			type            = "TagFilters"
+		    bucket_name     = "%s"
+		    path_expression = "*"
+		    scan_interval   = 30000
+		}
+	  }
+}
+`, cName, cDescription, cCategory, sName, sDescription, sCategory, testAwsRoleArn, testAwsBucket)
+}
+
+func testAccSumologicKinesisLogSourceNoAuthConfig(cName, cDescription, cCategory, sName, sDescription, sCategory string) string {
+	return fmt.Sprintf(`
+resource "sumologic_collector" "test" {
+	name = "%s"
+	description = "%s"
+	category = "%s"
+}
+
+resource "sumologic_kinesis_log_source" "kinesisLog" {
+	name = "%s"
+	description = "%s"
+	category = "%s"
+	content_type  = "KinesisLog"
+	collector_id = "${sumologic_collector.test.id}"
+	authentication {
+        type = "NoAuthentication"
+      }
+	  path {
+		type = "NoPathExpression"
+	  }
+	}
+}
+`, cName, cDescription, cCategory, sName, sDescription, sCategory)
+}

--- a/sumologic/resource_sumologic_kinesis_log_source_test.go
+++ b/sumologic/resource_sumologic_kinesis_log_source_test.go
@@ -165,15 +165,15 @@ resource "sumologic_kinesis_log_source" "kinesisLog" {
 	content_type  = "KinesisLog"
 	collector_id = "${sumologic_collector.test.id}"
 	authentication {
-		type = "AWSRoleBasedAuthentication"
-		role_arn = "%s"
-	  }
+    type = "AWSRoleBasedAuthentication"
+    role_arn = "%s"
+  }
 	path {
 		type = "KinesisLogPath"
-        bucket_name     = "%s"
-        path_expression = "*"
-        scan_interval   = 30000
-	  }
+    bucket_name     = "%s"
+    path_expression = "*"
+    scan_interval   = 30000
+	}
 }
 `, cName, cDescription, cCategory, sName, sDescription, sCategory, testAwsRoleArn, testAwsBucket)
 }
@@ -193,11 +193,10 @@ resource "sumologic_kinesis_log_source" "kinesisLog" {
 	content_type  = "KinesisLog"
 	collector_id = "${sumologic_collector.test.id}"
 	authentication {
-        type = "NoAuthentication"
-      }
-	  path {
+    type = "NoAuthentication"
+  }
+	path {
 		type = "NoPathExpression"
-	  }
 	}
 }
 `, cName, cDescription, cCategory, sName, sDescription, sCategory)

--- a/sumologic/resource_sumologic_kinesis_log_source_test.go
+++ b/sumologic/resource_sumologic_kinesis_log_source_test.go
@@ -46,7 +46,7 @@ func TestAccSumologicKinesisLogSource_update(t *testing.T) {
 	cName, cDescription, cCategory := getRandomizedParams()
 	sName, sDescription, sCategory := getRandomizedParams()
 	sNameUpdated, sDescriptionUpdated, sCategoryUpdated := getRandomizedParams()
-	kinesisLogResourceName := "sumologic_kinesis_Log_source.kinesisLog"
+	kinesisLogResourceName := "sumologic_kinesis_log_source.kinesisLog"
 	testAwsRoleArn := os.Getenv("SUMOLOGIC_TEST_ROLE_ARN")
 	testAwsBucket := os.Getenv("SUMOLOGIC_TEST_BUCKET_NAME")
 	resource.Test(t, resource.TestCase{

--- a/sumologic/sumologic_kinesis_log_source.go
+++ b/sumologic/sumologic_kinesis_log_source.go
@@ -18,8 +18,8 @@ type KinesisLogThirdPartyRef struct {
 
 type KinesisLogResource struct {
 	ServiceType    string                   `json:"serviceType"`
-	Authentication *PollingAuthentication   `json:"authentication,omitempty"`
-	Path           *KinesisLogPath          `json:"path,omitempty"`
+	Authentication PollingAuthentication   `json:"authentication,omitempty"`
+	Path           KinesisLogPath          `json:"path,omitempty"`
 }
 
 type KinesisLogPath struct {

--- a/sumologic/sumologic_kinesis_log_source.go
+++ b/sumologic/sumologic_kinesis_log_source.go
@@ -7,9 +7,9 @@ import (
 
 type KinesisLogSource struct {
 	Source
-	MessagePerRequest bool                      `json:"messagePerRequest"`
-	URL               string                    `json:"url,omitempty"`
-	ThirdPartyRef     KinesisLogThirdPartyRef   `json:"thirdPartyRef"`
+	MessagePerRequest bool                    `json:"messagePerRequest"`
+	URL               string                  `json:"url,omitempty"`
+	ThirdPartyRef     KinesisLogThirdPartyRef `json:"thirdPartyRef"`
 }
 
 type KinesisLogThirdPartyRef struct {
@@ -17,16 +17,16 @@ type KinesisLogThirdPartyRef struct {
 }
 
 type KinesisLogResource struct {
-	ServiceType    string                   `json:"serviceType"`
-	Authentication PollingAuthentication   `json:"authentication,omitempty"`
-	Path           KinesisLogPath          `json:"path,omitempty"`
+	ServiceType    string                `json:"serviceType"`
+	Authentication PollingAuthentication `json:"authentication,omitempty"`
+	Path           KinesisLogPath        `json:"path,omitempty"`
 }
 
 type KinesisLogPath struct {
-	Type              string    `json:"type"`
-    BucketName        string    `json:"bucketName,omitempty"`
-    PathExpression    string    `json:"pathExpression,omitempty"`
-	ScanInterval      int       `json:"scanInterval,omitempty"`
+	Type           string `json:"type"`
+	BucketName     string `json:"bucketName,omitempty"`
+	PathExpression string `json:"pathExpression,omitempty"`
+	ScanInterval   int    `json:"scanInterval,omitempty"`
 }
 
 func (s *Client) CreateKinesisLogSource(kinesisLogSource KinesisLogSource, collectorID int) (int, error) {

--- a/sumologic/sumologic_kinesis_log_source.go
+++ b/sumologic/sumologic_kinesis_log_source.go
@@ -1,0 +1,100 @@
+package sumologic
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type KinesisLogSource struct {
+	Source
+	MessagePerRequest bool                      `json:"messagePerRequest"`
+	URL               string                    `json:"url,omitempty"`
+	ThirdPartyRef     KinesisLogThirdPartyRef   `json:"thirdPartyRef"`
+}
+
+type KinesisLogThirdPartyRef struct {
+	Resources []KinesisLogResource `json:"resources"`
+}
+
+type KinesisLogResource struct {
+	ServiceType    string                   `json:"serviceType"`
+	Authentication *PollingAuthentication   `json:"authentication,omitempty"`
+	Path           *KinesisLogPath          `json:"path,omitempty"`
+}
+
+type KinesisLogPath struct {
+	Type              string    `json:"type"`
+    BucketName        string    `json:"bucketName,omitempty"`
+    PathExpression    string    `json:"pathExpression,omitempty"`
+	ScanInterval      int       `json:"scanInterval,omitempty"`
+}
+
+func (s *Client) CreateKinesisLogSource(kinesisLogSource KinesisLogSource, collectorID int) (int, error) {
+
+	type KinesisLogSourceMessage struct {
+		Source KinesisLogSource `json:"source"`
+	}
+
+	request := KinesisLogSourceMessage{
+		Source: kinesisLogSource,
+	}
+
+	urlPath := fmt.Sprintf("v1/collectors/%d/sources", collectorID)
+	body, err := s.Post(urlPath, request)
+
+	if err != nil {
+		return -1, err
+	}
+
+	var response KinesisLogSourceMessage
+
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		return -1, err
+	}
+
+	return response.Source.ID, nil
+}
+
+func (s *Client) GetKinesisLogSource(collectorID, sourceID int) (*KinesisLogSource, error) {
+
+	body, _, err := s.Get(
+		fmt.Sprintf("v1/collectors/%d/sources/%d", collectorID, sourceID),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if body == nil {
+		return nil, nil
+	}
+
+	type Response struct {
+		Source KinesisLogSource `json:"source"`
+	}
+
+	var response Response
+
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response.Source, nil
+}
+
+func (s *Client) UpdateKinesisLogSource(source KinesisLogSource, collectorID int) error {
+
+	type KinesisLogSourceMessage struct {
+		Source KinesisLogSource `json:"source"`
+	}
+
+	request := KinesisLogSourceMessage{
+		Source: source,
+	}
+
+	urlPath := fmt.Sprintf("v1/collectors/%d/sources/%d", collectorID, source.ID)
+	_, err := s.Put(urlPath, request)
+
+	return err
+}

--- a/website/docs/r/kinesis_log_source.html.markdown
+++ b/website/docs/r/kinesis_log_source.html.markdown
@@ -1,8 +1,8 @@
 ---
 layout: "sumologic"
-page_title: "SumoLogic: sumologic_log_metrics_source"
+page_title: "SumoLogic: sumologic_kinesis_log_source"
 description: |-
-  Provides a Sumologic Kinesis Log source. This source is used to integrate with Metrics Stream via Kinesis Firehose from AWS.
+  Provides a Sumologic Kinesis Log source. This source is used to integrate with Log Stream via Kinesis Firehose from AWS.
 ---
 
 # sumologic_kinesis_log_source
@@ -67,15 +67,15 @@ locals {
 In addition to the common properties, the following arguments are supported:
 
  - `content_type` - (Required) The content-type of the collected data. Details can be found in the [Sumologic documentation for hosted sources][1].
- - `authentication` - (Required) Authentication details for connecting to the S3 bucket.
+ - `authentication` - (Optional) Authentication details for connecting to the S3 bucket.
      + `type` - (Required) Must be either `S3BucketAuthentication` or `AWSRoleBasedAuthentication` or `NoAuthentication`
      + `access_key` - (Required) Your AWS access key if using type `S3BucketAuthentication`
      + `secret_key` - (Required) Your AWS secret key if using type `S3BucketAuthentication`
      + `role_arn` - (Required) Your AWS role ARN if using type `AWSRoleBasedAuthentication`
- - `path` - (Required) The location to scan for new data.
+ - `path` - (Optional) The location of S3 bucket for failed Kinesis log data.
      + `type` - (Required) Must be either `KinesisLogPath` or `NoPathExpression`
-     + `bucket_name` - (Optional) The name of the bucket. This is needed if using type `S3BucketPathExpression`. 
-     + `path_expression` - (Optional) The path to the data. This is needed if using type `S3BucketPathExpression`. For Kinesis log source, it must includes `http-endpoint-failed/`.
+     + `bucket_name` - (Optional) The name of the bucket. This is needed if using type `KinesisLogPath`. 
+     + `path_expression` - (Optional) The path to the data. This is needed if using type `KinesisLogPath`. For Kinesis log source, it must includes `http-endpoint-failed/`.
      + `scan_interval` - (Optional) The Time interval in milliseconds of scans for new data. The default is 300000 and the minimum value is 1000 milliseconds.
 
 ### See also
@@ -91,7 +91,7 @@ The following attributes are exported:
 Kinesis Log sources can be imported using the collector and source IDs (`collector/source`), e.g.:
 
 ```hcl
-terraform import sumologic_log_metrics_source.test 123/456
+terraform import sumologic_kinesis_log_source.test 123/456
 ```
 
 HTTP sources can be imported using the collector name and source name (`collectorName/sourceName`), e.g.:

--- a/website/docs/r/kinesis_log_source.html.markdown
+++ b/website/docs/r/kinesis_log_source.html.markdown
@@ -1,0 +1,103 @@
+---
+layout: "sumologic"
+page_title: "SumoLogic: sumologic_log_metrics_source"
+description: |-
+  Provides a Sumologic Kinesis Log source. This source is used to integrate with Metrics Stream via Kinesis Firehose from AWS.
+---
+
+# sumologic_kinesis_log_source
+
+Provides a Sumologic Kinesis Log source. This source is used to ingest log via Kinesis Firehose from AWS.
+
+__IMPORTANT:__ The AWS credentials are stored in plain-text in the state. This is a potential security issue.
+
+## Example Usage
+```hcl
+locals {
+
+  resource "sumologic_kinesis_log_source" "kinesis_log_access_key" {
+    name         = "Kinesis Log"
+    description  = "Description for Kinesis Log Source"
+    category     = "prod/kinesis/log"
+    content_type = "KinesisLog"
+    collector_id = "${sumologic_collector.collector.id}"
+    authentication {
+      type       = "S3BucketAuthentication"
+      access_key = "someKey"
+      secret_key = "******"
+    }
+
+    path {
+      type            = "KinesisLogPath"
+      bucket_name     = "testBucket"
+      path_expression = "http-endpoint-failed/*"
+      scan_interval   = 30000
+    }
+  }
+
+  resource "sumologic_kinesis_log_source" "kinesis_log_role_arn" {
+    name         = "Kinesis Log"
+    description  = "Description for Kinesis Log Source"
+    category     = "prod/kinesis/log"
+    content_type = "KinesisLog"
+    collector_id = "${sumologic_collector.collector.id}"
+
+    authentication {
+      type     = "AWSRoleBasedAuthentication"
+      role_arn = "arn:aws:iam::604066827510:role/cw-role-SumoRole-4AOLS73TGKYI"
+    }
+
+    path {
+      type            = "KinesisLogPath"
+      bucket_name     = "testBucket"
+      path_expression = "http-endpoint-failed/*"
+      scan_interval   = 30000
+    }
+  }
+
+  resource "sumologic_collector" "collector" {
+    name        = "my-collector"
+    description = "Just testing this"
+  }
+}
+```
+
+## Argument reference
+
+In addition to the common properties, the following arguments are supported:
+
+ - `content_type` - (Required) The content-type of the collected data. Details can be found in the [Sumologic documentation for hosted sources][1].
+ - `authentication` - (Required) Authentication details for connecting to the S3 bucket.
+     + `type` - (Required) Must be either `S3BucketAuthentication` or `AWSRoleBasedAuthentication` or `NoAuthentication`
+     + `access_key` - (Required) Your AWS access key if using type `S3BucketAuthentication`
+     + `secret_key` - (Required) Your AWS secret key if using type `S3BucketAuthentication`
+     + `role_arn` - (Required) Your AWS role ARN if using type `AWSRoleBasedAuthentication`
+ - `path` - (Required) The location to scan for new data.
+     + `type` - (Required) Must be either `KinesisLogPath` or `NoPathExpression`
+     + `bucket_name` - (Optional) The name of the bucket. This is needed if using type `S3BucketPathExpression`. 
+     + `path_expression` - (Optional) The path to the data. This is needed if using type `S3BucketPathExpression`. For Kinesis log source, it must includes `http-endpoint-failed/`.
+     + `scan_interval` - (Optional) The Time interval in milliseconds of scans for new data. The default is 300000 and the minimum value is 1000 milliseconds.
+
+### See also
+   * [Common Source Properties](https://registry.terraform.io/providers/SumoLogic/sumologic/latest/docs#common-source-properties)
+
+## Attributes Reference
+The following attributes are exported:
+
+- `id` - The internal ID of the source.
+- `url` - The HTTP endpoint to used while creating Kinesis Firehose on AWS.
+
+## Import
+Kinesis Log sources can be imported using the collector and source IDs (`collector/source`), e.g.:
+
+```hcl
+terraform import sumologic_log_metrics_source.test 123/456
+```
+
+HTTP sources can be imported using the collector name and source name (`collectorName/sourceName`), e.g.:
+
+```hcl
+terraform import sumologic_kinesis_log_source.test my-test-collector/my-test-source
+```
+
+[1]: https://help.sumologic.com/Send_Data/Sources/03Use_JSON_to_Configure_Sources/JSON_Parameters_for_Hosted_Sources


### PR DESCRIPTION
I've already added the new resource `sumologic_kinesis_log_source`

Already verified that the source has been created successfully:
```
resource "sumologic_kinesis_log_source" "kinesis_log" {
  name = "test-kinesis-tf"
  description = "test kinesis source with replay"
  content_type  = "KinesisLog"
  collector_id = "108404925"
  authentication {
      type = "S3BucketAuthentication"
      access_key = "XXX"
      secret_key = "XXXX"
  }
  path {
      type = "KinesisLogPath"
      bucket_name     = "test-kinesis-bucket-yuting-us-west-2"
      path_expression = "http-endpoint-failed/*"
      scan_interval   = 30000
  }
}
```


Besides, as for source update, we can update the source successfully with `NoAuthentication` placeholder:
```
resource "sumologic_kinesis_log_source" "kinesis_log" {
  name = "test-kinesis-tf"
  description = "test kinesis source with replay"
  content_type  = "KinesisLog"
  collector_id = "108404925"
  authentication {
      type = "NoAuthentication"
  }
  path {
      type = "NoPathExpression"
  }
}
```

The only issue is that there will be inconsistency after using the placeholder.
As for `terraform plan`, it will show one change needed to be apply:
```
Terraform will perform the following actions:

  # sumologic_kinesis_log_source.kinesis_log will be updated in-place
  ~ resource "sumologic_kinesis_log_source" "kinesis_log" {
        id                           = "114158598"
        name                         = "test-kinesis-tf"
        # (12 unchanged attributes hidden)


      + path {
          + scan_interval = 300000
          + type          = "NoPathExpression"
        }
        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

sumologic_kinesis_log_source.kinesis_log: Modifying... [id=114158598]
sumologic_kinesis_log_source.kinesis_log: Modifications complete after 2s [id=114158598]
```

However, there won't be errors.