### PR TITLE
SUMO-180864 terraform support for customizable alert name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 2.15.0 (Unreleased)
 
+FEATURES:
+* Add new optional `alert_name` field to resource/sumologic_monitor.
+
 ## 2.14.0 (March 30, 2022)
 
 FEATURES:

--- a/sumologic/resource_sumologic_monitors_library_monitor.go
+++ b/sumologic/resource_sumologic_monitors_library_monitor.go
@@ -325,6 +325,12 @@ func resourceSumologicMonitorsLibraryMonitor() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+
+			"alert_name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(1, 512),
+			},
 		},
 	}
 }
@@ -542,6 +548,7 @@ func resourceSumologicMonitorsLibraryMonitorRead(d *schema.ResourceData, meta in
 	d.Set("status", monitor.Status)
 	d.Set("group_notifications", monitor.GroupNotifications)
 	d.Set("playbook", monitor.Playbook)
+	d.Set("alert_name", monitor.AlertName)
 	// set notifications
 	notifications := make([]interface{}, len(monitor.Notifications))
 	for i, n := range monitor.Notifications {
@@ -1141,6 +1148,7 @@ func resourceToMonitorsLibraryMonitor(d *schema.ResourceData) MonitorsLibraryMon
 		Status:             status,
 		GroupNotifications: d.Get("group_notifications").(bool),
 		Playbook:           d.Get("playbook").(string),
+		AlertName:          d.Get("alert_name").(string),
 	}
 }
 
@@ -1229,11 +1237,6 @@ func (base TriggerCondition) cloneReadingFromNestedBlocks(block map[string]inter
 	if critical, ok := fromSingletonArray(block, "critical"); ok {
 		criticalCondition.readFrom(critical)
 		resolvedCriticalCondition.readFrom(critical)
-		if resolvedCriticalCondition.DetectionMethod == metricsStaticConditionDetectionMethod {
-			// do not inherit the top-level occurrence type into resolution blocks for MetricsStaticConditions
-			// we want the caller to be able to tell whether the resolution block had set its own occurrence type
-			resolvedCriticalCondition.OccurrenceType = ""
-		}
 		if alert, ok := fromSingletonArray(critical, "alert"); ok {
 			criticalCondition.readFrom(alert)
 		}
@@ -1245,11 +1248,6 @@ func (base TriggerCondition) cloneReadingFromNestedBlocks(block map[string]inter
 	if warning, ok := fromSingletonArray(block, "warning"); ok {
 		warningCondition.readFrom(warning)
 		resolvedWarningCondition.readFrom(warning)
-		if resolvedCriticalCondition.DetectionMethod == metricsStaticConditionDetectionMethod {
-			// do not inherit the top-level occurrence type into resolution blocks for MetricsStaticConditions
-			// we want the caller to be able to tell whether the resolution block had set its own occurrence type
-			resolvedCriticalCondition.OccurrenceType = ""
-		}
 		if alert, ok := fromSingletonArray(warning, "alert"); ok {
 			warningCondition.readFrom(alert)
 		}

--- a/sumologic/resource_sumologic_monitors_library_monitor.go
+++ b/sumologic/resource_sumologic_monitors_library_monitor.go
@@ -1237,6 +1237,11 @@ func (base TriggerCondition) cloneReadingFromNestedBlocks(block map[string]inter
 	if critical, ok := fromSingletonArray(block, "critical"); ok {
 		criticalCondition.readFrom(critical)
 		resolvedCriticalCondition.readFrom(critical)
+		if resolvedCriticalCondition.DetectionMethod == metricsStaticConditionDetectionMethod {
+			// do not inherit the top-level occurrence type into resolution blocks for MetricsStaticConditions
+			// we want the caller to be able to tell whether the resolution block had set its own occurrence type
+			resolvedCriticalCondition.OccurrenceType = ""
+		}
 		if alert, ok := fromSingletonArray(critical, "alert"); ok {
 			criticalCondition.readFrom(alert)
 		}
@@ -1248,6 +1253,11 @@ func (base TriggerCondition) cloneReadingFromNestedBlocks(block map[string]inter
 	if warning, ok := fromSingletonArray(block, "warning"); ok {
 		warningCondition.readFrom(warning)
 		resolvedWarningCondition.readFrom(warning)
+		if resolvedCriticalCondition.DetectionMethod == metricsStaticConditionDetectionMethod {
+			// do not inherit the top-level occurrence type into resolution blocks for MetricsStaticConditions
+			// we want the caller to be able to tell whether the resolution block had set its own occurrence type
+			resolvedCriticalCondition.OccurrenceType = ""
+		}
 		if alert, ok := fromSingletonArray(warning, "alert"); ok {
 			warningCondition.readFrom(alert)
 		}

--- a/sumologic/resource_sumologic_monitors_library_monitor_test.go
+++ b/sumologic/resource_sumologic_monitors_library_monitor_test.go
@@ -188,6 +188,7 @@ func TestAccSumologicMonitorsLibraryMonitor_create(t *testing.T) {
 			RunForTriggerTypes: testTriggerTypes,
 		},
 	}
+	testAlertName := "Alert from {{Name}}"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -210,6 +211,7 @@ func TestAccSumologicMonitorsLibraryMonitor_create(t *testing.T) {
 					resource.TestCheckResourceAttr("sumologic_monitor.test", "triggers.0.trigger_type", testTriggers[0].TriggerType),
 					resource.TestCheckResourceAttr("sumologic_monitor.test", "triggers.0.time_range", testTriggers[0].TimeRange),
 					resource.TestCheckResourceAttr("sumologic_monitor.test", "notifications.0.notification.0.connection_type", testNotifications[0].Notification.(EmailNotification).ConnectionType),
+					resource.TestCheckResourceAttr("sumologic_monitor.test", "alert_name", testAlertName),
 				),
 			},
 		},
@@ -303,6 +305,7 @@ func TestAccSumologicMonitorsLibraryMonitor_update(t *testing.T) {
 			RunForTriggerTypes: testTriggerTypes,
 		},
 	}
+	testAlertName := "Alert from {{Name}}"
 
 	// updated fields
 	testUpdatedName := "terraform_test_monitor_" + testNameSuffix
@@ -362,6 +365,7 @@ func TestAccSumologicMonitorsLibraryMonitor_update(t *testing.T) {
 			RunForTriggerTypes: testUpdatedTriggerTypes,
 		},
 	}
+	testUpdatedAlertName := "Updated Alert from {{Name}}"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -385,6 +389,7 @@ func TestAccSumologicMonitorsLibraryMonitor_update(t *testing.T) {
 					resource.TestCheckResourceAttr("sumologic_monitor.test", "triggers.0.time_range", testTriggers[0].TimeRange),
 					resource.TestCheckResourceAttr("sumologic_monitor.test", "notifications.0.notification.0.connection_type", testNotifications[0].Notification.(EmailNotification).ConnectionType),
 					resource.TestCheckResourceAttr("sumologic_monitor.test", "playbook", testPlaybook),
+					resource.TestCheckResourceAttr("sumologic_monitor.test", "alert_name", testAlertName),
 				),
 			},
 			{
@@ -402,6 +407,7 @@ func TestAccSumologicMonitorsLibraryMonitor_update(t *testing.T) {
 					resource.TestCheckResourceAttr("sumologic_monitor.test", "triggers.0.time_range", testUpdatedTriggers[0].TimeRange),
 					resource.TestCheckResourceAttr("sumologic_monitor.test", "notifications.0.notification.0.connection_type", testUpdatedNotifications[0].Notification.(EmailNotification).ConnectionType),
 					resource.TestCheckResourceAttr("sumologic_monitor.test", "playbook", testUpdatedPlaybook),
+					resource.TestCheckResourceAttr("sumologic_monitor.test", "alert_name", testUpdatedAlertName),
 				),
 			},
 		},
@@ -516,6 +522,7 @@ resource "sumologic_monitor" "test" {
 		run_for_trigger_types = ["Critical", "ResolvedCritical"]
 	  }
 	playbook = "This is a test playbook"  
+	alert_name =  "Alert from {{Name}}"
 }`, testName)
 }
 
@@ -562,6 +569,7 @@ resource "sumologic_monitor" "test" {
 		run_for_trigger_types = ["Critical", "ResolvedCritical"]
 	  }
 	playbook = "This is an updated test playbook"
+	alert_name = "Updated Alert from {{Name}}"
 }`, testName)
 }
 

--- a/sumologic/sumologic_monitors_library_monitor.go
+++ b/sumologic/sumologic_monitors_library_monitor.go
@@ -138,6 +138,7 @@ type MonitorsLibraryMonitor struct {
 	Status             []string              `json:"status"`
 	GroupNotifications bool                  `json:"groupNotifications"`
 	Playbook           string                `json:"playbook,omitempty"`
+	AlertName          string                `json:"alertName,omitempty"`
 }
 
 type MonitorQuery struct {

--- a/website/docs/r/monitor.html.markdown
+++ b/website/docs/r/monitor.html.markdown
@@ -216,7 +216,7 @@ The following arguments are supported:
 - `notifications` - (Optional) The notifications the monitor will send when the respective trigger condition is met.
 - `group_notifications` - (Optional) Whether or not to group notifications for individual items that meet the trigger condition. Defaults to true.
 - `playbook` - (Optional - Beta) Notes such as links and instruction to help you resolve alerts triggered by this monitor. {{Markdown}} supported. It will be enabled only if available for your organization. Please contact your Sumo Logic account team to learn more.
-- `alert_name` - (Optional) The display name when creating alerts. Monitor name will be used if `alert_name` is not provided.
+- `alert_name` - (Optional) The display name when creating alerts. Monitor name will be used if `alert_name` is not provided. All template variables can be used in `alert_name` except `{{AlertName}}` and `{{ResultsJson}}`.
 
 Additional data provided in state:
 

--- a/website/docs/r/monitor.html.markdown
+++ b/website/docs/r/monitor.html.markdown
@@ -59,6 +59,7 @@ resource "sumologic_monitor" "tf_logs_monitor_1" {
     run_for_trigger_types = ["Critical", "ResolvedCritical"]
   }
   playbook = "{{Name}} should be fixed in 24 hours when {{TriggerType}} is triggered."
+  alert_name = "Alert {{ResultJson.my_field}} from {{Name}}"
 }
 ```
 
@@ -215,6 +216,7 @@ The following arguments are supported:
 - `notifications` - (Optional) The notifications the monitor will send when the respective trigger condition is met.
 - `group_notifications` - (Optional) Whether or not to group notifications for individual items that meet the trigger condition. Defaults to true.
 - `playbook` - (Optional - Beta) Notes such as links and instruction to help you resolve alerts triggered by this monitor. {{Markdown}} supported. It will be enabled only if available for your organization. Please contact your Sumo Logic account team to learn more.
+- `alert_name` - (Optional) The display name when creating alerts. Monitor name will be used if `alert_name` is not provided.
 
 Additional data provided in state:
 


### PR DESCRIPTION
Testing done:
- `TestAccSumologicMonitorsLibraryMonitor_create` and `TestAccSumologicMonitorsLibraryMonitor_update`
- created a monitor with an alert name on us2Demo successfully 
