### PR TITLE
Setting up the ability to create local_file sources

### DIFF
--- a/sumologic/provider.go
+++ b/sumologic/provider.go
@@ -58,6 +58,7 @@ func Provider() terraform.ResourceProvider {
 			"sumologic_cse_threshold_rule":                 resourceSumologicCSEThresholdRule(),
 			"sumologic_collector":                          resourceSumologicCollector(),
 			"sumologic_http_source":                        resourceSumologicHTTPSource(),
+			"sumologic_local_file_source":                  resourceSumologicLocalFileSource(),
 			"sumologic_gcp_source":                         resourceSumologicGCPSource(),
 			"sumologic_polling_source":                     resourceSumologicPollingSource(),
 			"sumologic_s3_source":                          resourceSumologicGenericPollingSource(),

--- a/sumologic/resource_sumologic_local_file_source.go
+++ b/sumologic/resource_sumologic_local_file_source.go
@@ -71,13 +71,19 @@ func resourceSumologicLocalFileSourceUpdate(d *schema.ResourceData, meta interfa
 }
 
 func resourceToLocalFileSource(d *schema.ResourceData) LocalFileSource {
+	rawDenyList := d.Get("deny_list").(*schema.Set).List()
+	var denylist []string
+	for _, j := range rawDenyList {
+		denylist = append(denylist, j.(string))
+	}
 	source := resourceToSource(d)
 	source.Type = "LocalFile"
-	source.PathExpression = d.Get("path_expression").(string)
-	source.Encoding = d.Get("encoding").(string)
 
 	localFileSource := LocalFileSource{
-		Source: source,
+		Source:         source,
+		PathExpression: d.Get("path_expression").(string),
+		Encoding:       d.Get("encoding").(string),
+		DenyList:       denylist,
 	}
 
 	return localFileSource
@@ -105,6 +111,7 @@ func resourceSumologicLocalFileSourceRead(d *schema.ResourceData, meta interface
 	}
 	d.Set("path_expression", source.PathExpression)
 	d.Set("encoding", source.Encoding)
+	d.Set("deny_list", source.DenyList)
 
 	return nil
 }

--- a/sumologic/resource_sumologic_local_file_source.go
+++ b/sumologic/resource_sumologic_local_file_source.go
@@ -1,0 +1,110 @@
+package sumologic
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceSumologicLocalFileSource() *schema.Resource {
+	localFileSource := resourceSumologicSource()
+	localFileSource.Create = resourceSumologicLocalFileSourceCreate
+	localFileSource.Read = resourceSumologicLocalFileSourceRead
+	localFileSource.Update = resourceSumologicLocalFileSourceUpdate
+	localFileSource.Importer = &schema.ResourceImporter{
+		State: resourceSumologicSourceImport,
+	}
+
+	localFileSource.Schema["path_expression"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Optional: false,
+		Required: true,
+	}
+
+	localFileSource.Schema["encoding"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Optional: true,
+		Default:  "UTF-8",
+	}
+
+	localFileSource.Schema["deny_list"] = &schema.Schema{
+		Type:     schema.TypeSet,
+		Optional: true,
+		Elem:     &schema.Schema{Type: schema.TypeString},
+	}
+
+	return localFileSource
+}
+
+func resourceSumologicLocalFileSourceCreate(d *schema.ResourceData, meta interface{}) error {
+	c := meta.(*Client)
+
+	if d.Id() == "" {
+		source := resourceToLocalFileSource(d)
+
+		id, err := c.CreateLocalFileSource(source, d.Get("collector_id").(int))
+
+		if err != nil {
+			return err
+		}
+
+		d.SetId(strconv.Itoa(id))
+	}
+
+	return resourceSumologicLocalFileSourceRead(d, meta)
+}
+
+func resourceSumologicLocalFileSourceUpdate(d *schema.ResourceData, meta interface{}) error {
+	c := meta.(*Client)
+
+	source := resourceToLocalFileSource(d)
+
+	err := c.UpdateLocalFileSource(source, d.Get("collector_id").(int))
+
+	if err != nil {
+		return err
+	}
+
+	return resourceSumologicLocalFileSourceRead(d, meta)
+}
+
+func resourceToLocalFileSource(d *schema.ResourceData) LocalFileSource {
+	source := resourceToSource(d)
+	source.Type = "LocalFile"
+	source.PathExpression = d.Get("path_expression").(string)
+	source.Encoding = d.Get("encoding").(string)
+
+	localFileSource := LocalFileSource{
+		Source: source,
+	}
+
+	return localFileSource
+}
+
+func resourceSumologicLocalFileSourceRead(d *schema.ResourceData, meta interface{}) error {
+	c := meta.(*Client)
+
+	id, _ := strconv.Atoi(d.Id())
+	source, err := c.GetLocalFileSource(d.Get("collector_id").(int), id)
+
+	if err != nil {
+		return err
+	}
+
+	if source == nil {
+		log.Printf("[WARN] LocalFile source not found, removing from state: %v - %v", id, err)
+		d.SetId("")
+
+		return nil
+	}
+
+	if err := resourceSumologicSourceRead(d, source.Source); err != nil {
+		return fmt.Errorf("%s", err)
+	}
+	d.Set("path_expression", source.PathExpression)
+	d.Set("encoding", source.Encoding)
+
+	return nil
+}

--- a/sumologic/resource_sumologic_local_file_source_test.go
+++ b/sumologic/resource_sumologic_local_file_source_test.go
@@ -1,0 +1,259 @@
+package sumologic
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccSumologicLocalFileSource_create(t *testing.T) {
+	var localFileSource LocalFileSource
+	var localFileTraceSource LocalFileSource
+	var kinesisLogSource LocalFileSource
+	var collector Collector
+	cName := acctest.RandomWithPrefix("tf-acc-test")
+	cDescription := acctest.RandomWithPrefix("tf-acc-test")
+	cCategory := acctest.RandomWithPrefix("tf-acc-test")
+	sName := acctest.RandomWithPrefix("tf-acc-test")
+	sDescription := acctest.RandomWithPrefix("tf-acc-test")
+	sCategory := acctest.RandomWithPrefix("tf-acc-test")
+	tName := acctest.RandomWithPrefix("tf-acc-test")
+	tDescription := acctest.RandomWithPrefix("tf-acc-test")
+	tCategory := acctest.RandomWithPrefix("tf-acc-test")
+	kName := acctest.RandomWithPrefix("tf-acc-test")
+	kDescription := acctest.RandomWithPrefix("tf-acc-test")
+	kCategory := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "sumologic_localFile_source.localFile"
+	tracingResourceName := "sumologic_localFile_source.traces"
+	kinesisResourceName := "sumologic_localFile_source.kinesisLog"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLocalFileSourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSumologicLocalFileSourceConfig(cName, cDescription, cCategory, sName, sDescription, sCategory, tName, tDescription, tCategory, kName, kDescription, kCategory),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLocalFileSourceExists(resourceName, &localFileSource),
+					testAccCheckLocalFileSourceValues(&localFileSource, sName, sDescription, sCategory),
+					testAccCheckCollectorExists("sumologic_collector.test", &collector),
+					testAccCheckCollectorValues(&collector, cName, cDescription, cCategory, "Etc/UTC", ""),
+					testAccCheckLocalFileSourceExists(tracingResourceName, &localFileTraceSource),
+					testAccCheckLocalFileSourceValues(&localFileTraceSource, tName, tDescription, tCategory),
+					testAccCheckLocalFileSourceExists(kinesisResourceName, &kinesisLogSource),
+					testAccCheckLocalFileSourceValues(&kinesisLogSource, kName, kDescription, kCategory),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "url"),
+					resource.TestCheckResourceAttr(resourceName, "name", sName),
+					resource.TestCheckResourceAttr(resourceName, "description", sDescription),
+					resource.TestCheckResourceAttr(resourceName, "message_per_request", "false"),
+					resource.TestCheckResourceAttr(resourceName, "category", sCategory),
+					resource.TestCheckResourceAttrSet(tracingResourceName, "id"),
+					resource.TestCheckResourceAttrSet(tracingResourceName, "url"),
+					resource.TestCheckResourceAttr(tracingResourceName, "name", tName),
+					resource.TestCheckResourceAttr(tracingResourceName, "description", tDescription),
+					resource.TestCheckResourceAttr(tracingResourceName, "category", tCategory),
+					resource.TestCheckResourceAttr(tracingResourceName, "content_type", "Zipkin"),
+					resource.TestCheckResourceAttrSet(kinesisResourceName, "id"),
+					resource.TestCheckResourceAttrSet(kinesisResourceName, "url"),
+					resource.TestCheckResourceAttr(kinesisResourceName, "name", kName),
+					resource.TestCheckResourceAttr(kinesisResourceName, "description", kDescription),
+					resource.TestCheckResourceAttr(kinesisResourceName, "category", kCategory),
+					resource.TestCheckResourceAttr(kinesisResourceName, "content_type", "KinesisLog"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSumologicLocalFileSource_update(t *testing.T) {
+	var localFileSource LocalFileSource
+	var localFileTraceSource LocalFileSource
+	var kinesisLogSource LocalFileSource
+	cName := acctest.RandomWithPrefix("tf-acc-test")
+	cDescription := acctest.RandomWithPrefix("tf-acc-test")
+	cCategory := acctest.RandomWithPrefix("tf-acc-test")
+	sName := acctest.RandomWithPrefix("tf-acc-test")
+	sDescription := acctest.RandomWithPrefix("tf-acc-test")
+	sCategory := acctest.RandomWithPrefix("tf-acc-test")
+	tName := acctest.RandomWithPrefix("tf-acc-test")
+	tDescription := acctest.RandomWithPrefix("tf-acc-test")
+	tCategory := acctest.RandomWithPrefix("tf-acc-test")
+	kName := acctest.RandomWithPrefix("tf-acc-test")
+	kDescription := acctest.RandomWithPrefix("tf-acc-test")
+	kCategory := acctest.RandomWithPrefix("tf-acc-test")
+	sNameUpdated := acctest.RandomWithPrefix("tf-acc-test")
+	sDescriptionUpdated := acctest.RandomWithPrefix("tf-acc-test")
+	sCategoryUpdated := acctest.RandomWithPrefix("tf-acc-test")
+	resourceName := "sumologic_localFile_source.localFile"
+	tracingResourceName := "sumologic_localFile_source.traces"
+	kinesisResourceName := "sumologic_localFile_source.kinesisLog"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLocalFileSourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSumologicLocalFileSourceConfig(cName, cDescription, cCategory, sName, sDescription, sCategory, tName, tDescription, tCategory, kName, kDescription, kCategory),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLocalFileSourceExists(resourceName, &localFileSource),
+					testAccCheckLocalFileSourceValues(&localFileSource, sName, sDescription, sCategory),
+					testAccCheckLocalFileSourceExists(tracingResourceName, &localFileTraceSource),
+					testAccCheckLocalFileSourceValues(&localFileTraceSource, tName, tDescription, tCategory),
+					testAccCheckLocalFileSourceExists(kinesisResourceName, &kinesisLogSource),
+					testAccCheckLocalFileSourceValues(&kinesisLogSource, kName, kDescription, kCategory),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "url"),
+					resource.TestCheckResourceAttr(resourceName, "name", sName),
+					resource.TestCheckResourceAttr(resourceName, "description", sDescription),
+					resource.TestCheckResourceAttr(resourceName, "message_per_request", "false"),
+					resource.TestCheckResourceAttr(resourceName, "category", sCategory),
+					resource.TestCheckResourceAttrSet(tracingResourceName, "id"),
+					resource.TestCheckResourceAttrSet(tracingResourceName, "url"),
+					resource.TestCheckResourceAttr(tracingResourceName, "name", tName),
+					resource.TestCheckResourceAttr(tracingResourceName, "description", tDescription),
+					resource.TestCheckResourceAttr(tracingResourceName, "category", tCategory),
+					resource.TestCheckResourceAttr(tracingResourceName, "content_type", "Zipkin"),
+					resource.TestCheckResourceAttrSet(kinesisResourceName, "id"),
+					resource.TestCheckResourceAttrSet(kinesisResourceName, "url"),
+					resource.TestCheckResourceAttr(kinesisResourceName, "name", kName),
+					resource.TestCheckResourceAttr(kinesisResourceName, "description", kDescription),
+					resource.TestCheckResourceAttr(kinesisResourceName, "category", kCategory),
+					resource.TestCheckResourceAttr(kinesisResourceName, "content_type", "KinesisLog"),
+				),
+			},
+			{
+				Config: testAccSumologicLocalFileSourceConfig(cName, cDescription, cCategory, sNameUpdated, sDescriptionUpdated, sCategoryUpdated, tName, tDescription, tCategory, kName, kDescription, kCategory),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLocalFileSourceExists(resourceName, &localFileSource),
+					testAccCheckLocalFileSourceValues(&localFileSource, sNameUpdated, sDescriptionUpdated, sCategoryUpdated),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "pathExpression"),
+					resource.TestCheckResourceAttr(resourceName, "name", sNameUpdated),
+					resource.TestCheckResourceAttr(resourceName, "description", sDescriptionUpdated),
+					resource.TestCheckResourceAttr(resourceName, "category", sCategoryUpdated),
+					resource.TestCheckResourceAttr(tracingResourceName, "content_type", "Zipkin"),
+					resource.TestCheckResourceAttr(kinesisResourceName, "content_type", "KinesisLog"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckLocalFileSourceDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "sumologic_localFile_source" {
+			continue
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("LocalFile Source destruction check: LocalFile Source ID is not set")
+		}
+
+		id, err := strconv.Atoi(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("Encountered an error: " + err.Error())
+		}
+
+		collectorID, err := strconv.Atoi(rs.Primary.Attributes["collector_id"])
+		if err != nil {
+			return fmt.Errorf("Encountered an error: " + err.Error())
+		}
+
+		s, err := client.GetLocalFileSource(collectorID, id)
+		if err != nil {
+			return fmt.Errorf("Encountered an error: " + err.Error())
+		}
+		if s != nil {
+			return fmt.Errorf("LocalFile Source still exists")
+		}
+	}
+	return nil
+}
+
+func testAccCheckLocalFileSourceExists(n string, localFileSource *LocalFileSource) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("LocalFile Source ID is not set")
+		}
+
+		id, err := strconv.Atoi(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("LocalFile Source id should be int; got %s", rs.Primary.ID)
+		}
+
+		collectorID, err := strconv.Atoi(rs.Primary.Attributes["collector_id"])
+		if err != nil {
+			return fmt.Errorf("Encountered an error: " + err.Error())
+		}
+
+		c := testAccProvider.Meta().(*Client)
+		localFileSourceResp, err := c.GetLocalFileSource(collectorID, id)
+		if err != nil {
+			return err
+		}
+
+		*localFileSource = *localFileSourceResp
+
+		return nil
+	}
+}
+
+func testAccCheckLocalFileSourceValues(localFileSource *LocalFileSource, name, description, category string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if localFileSource.Name != name {
+			return fmt.Errorf("bad name, expected \"%s\", got: %#v", name, localFileSource.Name)
+		}
+		if localFileSource.Description != description {
+			return fmt.Errorf("bad description, expected \"%s\", got: %#v", description, localFileSource.Description)
+		}
+		if localFileSource.Category != category {
+			return fmt.Errorf("bad category, expected \"%s\", got: %#v", category, localFileSource.Category)
+		}
+		return nil
+	}
+}
+
+func testAccSumologicLocalFileSourceConfig(cName, cDescription, cCategory, sName, sDescription, sCategory, tName, tDescription, tCategory, kName, kDescription, kCategory string) string {
+	return fmt.Sprintf(`
+resource "sumologic_collector" "test" {
+	name = "%s"
+	description = "%s"
+	category = "%s"
+}
+	
+resource "sumologic_local_file_source" "localFile" {
+	name = "%s"
+	description = "%s"
+	category = "%s"
+	collector_id = "${sumologic_collector.test.id}"
+}
+
+resource "sumologic_local_file_source" "traces" {
+	name = "%s"
+	description = "%s"
+	category = "%s"
+	content_type = "Zipkin"
+	collector_id = "${sumologic_collector.test.id}"
+}
+
+resource "sumologic_local_file_source" "kinesisLog" {
+	name = "%s"
+	description = "%s"
+	category = "%s"
+	content_type = "KinesisLog"
+	collector_id = "${sumologic_collector.test.id}"
+}
+`, cName, cDescription, cCategory, sName, sDescription, sCategory, tName, tDescription, tCategory, kName, kDescription, kCategory)
+}

--- a/sumologic/resource_sumologic_local_file_source_test.go
+++ b/sumologic/resource_sumologic_local_file_source_test.go
@@ -133,6 +133,7 @@ func TestAccSumologicLocalFileSource_update(t *testing.T) {
 					testAccCheckLocalFileSourceValues(&localFileSource, sNameUpdated, sDescriptionUpdated, sCategoryUpdated),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "pathExpression"),
+					resource.TestCheckResourceAttrSet(resourceName, "denylist"),
 					resource.TestCheckResourceAttr(resourceName, "name", sNameUpdated),
 					resource.TestCheckResourceAttr(resourceName, "description", sDescriptionUpdated),
 					resource.TestCheckResourceAttr(resourceName, "category", sCategoryUpdated),

--- a/sumologic/sumologic_local_file_source.go
+++ b/sumologic/sumologic_local_file_source.go
@@ -1,0 +1,78 @@
+package sumologic
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type LocalFileSource struct {
+	Source
+}
+
+func (s *Client) CreateLocalFileSource(source LocalFileSource, collectorID int) (int, error) {
+
+	type LocalFileSourceMessage struct {
+		Source LocalFileSource `json:"source"`
+	}
+
+	request := LocalFileSourceMessage{
+		Source: source,
+	}
+
+	urlPath := fmt.Sprintf("v1/collectors/%d/sources", collectorID)
+	body, err := s.Post(urlPath, request)
+
+	if err != nil {
+		return -1, err
+	}
+
+	var response LocalFileSourceMessage
+
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		return -1, err
+	}
+
+	return response.Source.ID, nil
+}
+
+func (s *Client) GetLocalFileSource(collectorID, sourceID int) (*LocalFileSource, error) {
+
+	body, _, err := s.Get(fmt.Sprintf("v1/collectors/%d/sources/%d", collectorID, sourceID))
+	if err != nil {
+		return nil, err
+	}
+
+	if body == nil {
+		return nil, nil
+	}
+
+	type Response struct {
+		Source LocalFileSource `json:"source"`
+	}
+
+	var response Response
+
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response.Source, nil
+}
+
+func (s *Client) UpdateLocalFileSource(source LocalFileSource, collectorID int) error {
+
+	type LocalFileSourceMessage struct {
+		Source LocalFileSource `json:"source"`
+	}
+
+	request := LocalFileSourceMessage{
+		Source: source,
+	}
+
+	urlPath := fmt.Sprintf("v1/collectors/%d/sources/%d", collectorID, source.ID)
+	_, err := s.Put(urlPath, request)
+
+	return err
+}

--- a/sumologic/sumologic_local_file_source.go
+++ b/sumologic/sumologic_local_file_source.go
@@ -7,6 +7,9 @@ import (
 
 type LocalFileSource struct {
 	Source
+	PathExpression string   `json:"pathExpression,omitempty"`
+	Encoding       string   `json:"encoding,omitempty"`
+	DenyList       []string `json:"denylist,omitempty"`
 }
 
 func (s *Client) CreateLocalFileSource(source LocalFileSource, collectorID int) (int, error) {
@@ -47,11 +50,11 @@ func (s *Client) GetLocalFileSource(collectorID, sourceID int) (*LocalFileSource
 		return nil, nil
 	}
 
-	type Response struct {
+	type LocalFileSourceResponse struct {
 		Source LocalFileSource `json:"source"`
 	}
 
-	var response Response
+	var response LocalFileSourceResponse
 
 	err = json.Unmarshal(body, &response)
 	if err != nil {

--- a/sumologic/sumologic_sources.go
+++ b/sumologic/sumologic_sources.go
@@ -30,8 +30,6 @@ type Source struct {
 	Fields                     map[string]interface{} `json:"fields,omitempty"`
 	Url                        string                 `json:"url,omitempty"`
 	ContentType                string                 `json:"contentType,omitempty"`
-	PathExpression             string                 `json:"pathExpression,omitempty"`
-	Encoding                   string                 `json:"encoding,omitempty"`
 }
 
 type DefaultDateFormat struct {

--- a/sumologic/sumologic_sources.go
+++ b/sumologic/sumologic_sources.go
@@ -30,6 +30,8 @@ type Source struct {
 	Fields                     map[string]interface{} `json:"fields,omitempty"`
 	Url                        string                 `json:"url,omitempty"`
 	ContentType                string                 `json:"contentType,omitempty"`
+	PathExpression             string                 `json:"pathExpression,omitempty"`
+	Encoding                   string                 `json:"encoding,omitempty"`
 }
 
 type DefaultDateFormat struct {


### PR DESCRIPTION
Very Rudimentary resource provider for the resource "sumologic_local_file_source"

Implemented `path_expression` and `encoding` have not implimented `deny_list` as our use case does not yet require it

https://help.sumologic.com/03Send-Data/Sources/03Use-JSON-to-Configure-Sources/JSON-Parameters-for-Installed-Sources#Local_file_source