### PR TITLE
Set isAdminMode header param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 BUG FIXES:
 
-* Set admin mode in PostRawPayload method (GH-XXX)
+* Set admin mode in PostRawPayload method (GH-322)
 
 ## 2.11.4 (November 19, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## 2.12.0 (Unreleased)
 
+## 2.11.5 (Unreleased)
+
+BUG FIXES:
+
+* Set admin mode in PostRawPayload method (GH-XXX)
+
 ## 2.11.4 (November 19, 2021)
 
 BUG FIXES:
@@ -25,7 +31,7 @@ FEATURES:
 * **New Datasource:** sumologic_user (GH-299)
 
 BUG FIXES:
- 
+
 * Fix occurrence_type for metrics resolution conditions (GH-297)
 * Relaxed validation for monitor time range (GH-306)
 
@@ -39,7 +45,7 @@ FEATURES:
 * **New Resource:** sumologic_cse_insights_resolution (GH-274)
 * **New Resource:** sumologic_cse_insights_status (GH-274)
 * **New Resource:** sumologic_cse_insights_configuration (GH-274)
-* **New Resource:** sumologic_cse_log_mapping (GH-284) 
+* **New Resource:** sumologic_cse_log_mapping (GH-284)
 * **New Datasource:** sumologic_cse_log_mapping_vendor_product (GH-284)
 * **New Resource:** sumologic_cse_aggregation_rule (GH-290)
 * **New Resource:** sumologic_cse_chain_rule (GH-290)

--- a/sumologic/sumologic_client.go
+++ b/sumologic/sumologic_client.go
@@ -176,6 +176,10 @@ func (s *Client) PostRawPayload(urlPath string, payload string) ([]byte, error) 
 		return nil, err
 	}
 
+	if s.IsInAdminMode {
+		req.Header.Add("isAdminMode", "true")
+	}
+
 	<-rateLimiter.C
 	resp, err := s.httpClient.Do(req)
 


### PR DESCRIPTION
Set admin mode in `PostRawPayload` method. The admin mode wasn't set, leading to error when a user would try to create content inside "Admin Recommended" folder. 