### PR TITLE
Add import folder pass through.

### DIFF
--- a/sumologic/resource_sumologic_folder.go
+++ b/sumologic/resource_sumologic_folder.go
@@ -13,9 +13,9 @@ func resourceSumologicFolder() *schema.Resource {
 		Read:   resourceSumologicFolderRead,
 		Delete: resourceSumologicFolderDelete,
 		Update: resourceSumologicFolderUpdate,
-		//		Importer: &schema.ResourceImporter{
-		//			State: resourceSumologicFolderImport,
-		//		},
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"parent_id": {


### PR DESCRIPTION
Hello folks, 

I'm trying to update some of our orgs infrastructure to make use of Terraform. I wanted to use Terraform to manage our Sumologic instance, but I discovered this provider is missing the import setup. This is critical to migrating state from manual to Terraform. According to some people on stackoverflow this should be relatively straight forward https://stackoverflow.com/a/58376672/1072058. Could you all review this and see if it makes sense to include in your package? If it works out how soon would a new version be cut that supports this? I'd like to make use of this soon.