### PR TITLE
Fix unexpected end of JSON input in folder and dashboard resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## 2.12.0 (Unreleased)
 
+## 2.11.4 (November 19, 2021)
+
+BUG FIXES:
+
+* Fix unexpected end of JSON input error in folder and dashboard resources (GH-319)
+
 ## 2.11.3 (November 17, 2021)
 
 BUG FIXES:

--- a/sumologic/sumologic_dashboard.go
+++ b/sumologic/sumologic_dashboard.go
@@ -11,6 +11,9 @@ func (s *Client) GetDashboard(id string) (*Dashboard, error) {
 	if err != nil {
 		return nil, err
 	}
+	if data == nil {
+		return nil, nil
+	}
 
 	var dashboard Dashboard
 	err = json.Unmarshal(data, &dashboard)

--- a/sumologic/sumologic_folder.go
+++ b/sumologic/sumologic_folder.go
@@ -14,6 +14,9 @@ func (s *Client) GetFolder(id string) (*Folder, error) {
 	if err != nil {
 		return nil, err
 	}
+	if rawFolder == nil {
+		return nil, nil
+	}
 
 	var folder Folder
 	err = json.Unmarshal(rawFolder, &folder)


### PR DESCRIPTION
Addresses https://github.com/SumoLogic/terraform-provider-sumologic/issues/188 and (probably) https://github.com/SumoLogic/terraform-provider-sumologic/issues/317.

Steps to reproduce this issue:
1. Create a folder resource using some `user1` access key/id
2. Change the access key/id to some other `user2` with minimal credentials and do `terraform plan`
3. Get `Error: unexpected end of JSON input`

The reason this happened is because we already have the folder id in the state when `user1` created it, but `user2` does not have access to it. So when `user2` does `terraform plan`, we try to read that folder id from the API and get a 404. We were not handling that 404 properly (it's when the folder in `nil`) and hence we were trying to unmarshal a `nil` json object, which results in a `unexpected end of JSON input` error.