### PR TITLE
Accept AtLeastOnce resolution conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ENHANCEMENTS:
 * Add support for importing folder resource (GH-345)
+* Allow AtLeastOnce resolution conditions for Metrics monitors  (GH-346)
 
 ## 2.12.0 (February 7, 2022)
 
@@ -12,7 +13,6 @@ ENHANCEMENTS:
 * Add support for OTLP in HTTP source resource (GH-335)
 * Add backoff on http 429s (GH-338)
 * Add `domain` field to the dashboard resource (GH-341)
-* Allow AtLeastOnce resolution conditions for Metrics monitors  (GH-346)
 
 BUG FIXES:
 * Fix to allow more than one topology_label for Dashboard resource (GH-336)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ ENHANCEMENTS:
 * Add support for OTLP in HTTP source resource (GH-335)
 * Add backoff on http 429s (GH-338)
 * Add `domain` field to the dashboard resource (GH-341)
+* Allow AtLeastOnce resolution conditions for Metrics monitors  (GH-346)
 
 BUG FIXES:
 * Fix to allow more than one topology_label for Dashboard resource (GH-336)


### PR DESCRIPTION
Allow `AtLeastOnce` occurrence types for `ResolvedCritical` and `ResolvedWarning` trigger conditions in Metrics monitors.

For Metrics resolution blocks, the default `occurrence_type` is `Always`, regardless of the occurrence_type of the corresponding alert condition.

Users can now add an explicit `occurrence_type: "AtLeastOnce"` in `resolution` blocks to override the default behavior.

```
   metrics_static_condition {
     critical {
       time_range = "30m"
       occurrence_type = "Always"
       alert {
         threshold = 100.0
         threshold_type = "GreaterThan"
       }
       resolution {
         threshold = 90
         threshold_type = "LessThanOrEqual"
         occurrence_type = "AtLeastOnce"
       }
     }
   }
```
