### PR TITLE
Gcp metrics source

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,6 +91,7 @@ jobs:
         SUMOLOGIC_ENVIRONMENT:  ${{ secrets.SUMOLOGIC_ENVIRONMENT }}
         SUMOLOGIC_TEST_BUCKET_NAME:  ${{ secrets.SUMOLOGIC_TEST_BUCKET_NAME }}
         SUMOLOGIC_TEST_ROLE_ARN:  ${{ secrets.SUMOLOGIC_TEST_ROLE_ARN }}
+        SUMOLOGIC_TEST_GOOGLE_APPLICATION_CREDENTIALS:  ${{ secrets.SUMOLOGIC_TEST_GOOGLE_APPLICATION_CREDENTIALS }}
 
       # disable go test timeout. We rely on GitHub action timeout.
       run: |

--- a/README.md
+++ b/README.md
@@ -53,7 +53,11 @@ Then run `terraform init` to initialize it.
 
 In order to run the full suite of Acceptance tests, run `make testacc`.
 
-*Note:* Acceptance tests *create real resources*, and often cost money to run. The environment variables `SUMOLOGIC_ACCESSID`, `SUMOLOGIC_ACCESSKEY`, and `SUMOLOGIC_ENVIRONMENT` must also be set for acceptance tests to work properly.
+*Note:* 
+- Acceptance tests *create real resources*, and often cost money to run. The environment variables `SUMOLOGIC_ACCESSID`, `SUMOLOGIC_ACCESSKEY`, and `SUMOLOGIC_ENVIRONMENT` must also be set for acceptance tests to work properly.
+- Environment variable `SUMOLOGIC_TEST_GOOGLE_APPLICATION_CREDENTIALS` must be set for gcp metrics acceptance tests to work properly (ex. below).
+    - export SUMOLOGIC_TEST_GOOGLE_APPLICATION_CREDENTIALS=`cat /path/to/service_acccount.json`
+    - Set Environment variable `SUMOLOGIC_ENABLE_GCP_METRICS_ACC_TESTS` to false, to disable acceptance test for Gcp Metrics. 
 
 [0]: https://help.sumologic.com/Manage/Security/Access-Keys
 [1]: https://help.sumologic.com/APIs/General_API_Information/Sumo_Logic_Endpoints_and_Firewall_Security

--- a/sumologic/provider.go
+++ b/sumologic/provider.go
@@ -68,6 +68,7 @@ func Provider() terraform.ResourceProvider {
 			"sumologic_cloudtrail_source":                  resourceSumologicGenericPollingSource(),
 			"sumologic_elb_source":                         resourceSumologicGenericPollingSource(),
 			"sumologic_cloudfront_source":                  resourceSumologicGenericPollingSource(),
+			"sumologic_gcp_metrics_source":                 resourceSumologicGenericPollingSource(),
 			"sumologic_cloud_to_cloud_source":              resourceSumologicCloudToCloudSource(),
 			"sumologic_metadata_source":                    resourceSumologicMetadataSource(),
 			"sumologic_cloudsyslog_source":                 resourceSumologicCloudsyslogSource(),

--- a/sumologic/resource_sumologic_gcp_metrics_source_test.go
+++ b/sumologic/resource_sumologic_gcp_metrics_source_test.go
@@ -3,84 +3,92 @@ package sumologic
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
+func shouldTestGcpMetricsSource() bool {
+	return !strings.EqualFold(os.Getenv("SUMOLOGIC_ENABLE_GCP_METRICS_ACC_TESTS"), "false")
+}
+
 func TestAccSumologicGcpMetricsSource_create(t *testing.T) {
-	var GcpMetricsSource PollingSource
-	var collector Collector
-	cName, cDescription, cCategory := getRandomizedParams()
-	sName, sDescription, sCategory := getRandomizedParams()
-	GcpMetricsResourceName := "sumologic_gcp_metrics_source.gcp_metrics_source"
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { getServiceAccountCreds(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckGcpMetricsSourceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccSumologicGcpMetricsSourceConfig(t, cName, cDescription, cCategory, sName, sDescription, sCategory),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGcpMetricsSourceExists(GcpMetricsResourceName, &GcpMetricsSource),
-					testAccCheckGcpMetricsSourceValues(&GcpMetricsSource, sName, sDescription, sCategory),
-					testAccCheckCollectorExists("sumologic_collector.test", &collector),
-					testAccCheckCollectorValues(&collector, cName, cDescription, cCategory, "Etc/UTC", ""),
-					resource.TestCheckResourceAttrSet(GcpMetricsResourceName, "id"),
-					resource.TestCheckResourceAttr(GcpMetricsResourceName, "name", sName),
-					resource.TestCheckResourceAttr(GcpMetricsResourceName, "description", sDescription),
-					resource.TestCheckResourceAttr(GcpMetricsResourceName, "category", sCategory),
-					resource.TestCheckResourceAttr(GcpMetricsResourceName, "content_type", "GcpMetrics"),
-					resource.TestCheckResourceAttr(GcpMetricsResourceName, "path.0.type", "GcpMetricsPath"),
-				),
+	if shouldTestGcpMetricsSource() {
+		var GcpMetricsSource PollingSource
+		var collector Collector
+		cName, cDescription, cCategory := getRandomizedParams()
+		sName, sDescription, sCategory := getRandomizedParams()
+		GcpMetricsResourceName := "sumologic_gcp_metrics_source.gcp_metrics_source"
+		resource.Test(t, resource.TestCase{
+			PreCheck:     func() { getServiceAccountCreds(t) },
+			Providers:    testAccProviders,
+			CheckDestroy: testAccCheckGcpMetricsSourceDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccSumologicGcpMetricsSourceConfig(t, cName, cDescription, cCategory, sName, sDescription, sCategory),
+					Check: resource.ComposeTestCheckFunc(
+						testAccCheckGcpMetricsSourceExists(GcpMetricsResourceName, &GcpMetricsSource),
+						testAccCheckGcpMetricsSourceValues(&GcpMetricsSource, sName, sDescription, sCategory),
+						testAccCheckCollectorExists("sumologic_collector.test", &collector),
+						testAccCheckCollectorValues(&collector, cName, cDescription, cCategory, "Etc/UTC", ""),
+						resource.TestCheckResourceAttrSet(GcpMetricsResourceName, "id"),
+						resource.TestCheckResourceAttr(GcpMetricsResourceName, "name", sName),
+						resource.TestCheckResourceAttr(GcpMetricsResourceName, "description", sDescription),
+						resource.TestCheckResourceAttr(GcpMetricsResourceName, "category", sCategory),
+						resource.TestCheckResourceAttr(GcpMetricsResourceName, "content_type", "GcpMetrics"),
+						resource.TestCheckResourceAttr(GcpMetricsResourceName, "path.0.type", "GcpMetricsPath"),
+					),
+				},
 			},
-		},
-	})
+		})
+	}
 }
 
 func TestAccSumologicGcpMetricsSource_update(t *testing.T) {
-	var GcpMetricsSource PollingSource
-	cName, cDescription, cCategory := getRandomizedParams()
-	sName, sDescription, sCategory := getRandomizedParams()
-	sNameUpdated, sDescriptionUpdated, sCategoryUpdated := getRandomizedParams()
-	GcpMetricsResourceName := "sumologic_gcp_metrics_source.gcp_metrics_source"
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { getServiceAccountCreds(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckHTTPSourceDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccSumologicGcpMetricsSourceConfig(t, cName, cDescription, cCategory, sName, sDescription, sCategory),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGcpMetricsSourceExists(GcpMetricsResourceName, &GcpMetricsSource),
-					testAccCheckGcpMetricsSourceValues(&GcpMetricsSource, sName, sDescription, sCategory),
-					resource.TestCheckResourceAttrSet(GcpMetricsResourceName, "id"),
-					resource.TestCheckResourceAttr(GcpMetricsResourceName, "name", sName),
-					resource.TestCheckResourceAttr(GcpMetricsResourceName, "description", sDescription),
-					resource.TestCheckResourceAttr(GcpMetricsResourceName, "category", sCategory),
-					resource.TestCheckResourceAttr(GcpMetricsResourceName, "content_type", "GcpMetrics"),
-					resource.TestCheckResourceAttr(GcpMetricsResourceName, "path.0.type", "GcpMetricsPath"),
-				),
+	if shouldTestGcpMetricsSource() {
+		var GcpMetricsSource PollingSource
+		cName, cDescription, cCategory := getRandomizedParams()
+		sName, sDescription, sCategory := getRandomizedParams()
+		sNameUpdated, sDescriptionUpdated, sCategoryUpdated := getRandomizedParams()
+		GcpMetricsResourceName := "sumologic_gcp_metrics_source.gcp_metrics_source"
+		resource.Test(t, resource.TestCase{
+			PreCheck:     func() { getServiceAccountCreds(t) },
+			Providers:    testAccProviders,
+			CheckDestroy: testAccCheckHTTPSourceDestroy,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccSumologicGcpMetricsSourceConfig(t, cName, cDescription, cCategory, sName, sDescription, sCategory),
+					Check: resource.ComposeTestCheckFunc(
+						testAccCheckGcpMetricsSourceExists(GcpMetricsResourceName, &GcpMetricsSource),
+						testAccCheckGcpMetricsSourceValues(&GcpMetricsSource, sName, sDescription, sCategory),
+						resource.TestCheckResourceAttrSet(GcpMetricsResourceName, "id"),
+						resource.TestCheckResourceAttr(GcpMetricsResourceName, "name", sName),
+						resource.TestCheckResourceAttr(GcpMetricsResourceName, "description", sDescription),
+						resource.TestCheckResourceAttr(GcpMetricsResourceName, "category", sCategory),
+						resource.TestCheckResourceAttr(GcpMetricsResourceName, "content_type", "GcpMetrics"),
+						resource.TestCheckResourceAttr(GcpMetricsResourceName, "path.0.type", "GcpMetricsPath"),
+					),
+				},
+				{
+					Config: testAccSumologicGcpMetricsSourceConfig(t, cName, cDescription, cCategory, sNameUpdated, sDescriptionUpdated, sCategoryUpdated),
+					Check: resource.ComposeTestCheckFunc(
+						testAccCheckGcpMetricsSourceExists(GcpMetricsResourceName, &GcpMetricsSource),
+						testAccCheckGcpMetricsSourceValues(&GcpMetricsSource, sNameUpdated, sDescriptionUpdated, sCategoryUpdated),
+						resource.TestCheckResourceAttrSet(GcpMetricsResourceName, "id"),
+						resource.TestCheckResourceAttr(GcpMetricsResourceName, "name", sNameUpdated),
+						resource.TestCheckResourceAttr(GcpMetricsResourceName, "description", sDescriptionUpdated),
+						resource.TestCheckResourceAttr(GcpMetricsResourceName, "category", sCategoryUpdated),
+						resource.TestCheckResourceAttr(GcpMetricsResourceName, "content_type", "GcpMetrics"),
+						resource.TestCheckResourceAttr(GcpMetricsResourceName, "path.0.type", "GcpMetricsPath"),
+					),
+				},
 			},
-			{
-				Config: testAccSumologicGcpMetricsSourceConfig(t, cName, cDescription, cCategory, sNameUpdated, sDescriptionUpdated, sCategoryUpdated),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGcpMetricsSourceExists(GcpMetricsResourceName, &GcpMetricsSource),
-					testAccCheckGcpMetricsSourceValues(&GcpMetricsSource, sNameUpdated, sDescriptionUpdated, sCategoryUpdated),
-					resource.TestCheckResourceAttrSet(GcpMetricsResourceName, "id"),
-					resource.TestCheckResourceAttr(GcpMetricsResourceName, "name", sNameUpdated),
-					resource.TestCheckResourceAttr(GcpMetricsResourceName, "description", sDescriptionUpdated),
-					resource.TestCheckResourceAttr(GcpMetricsResourceName, "category", sCategoryUpdated),
-					resource.TestCheckResourceAttr(GcpMetricsResourceName, "content_type", "GcpMetrics"),
-					resource.TestCheckResourceAttr(GcpMetricsResourceName, "path.0.type", "GcpMetricsPath"),
-				),
-			},
-		},
-	})
+		})
+	}
 }
 
 func testAccCheckGcpMetricsSourceDestroy(s *terraform.State) error {
@@ -169,23 +177,21 @@ type ServiceAccountCreds struct {
 func getServiceAccountCreds(t *testing.T) ServiceAccountCreds {
 	var err error
 	contentBytes := []byte("")
-	serviceAccountDetailsFileEnvName := "SUMOLOGIC_GOOGLE_APPLICATION_CREDENTIALS"
+	serviceAccountDetailsJsonEnvName := "SUMOLOGIC_TEST_GOOGLE_APPLICATION_CREDENTIALS"
 
-	serviceAccountDetailsFile, isEnvVarDefined := os.LookupEnv(serviceAccountDetailsFileEnvName)
+	serviceAccountDetailsJson, isEnvVarDefined := os.LookupEnv(serviceAccountDetailsJsonEnvName)
 	if !isEnvVarDefined {
-		t.Fatal(fmt.Sprintf("Environment variable %#v has to be defined", serviceAccountDetailsFileEnvName))
-	} else if len(serviceAccountDetailsFile) == 0 {
-		t.Fatal(fmt.Sprintf("Environment variable %#v can not be empty string", serviceAccountDetailsFileEnvName))
-	} else if _, statErr := os.Stat(serviceAccountDetailsFile); statErr != nil {
-		t.Fatal(fmt.Sprintf("Environment variable %#v points to non-existing file %#v", serviceAccountDetailsFileEnvName, serviceAccountDetailsFile))
-	} else {
-		contentBytes, err = ioutil.ReadFile(serviceAccountDetailsFile)
+		t.Fatal(fmt.Sprintf("Environment variable %#v has to be defined", serviceAccountDetailsJsonEnvName))
+	} else if len(serviceAccountDetailsJson) == 0 {
+		t.Fatal(fmt.Sprintf("Environment variable %#v can not be empty string", serviceAccountDetailsJsonEnvName))
 	}
-	if err != nil {
-		t.Fatal(fmt.Sprintf("Failed to read %#v", serviceAccountDetailsFile))
-	}
+
+	contentBytes = []byte(serviceAccountDetailsJson)
 	var serviceAccountCreds ServiceAccountCreds
-	json.Unmarshal(contentBytes, &serviceAccountCreds)
+	err = json.Unmarshal(contentBytes, &serviceAccountCreds)
+	if err != nil {
+		t.Fatal(fmt.Sprintf("Failed to parse content pointed by environment variable %#v", serviceAccountDetailsJsonEnvName))
+	}
 	return serviceAccountCreds
 }
 

--- a/sumologic/resource_sumologic_gcp_metrics_source_test.go
+++ b/sumologic/resource_sumologic_gcp_metrics_source_test.go
@@ -1,0 +1,233 @@
+package sumologic
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccSumologicGcpMetricsSource_create(t *testing.T) {
+	var GcpMetricsSource PollingSource
+	var collector Collector
+	cName, cDescription, cCategory := getRandomizedParams()
+	sName, sDescription, sCategory := getRandomizedParams()
+	GcpMetricsResourceName := "sumologic_gcp_metrics_source.gcp_metrics_source"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { getServiceAccountCreds(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGcpMetricsSourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSumologicGcpMetricsSourceConfig(t, cName, cDescription, cCategory, sName, sDescription, sCategory),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGcpMetricsSourceExists(GcpMetricsResourceName, &GcpMetricsSource),
+					testAccCheckGcpMetricsSourceValues(&GcpMetricsSource, sName, sDescription, sCategory),
+					testAccCheckCollectorExists("sumologic_collector.test", &collector),
+					testAccCheckCollectorValues(&collector, cName, cDescription, cCategory, "Etc/UTC", ""),
+					resource.TestCheckResourceAttrSet(GcpMetricsResourceName, "id"),
+					resource.TestCheckResourceAttr(GcpMetricsResourceName, "name", sName),
+					resource.TestCheckResourceAttr(GcpMetricsResourceName, "description", sDescription),
+					resource.TestCheckResourceAttr(GcpMetricsResourceName, "category", sCategory),
+					resource.TestCheckResourceAttr(GcpMetricsResourceName, "content_type", "GcpMetrics"),
+					resource.TestCheckResourceAttr(GcpMetricsResourceName, "path.0.type", "GcpMetricsPath"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSumologicGcpMetricsSource_update(t *testing.T) {
+	var GcpMetricsSource PollingSource
+	cName, cDescription, cCategory := getRandomizedParams()
+	sName, sDescription, sCategory := getRandomizedParams()
+	sNameUpdated, sDescriptionUpdated, sCategoryUpdated := getRandomizedParams()
+	GcpMetricsResourceName := "sumologic_gcp_metrics_source.gcp_metrics_source"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { getServiceAccountCreds(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckHTTPSourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSumologicGcpMetricsSourceConfig(t, cName, cDescription, cCategory, sName, sDescription, sCategory),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGcpMetricsSourceExists(GcpMetricsResourceName, &GcpMetricsSource),
+					testAccCheckGcpMetricsSourceValues(&GcpMetricsSource, sName, sDescription, sCategory),
+					resource.TestCheckResourceAttrSet(GcpMetricsResourceName, "id"),
+					resource.TestCheckResourceAttr(GcpMetricsResourceName, "name", sName),
+					resource.TestCheckResourceAttr(GcpMetricsResourceName, "description", sDescription),
+					resource.TestCheckResourceAttr(GcpMetricsResourceName, "category", sCategory),
+					resource.TestCheckResourceAttr(GcpMetricsResourceName, "content_type", "GcpMetrics"),
+					resource.TestCheckResourceAttr(GcpMetricsResourceName, "path.0.type", "GcpMetricsPath"),
+				),
+			},
+			{
+				Config: testAccSumologicGcpMetricsSourceConfig(t, cName, cDescription, cCategory, sNameUpdated, sDescriptionUpdated, sCategoryUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGcpMetricsSourceExists(GcpMetricsResourceName, &GcpMetricsSource),
+					testAccCheckGcpMetricsSourceValues(&GcpMetricsSource, sNameUpdated, sDescriptionUpdated, sCategoryUpdated),
+					resource.TestCheckResourceAttrSet(GcpMetricsResourceName, "id"),
+					resource.TestCheckResourceAttr(GcpMetricsResourceName, "name", sNameUpdated),
+					resource.TestCheckResourceAttr(GcpMetricsResourceName, "description", sDescriptionUpdated),
+					resource.TestCheckResourceAttr(GcpMetricsResourceName, "category", sCategoryUpdated),
+					resource.TestCheckResourceAttr(GcpMetricsResourceName, "content_type", "GcpMetrics"),
+					resource.TestCheckResourceAttr(GcpMetricsResourceName, "path.0.type", "GcpMetricsPath"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckGcpMetricsSourceDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "sumologic_gcp_metrics_source" {
+			continue
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("HTTP Source destruction check: HTTP Source ID is not set")
+		}
+		id, err := strconv.Atoi(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("Encountered an error: " + err.Error())
+		}
+		collectorID, err := strconv.Atoi(rs.Primary.Attributes["collector_id"])
+		if err != nil {
+			return fmt.Errorf("Encountered an error: " + err.Error())
+		}
+		s, err := client.GetPollingSource(collectorID, id)
+		if err != nil {
+			return fmt.Errorf("Encountered an error: " + err.Error())
+		}
+		if s != nil {
+			return fmt.Errorf("Polling Source still exists")
+		}
+	}
+	return nil
+}
+
+func testAccCheckGcpMetricsSourceExists(n string, pollingSource *PollingSource) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Polling Source ID is not set")
+		}
+		id, err := strconv.Atoi(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("Polling Source id should be int; got %s", rs.Primary.ID)
+		}
+		collectorID, err := strconv.Atoi(rs.Primary.Attributes["collector_id"])
+		if err != nil {
+			return fmt.Errorf("Encountered an error: " + err.Error())
+		}
+		c := testAccProvider.Meta().(*Client)
+		pollingSourceResp, err := c.GetPollingSource(collectorID, id)
+		if err != nil {
+			return err
+		}
+		*pollingSource = *pollingSourceResp
+		return nil
+	}
+}
+
+func testAccCheckGcpMetricsSourceValues(pollingSource *PollingSource, name, description, category string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if pollingSource.Name != name {
+			return fmt.Errorf("bad name, expected \"%s\", got: %#v", name, pollingSource.Name)
+		}
+		if pollingSource.Description != description {
+			return fmt.Errorf("bad description, expected \"%s\", got: %#v", description, pollingSource.Description)
+		}
+		if pollingSource.Category != category {
+			return fmt.Errorf("bad category, expected \"%s\", got: %#v", category, pollingSource.Category)
+		}
+		return nil
+	}
+}
+
+type ServiceAccountCreds struct {
+	Type                    string `json:"type"`
+	ProjectId               string `json:"project_id"`
+	PrivateKeyId            string `json:"private_key_id"`
+	PrivateKey              string `json:"private_key"`
+	ClientEmail             string `json:"client_email"`
+	ClientId                string `json:"client_id"`
+	AuthUri                 string `json:"auth_uri"`
+	TokenUri                string `json:"token_uri"`
+	AuthProviderX509CertUrl string `json:"auth_provider_x509_cert_url"`
+	ClientX509CertUrl       string `json:"client_x509_cert_url"`
+}
+
+func getServiceAccountCreds(t *testing.T) ServiceAccountCreds {
+	var err error
+	contentBytes := []byte("")
+	serviceAccountDetailsFileEnvName := "SUMOLOGIC_GOOGLE_APPLICATION_CREDENTIALS"
+
+	serviceAccountDetailsFile, isEnvVarDefined := os.LookupEnv(serviceAccountDetailsFileEnvName)
+	if !isEnvVarDefined {
+		t.Fatal(fmt.Sprintf("Environment variable %#v has to be defined", serviceAccountDetailsFileEnvName))
+	} else if len(serviceAccountDetailsFile) == 0 {
+		t.Fatal(fmt.Sprintf("Environment variable %#v can not be empty string", serviceAccountDetailsFileEnvName))
+	} else if _, statErr := os.Stat(serviceAccountDetailsFile); statErr != nil {
+		t.Fatal(fmt.Sprintf("Environment variable %#v points to non-existing file %#v", serviceAccountDetailsFileEnvName, serviceAccountDetailsFile))
+	} else {
+		contentBytes, err = ioutil.ReadFile(serviceAccountDetailsFile)
+	}
+	if err != nil {
+		t.Fatal(fmt.Sprintf("Failed to read %#v", serviceAccountDetailsFile))
+	}
+	var serviceAccountCreds ServiceAccountCreds
+	json.Unmarshal(contentBytes, &serviceAccountCreds)
+	return serviceAccountCreds
+}
+
+func testAccSumologicGcpMetricsSourceConfig(t *testing.T, cName, cDescription, cCategory, sName, sDescription, sCategory string) string {
+	cred := getServiceAccountCreds(t)
+	srcStr := fmt.Sprintf(`
+	resource "sumologic_collector" "test" {
+		name = "%s"
+		description = "%s"
+		category = "%s"
+	}
+	resource "sumologic_gcp_metrics_source" "gcp_metrics_source" {
+		name = "%s"
+		description = "%s"
+		category = "%s"
+		content_type  = "GcpMetrics"
+		scan_interval = 300000
+		paused        = false
+		collector_id = "${sumologic_collector.test.id}"
+		authentication {
+            type = "%s"
+            project_id = "%s"
+            private_key_id = "%s"
+            private_key = <<EOPK
+%sEOPK
+            client_email = "%s"
+            client_id = "%s"
+            auth_uri = "%s"
+            token_uri = "%s"
+            auth_provider_x509_cert_url = "%s"
+            client_x509_cert_url = "%s"
+		  }
+		  path {
+			type = "GcpMetricsPath"
+            limit_to_regions = ["asia-south1"]
+            limit_to_services = ["Compute Engine", "CloudSQL"]
+		  }
+		  lifecycle {
+			ignore_changes = [authentication[0].private_key]
+          }
+		}
+	`, cName, cDescription, cCategory, sName, sDescription, sCategory,
+		cred.Type, cred.ProjectId, cred.PrivateKeyId, cred.PrivateKey, cred.ClientEmail, cred.ClientId, cred.AuthUri, cred.TokenUri, cred.AuthProviderX509CertUrl, cred.ClientX509CertUrl)
+	return srcStr
+}

--- a/sumologic/resource_sumologic_generic_polling_source.go
+++ b/sumologic/resource_sumologic_generic_polling_source.go
@@ -72,9 +72,8 @@ func resourceSumologicGenericPollingSource() *schema.Resource {
 					Optional: true,
 				},
 				"private_key_id": {
-					Type:      schema.TypeString,
-					Sensitive: true,
-					Optional:  true,
+					Type:     schema.TypeString,
+					Optional: true,
 				},
 				"private_key": {
 					Type:     schema.TypeString,

--- a/sumologic/sumologic_polling_source.go
+++ b/sumologic/sumologic_polling_source.go
@@ -25,11 +25,20 @@ type PollingResource struct {
 }
 
 type PollingAuthentication struct {
-	Type    string `json:"type"`
-	AwsID   string `json:"awsId"`
-	AwsKey  string `json:"awsKey"`
-	RoleARN string `json:"roleARN"`
-	Region  string `json:"region,omitempty"`
+	Type                    string `json:"type"`
+	AwsID                   string `json:"awsId"`
+	AwsKey                  string `json:"awsKey"`
+	RoleARN                 string `json:"roleARN"`
+	Region                  string `json:"region,omitempty"`
+	ProjectId               string `json:"project_id"`
+	PrivateKeyId            string `json:"private_key_id"`
+	PrivateKey              string `json:"private_key"`
+	ClientEmail             string `json:"client_email"`
+	ClientId                string `json:"client_id"`
+	AuthUrl                 string `json:"auth_uri"`
+	TokenUrl                string `json:"token_uri"`
+	AuthProviderX509CertUrl string `json:"auth_provider_x509_cert_url"`
+	ClientX509CertUrl       string `json:"client_x509_cert_url"`
 }
 
 type PollingPath struct {
@@ -38,6 +47,7 @@ type PollingPath struct {
 	PathExpression            string                           `json:"pathExpression,omitempty"`
 	LimitToRegions            []string                         `json:"limitToRegions,omitempty"`
 	LimitToNamespaces         []string                         `json:"limitToNamespaces,omitempty"`
+	LimitToServices           []string                         `json:"limitToServices,omitempty"`
 	TagFilters                []TagFilter                      `json:"tagFilters,omitempty"`
 	SnsTopicOrSubscriptionArn PollingSnsTopicOrSubscriptionArn `json:"snsTopicOrSubscriptionArn,omitempty"`
 }

--- a/website/docs/r/gcp_metrics_source.html.markdown
+++ b/website/docs/r/gcp_metrics_source.html.markdown
@@ -39,7 +39,7 @@ EOPK
 
   path {
     type = "GcpMetricsPath"
-    limit_to_regions = ["us-east1", "us-central-1", "asia-south1"]
+    limit_to_regions = ["us-east1", "us-central1", "asia-south1"]
     limit_to_services = ["Compute Engine", "Firebase", "App Engine"]
   }
 

--- a/website/docs/r/gcp_metrics_source.html.markdown
+++ b/website/docs/r/gcp_metrics_source.html.markdown
@@ -1,0 +1,103 @@
+---
+layout: "sumologic"
+page_title: "SumoLogic: sumologic_gcp_metrics_source"
+description: |-
+  Provides a Sumologic GCP Metrics Source.
+---
+
+# sumologic_gcp_metrics_source
+Provides a `Sumologic GCP Metrics Source`
+
+__IMPORTANT:__ The Service Account parameters (including private key) are stored in plain-text in the state. This is a potential security issue.
+
+## Example Usage
+```hcl
+
+resource "sumologic_gcp_metrics_source" "terraform_gcp_metrics_source" {
+  name          = "GCP Metrics Source"
+  description   = "Description for GCP Metrics Source"
+  category      = "gcp/metrics"
+  content_type  = "GcpMetrics"
+  scan_interval = 300000
+  paused        = false
+  collector_id  = "${sumologic_collector.collector.id}"
+
+  authentication {
+    type = "service_account"
+    project_id = "service_account_project_id"
+    private_key_id = "service_account_private_key_id"
+    private_key = <<EOPK
+service_account_private_key
+EOPK
+    client_email = "service_account_client_email"
+    client_id = "service_account_client_id"
+    auth_uri = "service_account_auth_uri"
+    token_uri = "service_account_token_uri"
+    auth_provider_x509_cert_url = "service_account_auth_provider_x509_cert_url"
+    client_x509_cert_url = "service_account_client_x509_cert_url"
+  }
+
+  path {
+    type = "GcpMetricsPath"
+    limit_to_regions = ["us-east1", "us-central-1", "asia-south1"]
+    limit_to_services = ["Compute Engine", "Firebase", "App Engine"]
+  }
+
+  lifecycle {
+    ignore_changes = [authentication[0].private_key]
+  }
+}
+
+resource "sumologic_collector" "collector" {
+  name        = "my-collector"
+  description = "Just testing this"
+}
+```
+
+## Argument reference
+
+In addition to the [Common Source Properties](https://registry.terraform.io/providers/SumoLogic/sumologic/latest/docs#common-source-properties), the following arguments are supported:
+
+ - `content_type` - (Required) The content-type of the collected data. Details can be found in the [Sumologic documentation for hosted sources][1].
+ - `scan_interval` - (Required) Time interval in milliseconds of scans for new data. The default is 300000 and the minimum value is 1000 milliseconds.
+ - `paused` - (Required) When set to true, the scanner is paused. To disable, set to false.
+ - `authentication` - (Required) Authentication details for connecting to the  GCP Monitoring using service_account credentials.
+     + `type` - (Required) Must be `service_account`.
+     + `project_id` - (Required) As per the service_account.json downloaded from GCP
+     + `private_key_id` - (Required) As per the service_account.json downloaded from GCP
+     + `private_key` - (Required) As per the service_account.json downloaded from GCP
+     + `client_email` - (Required) As per the service_account.json downloaded from GCP
+     + `client_id` - (Required) As per the service_account.json downloaded from GCP
+     + `auth_uri` - (Required) As per the service_account.json downloaded from GCP
+     + `token_uri` - (Required) As per the service_account.json downloaded from GCP
+     + `auth_provider_x509_cert_url` - (Required) As per the service_account.json downloaded from GCP
+     + `client_x509_cert_url` - (Required) As per the service_account.json downloaded from GCP
+
+ - `path` - (Required) Details about what data to ingest
+     + `type` - (Required) Type of polling source. This has to be `GcpMetricsPath`.
+     + `limit_to_regions` - (Optional) List of regions for which metrics would be collected (Empty to collect from all regions)
+     + `limit_to_services` - (Required) List of services from which metrics would be collected
+ - `lifecycle` - (Required) describe fields that should be ignored by terraform while doing comparision i.e. Sumologic backend will return `private_key` as `********` 
+
+### See also
+  * [Common Source Properties](https://registry.terraform.io/providers/SumoLogic/sumologic/latest/docs#common-source-properties)
+
+## Attributes Reference
+The following attributes are exported:
+
+- `id` - The internal ID of the source.
+
+## Import
+GCP Metrics sources can be imported using the collector and source IDs (`collector/source`), e.g.:
+
+```hcl
+terraform import sumologic_gcp_metrics_source.test 123/456
+```
+
+GCP Metrics sources can be imported using the collector name and source name (`collectorName/sourceName`), e.g.:
+
+```hcl
+terraform import sumologic_gcp_metrics_source.test my-test-collector/my-test-source
+```
+
+[1]: https://help.sumologic.com/Send_Data/Sources/03Use_JSON_to_Configure_Sources/JSON_Parameters_for_Hosted_Sources


### PR DESCRIPTION
This PR brings ability to create Gcp Metrics Source. 

I have used below to ensure that returned private_key as "********" works fine. 
I am not sure if this is the best option, any input on this, (Or any other feedback) would help. 

```
           lifecycle {
             ignore_changes = [authentication[0].private_key]
           }
         }
```