### PR TITLE
Fix provider crash for user and role data sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 2.12.0 (Unreleased)
+## 2.11.3 (Unreleased)
+
+BUG FIXES:
+
+* Fix provider crash when user / role data source is declared with a non-existent identifier (GH-316)
 
 ## 2.11.2 (November 11, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## 2.11.3 (Unreleased)
+## 2.12.0 (Unreleased)
+
+## 2.11.3 (November 17, 2021)
 
 BUG FIXES:
 

--- a/sumologic/data_source_sumologic_role.go
+++ b/sumologic/data_source_sumologic_role.go
@@ -55,6 +55,9 @@ func dataSourceSumologicRoleRead(d *schema.ResourceData, meta interface{}) error
 		if err != nil {
 			return fmt.Errorf("role with id %v not found: %v", id, err)
 		}
+		if role == nil {
+			return fmt.Errorf("role with id %v not found", id)
+		}
 	} else {
 		if rname, ok := d.GetOk("name"); ok {
 			name := rname.(string)
@@ -96,6 +99,9 @@ func (s *Client) GetRoleName(name string) (*Role, error) {
 	err = json.Unmarshal(data, &response)
 	if err != nil {
 		return nil, err
+	}
+	if len(response.Roles) == 0 {
+		return nil, fmt.Errorf("role with name '%s' does not exist", name)
 	}
 
 	return &response.Roles[0], nil

--- a/sumologic/data_source_sumologic_role_test.go
+++ b/sumologic/data_source_sumologic_role_test.go
@@ -1,12 +1,13 @@
 package sumologic
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccDataSourcSumologicRole_basic(t *testing.T) {
+func TestAccDataSourceSumologicRole_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -31,6 +32,40 @@ func testAccDataSourceRoleCheck(name, reference string) resource.TestCheckFunc {
 		resource.TestCheckResourceAttrPair(name, "filter_predicate", reference, "filter_predicate"),
 		resource.TestCheckResourceAttrPair(name, "capabilities", reference, "capabilities"),
 	)
+}
+
+func TestAccDataSourceSumologicRole_role_name_doesnt_exist(t *testing.T) {
+	roleDoestExistConfig := `
+  data "sumologic_role" "role_name_doesnt_exist" {
+    name = "someRoleNameDoesntExist8746"
+  }`
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      roleDoestExistConfig,
+				ExpectError: regexp.MustCompile("role with name 'someRoleNameDoesntExist8746' does not exist"),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceSumologicRole_role_id_doesnt_exist(t *testing.T) {
+	roleDoestExistConfig := `
+  data "sumologic_role" "role_id_doesnt_exist" {
+    id = 99999999999999
+  }`
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      roleDoestExistConfig,
+				ExpectError: regexp.MustCompile("role with id 99999999999999 not found"),
+			},
+		},
+	})
 }
 
 var testDataSourceAccSumologicRoleConfig = `

--- a/sumologic/data_source_sumologic_user.go
+++ b/sumologic/data_source_sumologic_user.go
@@ -59,6 +59,9 @@ func dataSourceSumologicUserRead(d *schema.ResourceData, meta interface{}) error
 		if err != nil {
 			return fmt.Errorf("user with id %v not found: %v", id, err)
 		}
+		if user == nil {
+			return fmt.Errorf("user with id %v not found", id)
+		}
 	} else {
 		if userEmail, ok := d.GetOk("email"); ok {
 			email := userEmail.(string)
@@ -101,6 +104,9 @@ func (s *Client) GetUserByEmail(email string) (*User, error) {
 	err = json.Unmarshal(data, &response)
 	if err != nil {
 		return nil, err
+	}
+	if len(response.User) == 0 {
+		return nil, fmt.Errorf("user with email address '%s' does not exist", email)
 	}
 
 	return &response.User[0], nil

--- a/sumologic/data_source_sumologic_user_test.go
+++ b/sumologic/data_source_sumologic_user_test.go
@@ -2,12 +2,13 @@ package sumologic
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccDataSourcSumologicUser_basic(t *testing.T) {
+func TestAccDataSourceSumologicUser_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -32,6 +33,40 @@ func testAccDataSourceUserCheck(email, reference string) resource.TestCheckFunc 
 		resource.TestCheckResourceAttrPair(email, "last_name", reference, "last_name"),
 		resource.TestCheckResourceAttrPair(email, "is_active", reference, "is_active"),
 	)
+}
+
+func TestAccDataSourceSumologicUser_user_email_doesnt_exist(t *testing.T) {
+	userDoestExistConfig := `
+  data "sumologic_user" "user_email_doesnt_exist" {
+    email = "someNonExistentEmail2374@sumologic.com"
+  }`
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      userDoestExistConfig,
+				ExpectError: regexp.MustCompile("user with email address 'someNonExistentEmail2374@sumologic.com' does not exist"),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceSumologicUser_user_id_doesnt_exist(t *testing.T) {
+	userDoestExistConfig := `
+  data "sumologic_user" "user_id_doesnt_exist" {
+    id = 99999999999999
+  }`
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      userDoestExistConfig,
+				ExpectError: regexp.MustCompile("user with id 99999999999999 not found"),
+			},
+		},
+	})
 }
 
 var testDataSourceAccSumologicUserConfig = fmt.Sprintf(`


### PR DESCRIPTION
- Fix provider crash when role `id` / `name` not found
- Fix provider crash when user `id` / `email` not found