### PR TITLE
Add CRITICAL as a valid value for cse_custom_insight severity field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ FEATURES:
 * Add new optional `alert_name` field to resource/sumologic_monitor.
 
 BUG FIXES:
-* Add CRITICAL as a valid value for cse_custom_insight severity field
+* Add CRITICAL as a valid value for cse_custom_insight severity field (GH-367)
 
 ## 2.14.0 (March 30, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 FEATURES:
 * Add new optional `alert_name` field to resource/sumologic_monitor.
 
+BUG FIXES:
+* Add CRITICAL as a valid value for cse_custom_insight severity field
+
 ## 2.14.0 (March 30, 2022)
 
 FEATURES:

--- a/sumologic/resource_sumologic_cse_custom_insight.go
+++ b/sumologic/resource_sumologic_cse_custom_insight.go
@@ -43,7 +43,7 @@ func resourceSumologicCSECustomInsight() *schema.Resource {
 			"severity": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validation.StringInSlice([]string{"HIGH", "MEDIUM", "LOW"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"HIGH", "MEDIUM", "LOW", "CRITICAL"}, false),
 			},
 			"signal_names": {
 				Type:     schema.TypeList,


### PR DESCRIPTION
2022/05/04 13:05:56 [WARN] <root>: eval: *terraform.EvalValidateResource, non-fatal err: expected severity to be one of [HIGH MEDIUM LOW], got CRITICAL
2022/05/04 13:05:56 [ERROR] <root>: eval: *terraform.EvalSequence, err: expected severity to be one of [HIGH MEDIUM LOW], got CRITICAL
    testing.go:705: Step 0 error: config is invalid: expected severity to be one of [HIGH MEDIUM LOW], got CRITICAL
    
    