### PR TITLE
SUMO-164539: adding TF support for CMF FGP under Monitor Folder

### DIFF
--- a/sumologic/resource_sumologic_monitors_library_folder.go
+++ b/sumologic/resource_sumologic_monitors_library_folder.go
@@ -100,6 +100,7 @@ func resourceSumologicMonitorsLibraryFolder() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+
 			"obj_permission": GetCmfFgpObjPermSetSchema(),
 		},
 	}

--- a/sumologic/resource_sumologic_monitors_library_folder.go
+++ b/sumologic/resource_sumologic_monitors_library_folder.go
@@ -92,6 +92,7 @@ func resourceSumologicMonitorsLibraryFolder() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+
 			"post_request_map": {
 				Type:     schema.TypeMap,
 				Optional: true,
@@ -99,11 +100,15 @@ func resourceSumologicMonitorsLibraryFolder() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"obj_permission": GetCmfFgpObjPermSetSchema(),
 		},
 	}
 }
 
+const fgpTargetType = "monitors"
+
 func resourceSumologicMonitorsLibraryFolderCreate(d *schema.ResourceData, meta interface{}) error {
+
 	c := meta.(*Client)
 	if d.Id() == "" {
 		folder := resourceToMonitorsLibraryFolder(d)
@@ -122,12 +127,24 @@ func resourceSumologicMonitorsLibraryFolderCreate(d *schema.ResourceData, meta i
 			return err
 		}
 
+		permStmts, convErr := ResourceToCmfFgpPermStmts(d, monitorDefinitionID)
+		if convErr != nil {
+			return convErr
+		}
+		_, fgpErr := c.SetCmfFgp(fgpTargetType, CmfFgpRequest{
+			PermissionStatements: permStmts,
+		})
+		if fgpErr != nil {
+			return fgpErr
+		}
+
 		d.SetId(monitorDefinitionID)
 	}
 	return resourceSumologicMonitorsLibraryFolderRead(d, meta)
 }
 
 func resourceSumologicMonitorsLibraryFolderRead(d *schema.ResourceData, meta interface{}) error {
+
 	c := meta.(*Client)
 
 	folder, err := c.GetMonitorsLibraryFolder(d.Id())
@@ -139,6 +156,16 @@ func resourceSumologicMonitorsLibraryFolderRead(d *schema.ResourceData, meta int
 		log.Printf("[WARN] Monitor Folder not found, removing from state: %v - %v", d.Id(), err)
 		d.SetId("")
 		return nil
+	}
+
+	fgpResponse, fgpErr := c.GetCmfFgp(fgpTargetType, folder.ID)
+	if fgpErr != nil {
+		// if FGP endpoint is not enabled (not implemented), we should suppress this error
+		if !HasErrorCode(fgpErr.Error(), "not_implemented_yet") {
+			return fgpErr
+		}
+	} else {
+		CmfFgpPermStmtsSetToResource(d, fgpResponse.PermissionStatements)
 	}
 
 	d.Set("created_by", folder.CreatedBy)
@@ -158,13 +185,42 @@ func resourceSumologicMonitorsLibraryFolderRead(d *schema.ResourceData, meta int
 }
 
 func resourceSumologicMonitorsLibraryFolderUpdate(d *schema.ResourceData, meta interface{}) error {
+
 	c := meta.(*Client)
-	monitor := resourceToMonitorsLibraryFolder(d)
-	monitor.Type = "MonitorsLibraryFolderUpdate"
-	err := c.UpdateMonitorsLibraryFolder(monitor)
+	monitorFolder := resourceToMonitorsLibraryFolder(d)
+	monitorFolder.Type = "MonitorsLibraryFolderUpdate"
+	err := c.UpdateMonitorsLibraryFolder(monitorFolder)
 	if err != nil {
 		return err
 	}
+
+	// converting Reource FGP to Struct
+	permStmts, convErr := ResourceToCmfFgpPermStmts(d, monitorFolder.ID)
+	if convErr != nil {
+		return convErr
+	}
+
+	// reading FGP from Backend to reconcille
+	fgpGetResponse, fgpGetErr := c.GetCmfFgp(fgpTargetType, monitorFolder.ID)
+	if fgpGetErr != nil {
+		// if FGP endpoint is not enabled (not implemented) and FGP feature is not used,
+		// we should suppress this error
+		if !HasErrorCode(fgpGetErr.Error(), "not_implemented_yet") && len(permStmts) == 0 {
+			return fgpGetErr
+		}
+	}
+
+	if len(permStmts) > 0 || fgpGetResponse != nil {
+		_, fgpSetErr := c.SetCmfFgp(fgpTargetType, CmfFgpRequest{
+			PermissionStatements: ReconcileFgpPermStmtsWithEmptyPerms(
+				permStmts, fgpGetResponse.PermissionStatements,
+			),
+		})
+		if fgpSetErr != nil {
+			return fgpSetErr
+		}
+	}
+
 	return resourceSumologicMonitorsLibraryFolderRead(d, meta)
 }
 

--- a/sumologic/resource_sumologic_monitors_library_folder_test.go
+++ b/sumologic/resource_sumologic_monitors_library_folder_test.go
@@ -1,0 +1,518 @@
+package sumologic
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccSumologicMonitorsLibraryFolder_fgpSchemaValidations(t *testing.T) {
+	config01 := `
+resource "sumologic_monitor_folder" "test_monitorfolder" {
+	name        = "terraform_test_monitorfolder"
+	description = "terraform_test_monitorfolder_desc"
+	obj_permission {
+		subject_type = "foo_invalid_subject_type"
+		subject_id = "dummyID_01"
+		permissions = ["Create","Read","Update","Delete"] 
+	}
+	obj_permission {
+		subject_type = "role"
+		subject_id = "dummyID_02"
+		permissions = ["Create", "Read"]
+	}
+}`
+	expectedError01 := regexp.MustCompile(
+		".*expected obj_permission.0.subject_type to be one of \\[role org], got foo_invalid_subject_type.*")
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMonitorsLibraryFolderDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config:      config01,
+				PlanOnly:    true,
+				ExpectError: expectedError01,
+			},
+		},
+	})
+
+	config02 := `
+resource "sumologic_monitor_folder" "test_monitorfolder" {
+		name        = "terraform_test_monitorfolder"
+		description = "terraform_test_monitorfolder_desc"
+		obj_permission {
+			subject_type = "role"
+			subject_id = "dummyID_01"
+			permissions = ["Create","Read","Update","Delete"] 
+		}
+		obj_permission {
+			subject_type = "role"
+			subject_id = "dummyID_02"
+			permissions = ["Create", "Read", "Invalid_Perm"]
+		}
+}`
+	expectedError02 := regexp.MustCompile(
+		".*expected obj_permission.1.permissions.1 to be one of \\[Create Read Update Delete Manage], got Invalid_Perm.*")
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMonitorsLibraryFolderDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config:      config02,
+				PlanOnly:    true,
+				ExpectError: expectedError02,
+			},
+		},
+	})
+
+}
+
+func TestAccSumologicMonitorsLibraryFolder_createWithFGP(t *testing.T) {
+
+	testNameSuffix := acctest.RandString(16)
+	tfResourceKey := "sumologic_monitor_folder.test_monitorfolder"
+	testName := "terraform_test_monitorfolder_" + testNameSuffix
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMonitorsLibraryFolderDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSumologicMonitorsLibraryFolder(testNameSuffix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMonitorsLibraryFolderExists(tfResourceKey, t),
+					testAccCheckMonitorsLibraryFolderAttributes(tfResourceKey),
+
+					resource.TestCheckResourceAttr("sumologic_monitor_folder.test_monitorfolder", "name", testName),
+					resource.TestCheckResourceAttr("sumologic_monitor_folder.test_monitorfolder", "description",
+						"terraform_test_monitorfolder_desc"),
+
+					resource.TestCheckResourceAttr("sumologic_monitor_folder.test_monitorfolder",
+						"obj_permission.#", "2"),
+					testAccCheckMonitorsLibraryFolderFGPBackend(tfResourceKey, t, genExpectedPermStmts),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSumologicMonitorsLibraryFolder_updateWithFGP(t *testing.T) {
+
+	testNameSuffix := acctest.RandString(16)
+	tfResourceKey := "sumologic_monitor_folder.test_monitorfolder"
+	testName := "terraform_test_monitorfolder_" + testNameSuffix
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMonitorsLibraryFolderDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSumologicMonitorsLibraryFolder(testNameSuffix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMonitorsLibraryFolderExists(tfResourceKey, t),
+					testAccCheckMonitorsLibraryFolderAttributes(tfResourceKey),
+
+					resource.TestCheckResourceAttr("sumologic_monitor_folder.test_monitorfolder", "name", testName),
+					resource.TestCheckResourceAttr("sumologic_monitor_folder.test_monitorfolder", "description",
+						"terraform_test_monitorfolder_desc"),
+
+					resource.TestCheckResourceAttr("sumologic_monitor_folder.test_monitorfolder",
+						"obj_permission.#", "2"),
+					testAccCheckMonitorsLibraryFolderFGPBackend(tfResourceKey, t, genExpectedPermStmts),
+				),
+			},
+			{
+				Config: testAccSumologicMonitorsLibraryFolderForUpdate(testNameSuffix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMonitorsLibraryFolderExists(tfResourceKey, t),
+					testAccCheckMonitorsLibraryFolderAttributes(tfResourceKey),
+
+					resource.TestCheckResourceAttr("sumologic_monitor_folder.test_monitorfolder", "name", testName),
+					resource.TestCheckResourceAttr("sumologic_monitor_folder.test_monitorfolder", "description",
+						"terraform_test_monitorfolder_desc update test"),
+					// updated desc
+
+					resource.TestCheckResourceAttr("sumologic_monitor_folder.test_monitorfolder",
+						"obj_permission.#", "1"),
+					// 1, instead of 2
+					testAccCheckMonitorsLibraryFolderFGPBackend(tfResourceKey, t, genExpectedPermStmtsForUpdate),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSumologicMonitorsLibraryFolder_driftingCorrectionFGP(t *testing.T) {
+
+	testNameSuffix := acctest.RandString(16)
+	tfResourceKey := "sumologic_monitor_folder.test_monitorfolder"
+	testName := "terraform_test_monitorfolder_" + testNameSuffix
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMonitorsLibraryFolderDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSumologicMonitorsLibraryFolder(testNameSuffix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMonitorsLibraryFolderExists(tfResourceKey, t),
+					testAccCheckMonitorsLibraryFolderAttributes(tfResourceKey),
+
+					resource.TestCheckResourceAttr("sumologic_monitor_folder.test_monitorfolder", "name", testName),
+					resource.TestCheckResourceAttr("sumologic_monitor_folder.test_monitorfolder", "description",
+						"terraform_test_monitorfolder_desc"),
+
+					resource.TestCheckResourceAttr("sumologic_monitor_folder.test_monitorfolder",
+						"obj_permission.#", "2"),
+					testAccCheckMonitorsLibraryFolderFGPBackend(tfResourceKey, t, genExpectedPermStmts),
+					// Emulating Drifting at the Backend
+					testAccEmulateFGPDrifting(t),
+				),
+				// "After applying this step and refreshing, the plan was not empty"
+				// Non-Empty Plan would occur, after the above step that emulates FGP drifting
+				ExpectNonEmptyPlan: true,
+			},
+			// the following Test Step emulates running "terraform apply" again.
+			// This step would detect and correct Drifting
+			{
+				Config: testAccSumologicMonitorsLibraryFolder(testNameSuffix),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMonitorsLibraryFolderExists(tfResourceKey, t),
+					testAccCheckMonitorsLibraryFolderAttributes(tfResourceKey),
+
+					resource.TestCheckResourceAttr("sumologic_monitor_folder.test_monitorfolder", "name", testName),
+					resource.TestCheckResourceAttr("sumologic_monitor_folder.test_monitorfolder", "description",
+						"terraform_test_monitorfolder_desc"),
+
+					resource.TestCheckResourceAttr("sumologic_monitor_folder.test_monitorfolder",
+						"obj_permission.#", "2"),
+					testAccCheckMonitorsLibraryFolderFGPBackend(tfResourceKey, t, genExpectedPermStmts),
+				),
+			},
+		},
+	})
+
+}
+
+func testAccCheckMonitorsLibraryFolderDestroy() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*Client)
+		for _, r := range s.RootModule().Resources {
+			id := r.Primary.ID
+			u, err := client.GetMonitorsLibraryFolder(id)
+			if err != nil {
+				return fmt.Errorf("Encountered an error: " + err.Error())
+			}
+			if u != nil {
+				return fmt.Errorf("monitorsLibraryFolder %s still exists", id)
+			}
+		}
+		return nil
+	}
+}
+
+func getResourceID(s *terraform.State, name string) (string, error) {
+	rs, ok := s.RootModule().Resources[name]
+	if !ok {
+		return "", fmt.Errorf("getResourceID: ok = %t. Resource not found: %s", ok, name)
+	}
+	if rs.Primary.ID == "" {
+		return "", fmt.Errorf("getResourceID: ID is not set")
+	}
+	return rs.Primary.ID, nil
+}
+
+func testAccCheckMonitorsLibraryFolderExists(name string, t *testing.T) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		id, resIdErr := getResourceID(s, name)
+		if resIdErr != nil {
+			return resIdErr
+		}
+
+		client := testAccProvider.Meta().(*Client)
+		folder, err := client.GetMonitorsLibraryFolder(id)
+		if err != nil {
+			return err
+		}
+		if folder == nil {
+			return fmt.Errorf("MonitorsLibraryFolder %s not found", id)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckMonitorsLibraryFolderFGPBackend(
+	name string,
+	t *testing.T,
+	expectedFGPFunc func(*terraform.State, string) ([]CmfFgpPermStatement, error),
+) resource.TestCheckFunc {
+
+	return func(s *terraform.State) error {
+		targetId, resIdErr := getResourceID(s, name)
+		if resIdErr != nil {
+			return resIdErr
+		}
+
+		expectedPermStmts, resIdErr := expectedFGPFunc(s, targetId)
+		if resIdErr != nil {
+			return resIdErr
+		}
+
+		client := testAccProvider.Meta().(*Client)
+
+		fgpResult, fgpErr := client.GetCmfFgp("monitors", targetId)
+		if fgpErr != nil {
+			return fgpErr
+		}
+
+		if !CmfFgpPermStmtSetEqual(fgpResult.PermissionStatements, expectedPermStmts) {
+			return fmt.Errorf("Permission Statements are different:\n  %+v\n  %+v\n",
+				fgpResult.PermissionStatements, expectedPermStmts)
+		}
+
+		return nil
+	}
+}
+
+func testAccEmulateFGPDrifting(
+	t *testing.T,
+	// expectedFGPFunc func(*terraform.State, string) ([]CmfFgpPermStatement, error),
+) resource.TestCheckFunc {
+
+	return func(s *terraform.State) error {
+
+		folderTargetId, resIdErr := getResourceID(s, "sumologic_monitor_folder.test_monitorfolder")
+		if resIdErr != nil {
+			return resIdErr
+		}
+		role01Id, resIdErr := getResourceID(s, "sumologic_role.tf_test_role_01")
+		if resIdErr != nil {
+			return resIdErr
+		}
+		role02Id, resIdErr := getResourceID(s, "sumologic_role.tf_test_role_02")
+		if resIdErr != nil {
+			return resIdErr
+		}
+		role03Id, resIdErr := getResourceID(s, "sumologic_role.tf_test_role_03")
+		if resIdErr != nil {
+			return resIdErr
+		}
+
+		client := testAccProvider.Meta().(*Client)
+		expectedReadPermStmts := []CmfFgpPermStatement{
+			{SubjectType: "role", SubjectId: role01Id, TargetId: folderTargetId,
+				Permissions: []string{"Create", "Read", "Update"}},
+			{SubjectType: "role", SubjectId: role03Id, TargetId: folderTargetId,
+				Permissions: []string{"Read"}},
+		}
+		// using an empty Permissions array to achieve the effect of FGP Revocation
+		setFGPPermStmts := append(expectedReadPermStmts,
+			CmfFgpPermStatement{SubjectType: "role", SubjectId: role02Id, TargetId: folderTargetId,
+				Permissions: []string{}})
+
+		_, setFgpErr := client.SetCmfFgp("monitors", CmfFgpRequest{
+			PermissionStatements: setFGPPermStmts})
+		if setFgpErr != nil {
+			return setFgpErr
+		}
+
+		readfgpResult, readFgpErr := client.GetCmfFgp("monitors", folderTargetId)
+		if readFgpErr != nil {
+			return readFgpErr
+		}
+
+		var expectedPermStmts []CmfFgpPermStatement
+		expectedPermStmts = append(expectedPermStmts,
+			CmfFgpPermStatement{
+				SubjectId:   role01Id,
+				SubjectType: "role",
+				TargetId:    folderTargetId,
+				Permissions: []string{"Create", "Read", "Update"},
+			},
+			CmfFgpPermStatement{
+				SubjectId:   role03Id,
+				SubjectType: "role",
+				TargetId:    folderTargetId,
+				Permissions: []string{"Read"},
+			},
+		)
+
+		if !CmfFgpPermStmtSetEqual(readfgpResult.PermissionStatements, expectedPermStmts) {
+			return fmt.Errorf("Permission Statements are different:\n  %+v\n  %+v\n",
+				readfgpResult.PermissionStatements, expectedPermStmts)
+		}
+		return nil
+	}
+}
+
+func testAccCheckMonitorsLibraryFolderAttributes(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		f := resource.ComposeTestCheckFunc(
+			resource.TestCheckResourceAttrSet(name, "name"),
+			resource.TestCheckResourceAttrSet(name, "parent_id"),
+			resource.TestCheckResourceAttrSet(name, "description"),
+
+			resource.TestCheckResourceAttrSet(name, "version"),
+			resource.TestCheckResourceAttrSet(name, "is_locked"),
+			resource.TestCheckResourceAttrSet(name, "is_mutable"),
+			resource.TestCheckResourceAttrSet(name, "is_system"),
+
+			resource.TestCheckResourceAttrSet(name, "modified_at"),
+			resource.TestCheckResourceAttrSet(name, "modified_by"),
+			resource.TestCheckResourceAttrSet(name, "created_by"),
+			resource.TestCheckResourceAttrSet(name, "created_at"),
+
+			resource.TestCheckResourceAttrSet(name, "content_type"),
+			resource.TestCheckResourceAttrSet(name, "type"),
+		)
+		return f(s)
+	}
+}
+
+func testAccSumologicMonitorsLibraryFolder(testNameSuffix string) string {
+	return fmt.Sprintf(`
+resource "sumologic_role" "tf_test_role_01" {
+	name        = "tf_test_role_01_%s"
+	description = "Testing resource sumologic_role"
+	capabilities = [
+		"viewAlerts",
+		"viewMonitorsV2",
+		"manageMonitorsV2"
+	]
+}	
+resource "sumologic_role" "tf_test_role_02" {
+	name        = "tf_test_role_02_%s"
+	description = "Testing resource sumologic_role"
+	capabilities = [
+		"viewAlerts",
+		"viewMonitorsV2",
+		"manageMonitorsV2"
+	]
+}
+resource "sumologic_role" "tf_test_role_03" {
+	name        = "tf_test_role_03_%s"
+	description = "Testing resource sumologic_role"
+	capabilities = [
+		"viewAlerts",
+		"viewMonitorsV2",
+		"manageMonitorsV2"
+	]
+}
+
+resource "sumologic_monitor_folder" "test_monitorfolder" {
+		name        = "terraform_test_monitorfolder_%s"
+		description = "terraform_test_monitorfolder_desc"
+		obj_permission {
+		  subject_type = "role"
+		  subject_id = sumologic_role.tf_test_role_01.id 
+		  permissions = ["Create","Read","Update","Delete"] 
+		}
+		obj_permission {
+		  subject_type = "role"
+		  subject_id = sumologic_role.tf_test_role_02.id
+		  permissions = ["Create", "Read"]
+		}
+}
+`, testNameSuffix, testNameSuffix, testNameSuffix, testNameSuffix)
+}
+
+func testAccSumologicMonitorsLibraryFolderForUpdate(testNameSuffix string) string {
+	return fmt.Sprintf(`
+resource "sumologic_role" "tf_test_role_01" {
+	name        = "tf_test_role_01_%s"
+	description = "Testing resource sumologic_role"
+	capabilities = [
+		"viewAlerts",
+		"viewMonitorsV2",
+		"manageMonitorsV2"
+	]
+}	
+resource "sumologic_role" "tf_test_role_02" {
+	name        = "tf_test_role_02_%s"
+	description = "Testing resource sumologic_role"
+	capabilities = [
+		"viewAlerts",
+		"viewMonitorsV2",
+		"manageMonitorsV2"
+	]
+}
+resource "sumologic_role" "tf_test_role_03" {
+	name        = "tf_test_role_03_%s"
+	description = "Testing resource sumologic_role"
+	capabilities = [
+		"viewAlerts",
+		"viewMonitorsV2",
+		"manageMonitorsV2"
+	]
+}
+
+resource "sumologic_monitor_folder" "test_monitorfolder" {
+		name        = "terraform_test_monitorfolder_%s"
+		description = "terraform_test_monitorfolder_desc update test"
+		obj_permission {
+		  subject_type = "role"
+		  subject_id = sumologic_role.tf_test_role_01.id 
+		  permissions = ["Create","Read","Update"] 
+		  // "Delete" permission is removed here. 
+		}
+		// permission for tf_test_role_02 is removed here. 
+}
+`, testNameSuffix, testNameSuffix, testNameSuffix, testNameSuffix)
+}
+
+func genExpectedPermStmts(s *terraform.State, targetId string) ([]CmfFgpPermStatement, error) {
+	role01Id, resIdErr := getResourceID(s, "sumologic_role.tf_test_role_01")
+	if resIdErr != nil {
+		return nil, resIdErr
+	}
+	role02Id, resIdErr := getResourceID(s, "sumologic_role.tf_test_role_02")
+	if resIdErr != nil {
+		return nil, resIdErr
+	}
+
+	var expectedPermStmts []CmfFgpPermStatement
+	expectedPermStmts = append(expectedPermStmts,
+		CmfFgpPermStatement{
+			SubjectId:   role01Id,
+			SubjectType: "role",
+			TargetId:    targetId,
+			Permissions: []string{"Create", "Read", "Update", "Delete"},
+		},
+		CmfFgpPermStatement{
+			SubjectId:   role02Id,
+			SubjectType: "role",
+			TargetId:    targetId,
+			Permissions: []string{"Create", "Read"},
+		},
+	)
+	return expectedPermStmts, nil
+}
+
+func genExpectedPermStmtsForUpdate(s *terraform.State, targetId string) ([]CmfFgpPermStatement, error) {
+	role01Id, resIdErr := getResourceID(s, "sumologic_role.tf_test_role_01")
+	if resIdErr != nil {
+		return nil, resIdErr
+	}
+
+	var expectedPermStmts []CmfFgpPermStatement
+	expectedPermStmts = append(expectedPermStmts,
+		CmfFgpPermStatement{
+			SubjectId:   role01Id,
+			SubjectType: "role",
+			TargetId:    targetId,
+			Permissions: []string{"Create", "Read", "Update"},
+		},
+	)
+	return expectedPermStmts, nil
+}

--- a/sumologic/resource_sumologic_monitors_library_folder_test.go
+++ b/sumologic/resource_sumologic_monitors_library_folder_test.go
@@ -29,6 +29,24 @@ resource "sumologic_monitor_folder" "test_monitorfolder" {
 	expectedError01 := regexp.MustCompile(
 		".*expected obj_permission.0.subject_type to be one of \\[role org], got foo_invalid_subject_type.*")
 
+	config02 := `
+		resource "sumologic_monitor_folder" "test_monitorfolder" {
+				name        = "terraform_test_monitorfolder"
+				description = "terraform_test_monitorfolder_desc"
+				obj_permission {
+					subject_type = "role"
+					subject_id = "dummyID_01"
+					permissions = ["Create","Read","Update","Delete"] 
+				}
+				obj_permission {
+					subject_type = "role"
+					subject_id = "dummyID_02"
+					permissions = ["Create", "Read", "Invalid_Perm"]
+				}
+		}`
+	expectedError02 := regexp.MustCompile(
+		".*expected obj_permission.1.permissions.1 to be one of \\[Create Read Update Delete Manage], got Invalid_Perm.*")
+
 	resource.Test(t, resource.TestCase{
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMonitorsLibraryFolderDestroy(),
@@ -38,31 +56,6 @@ resource "sumologic_monitor_folder" "test_monitorfolder" {
 				PlanOnly:    true,
 				ExpectError: expectedError01,
 			},
-		},
-	})
-
-	config02 := `
-resource "sumologic_monitor_folder" "test_monitorfolder" {
-		name        = "terraform_test_monitorfolder"
-		description = "terraform_test_monitorfolder_desc"
-		obj_permission {
-			subject_type = "role"
-			subject_id = "dummyID_01"
-			permissions = ["Create","Read","Update","Delete"] 
-		}
-		obj_permission {
-			subject_type = "role"
-			subject_id = "dummyID_02"
-			permissions = ["Create", "Read", "Invalid_Perm"]
-		}
-}`
-	expectedError02 := regexp.MustCompile(
-		".*expected obj_permission.1.permissions.1 to be one of \\[Create Read Update Delete Manage], got Invalid_Perm.*")
-
-	resource.Test(t, resource.TestCase{
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckMonitorsLibraryFolderDestroy(),
-		Steps: []resource.TestStep{
 			{
 				Config:      config02,
 				PlanOnly:    true,
@@ -70,7 +63,6 @@ resource "sumologic_monitor_folder" "test_monitorfolder" {
 			},
 		},
 	})
-
 }
 
 func TestAccSumologicMonitorsLibraryFolder_createWithFGP(t *testing.T) {
@@ -150,7 +142,6 @@ func TestAccSumologicMonitorsLibraryFolder_updateWithFGP(t *testing.T) {
 	})
 }
 
-//lintignore:AT006
 func TestAccSumologicMonitorsLibraryFolder_driftingCorrectionFGP(t *testing.T) {
 
 	// using the above lintignore, as we want to use multiple tests to emulate Drifting Detection and Correction

--- a/sumologic/resource_sumologic_monitors_library_folder_test.go
+++ b/sumologic/resource_sumologic_monitors_library_folder_test.go
@@ -150,7 +150,10 @@ func TestAccSumologicMonitorsLibraryFolder_updateWithFGP(t *testing.T) {
 	})
 }
 
+//lintignore:AT006
 func TestAccSumologicMonitorsLibraryFolder_driftingCorrectionFGP(t *testing.T) {
+
+	// using the above lintignore, as we want to use multiple tests to emulate Drifting Detection and Correction
 
 	testNameSuffix := acctest.RandString(16)
 	tfResourceKey := "sumologic_monitor_folder.test_monitorfolder"

--- a/sumologic/sumologic_client.go
+++ b/sumologic/sumologic_client.go
@@ -341,10 +341,31 @@ func NewClient(accessID, accessKey, authJwt, environment, base_url string, admin
 	return &client, nil
 }
 
+func HasErrorCode(errorJsonStr string, errorCode string) bool {
+	var apiError ApiError
+	jsonErr := json.Unmarshal([]byte(errorJsonStr), &apiError)
+	if jsonErr != nil {
+		// when fail to unmarshal JSON, we should consider the errorCode is not found
+		return false
+	}
+	for i := range apiError.Errors {
+		if apiError.Errors[i].Code == errorCode {
+			return true
+		}
+	}
+	return false
+}
+
 type Error struct {
 	Code    string `json:"code"`
 	Message string `json:"message"`
 	Detail  string `json:"detail"`
+}
+
+// e.g. {"id":"8UQOI-82VTR-YBQ8G","errors":[{"code":"not_implemented_yet","message":"Not implemented yet"}]}
+type ApiError struct {
+	Id     string  `json:"id"`
+	Errors []Error `json:"errors"`
 }
 
 type Status struct {

--- a/sumologic/sumologic_cmffgp.go
+++ b/sumologic/sumologic_cmffgp.go
@@ -1,0 +1,181 @@
+package sumologic
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+)
+
+func (s *Client) GetCmfFgp(targetType string, targetId string) (*CmfFgpResponse, error) {
+
+	// e.g. "v1/monitors/0000000000000003/permissions"
+	url := fmt.Sprintf("v1/%s/%s/permissions", targetType, targetId)
+	data, _, err := s.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	if data == nil {
+		return nil, nil
+	}
+
+	var cmfFgpResponse CmfFgpResponse
+	err = json.Unmarshal(data, &cmfFgpResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter subjectType "user"
+	cmfFgpResponse.PermissionStatements = cmfFgpFilter(cmfFgpResponse.PermissionStatements,
+		func(perm *CmfFgpPermStatement) bool {
+			return perm.SubjectType != "user"
+		})
+	return &cmfFgpResponse, nil
+}
+
+func (s *Client) SetCmfFgp(targetType string, cmfFgpRequest CmfFgpRequest) (*CmfFgpResponse, error) {
+
+	if len(cmfFgpRequest.PermissionStatements) == 0 {
+		log.Printf("[INFO] SetCmfFgp does not contain any PermissionStatements. Hence, No-Op")
+		return nil, nil
+	}
+
+	// e.g. "v1/monitors/permissions/set"
+	url := fmt.Sprintf("v1/%s/permissions/set", targetType)
+	data, err := s.Put(url, cmfFgpRequest)
+	if err != nil {
+		return nil, err
+	}
+	if data == nil {
+		return nil, nil
+	}
+
+	var cmfFgpResponse CmfFgpResponse
+	err = json.Unmarshal(data, &cmfFgpResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter subjectType "user"
+	cmfFgpResponse.PermissionStatements = cmfFgpFilter(cmfFgpResponse.PermissionStatements,
+		func(perm *CmfFgpPermStatement) bool {
+			return perm.SubjectType != "user"
+		})
+
+	return &cmfFgpResponse, nil
+}
+
+type CmfFgpResponse struct {
+	PermissionStatements []CmfFgpPermStatement `json:"permissionStatements"`
+}
+
+type CmfFgpRequest struct {
+	PermissionStatements []CmfFgpPermStatement `json:"permissionStatementDefinitions"`
+}
+
+type CmfFgpIdentifier struct {
+	SubjectId   string `json:"subjectId"`
+	SubjectType string `json:"subjectType"`
+	TargetId    string `json:"targetId"`
+}
+
+// CmfFgpPermStatement is used to handle JSON Marshal and Unmarshal
+// for both FGP Request and FGP Response
+// Under FGP Response, those "createdAt", "createdBy", "modifiedAt", "modifiedBy" fields
+// would be ignored.
+type CmfFgpPermStatement struct {
+	SubjectId   string   `json:"subjectId"`
+	SubjectType string   `json:"subjectType"`
+	TargetId    string   `json:"targetId"`
+	Permissions []string `json:"permissions"`
+}
+
+func CmfFgpPermStmtSetEqual(permStmts01 []CmfFgpPermStatement, permStmts02 []CmfFgpPermStatement) bool {
+	permStmtMap01 := cmfFgpPermStmtsToPermStmtMap(permStmts01)
+	permStmtMap02 := cmfFgpPermStmtsToPermStmtMap(permStmts02)
+	if len(permStmtMap01) != len(permStmtMap02) {
+		return false
+	}
+	for k, v01 := range permStmtMap01 {
+		v02, ok := permStmtMap02[k]
+		if ok {
+			if !cmfFgpStringSetEqual(v01.Permissions, v02.Permissions) {
+				return false
+			}
+		} else {
+			return false
+		}
+	}
+	return true
+}
+
+func (permStmt *CmfFgpPermStatement) ToCmfFgpIdentifier() CmfFgpIdentifier {
+	return CmfFgpIdentifier{
+		SubjectId:   permStmt.SubjectId,
+		SubjectType: permStmt.SubjectType,
+		TargetId:    permStmt.TargetId,
+	}
+}
+
+func cmfFgpFilter(arr []CmfFgpPermStatement, cond func(*CmfFgpPermStatement) bool) []CmfFgpPermStatement {
+	result := []CmfFgpPermStatement{}
+	for i := range arr {
+		if cond(&(arr[i])) {
+			result = append(result, arr[i])
+		}
+	}
+	return result
+}
+
+func cmfFgpStringSetEqual(strs01 []string, strs02 []string) bool {
+	strmap01 := cmfFgpToStringMap(strs01)
+	strmap02 := cmfFgpToStringMap(strs02)
+
+	if len(strmap01) != len(strmap02) {
+		return false
+	}
+	for k := range strmap01 {
+		if !strmap02[k] {
+			return false
+		}
+	}
+	return true
+}
+
+func cmfFgpPermStmtsToPermStmtMap(permStmts []CmfFgpPermStatement) map[CmfFgpIdentifier]CmfFgpPermStatement {
+	stmtMap := make(map[CmfFgpIdentifier]CmfFgpPermStatement)
+	for _, v := range permStmts {
+		stmtMap[v.ToCmfFgpIdentifier()] = v
+	}
+	return stmtMap
+}
+
+func cmfFgpToStringMap(strs []string) map[string]bool {
+	strmap := make(map[string]bool)
+	for _, v := range strs {
+		strmap[v] = true
+	}
+	return strmap
+}
+
+// Under FGP Request:
+/*
+	{
+		"targetId": "0000000000121E9E",
+		"subjectType": "org",
+		"subjectId": "0000000006B11645",
+		"permissions": ["Read"]
+	}
+*/
+// Under FGP Response:
+/*
+	{
+		"permissions": ["Read"],
+		"subjectType": "org",
+		"subjectId": "0000000006B11645",
+		"targetId": "0000000000121E9E",
+		"createdAt": "2022-04-27T17:33:53.194Z",
+		"createdBy": "0000000006D5CC14",
+		"modifiedAt": "2022-04-27T17:33:53.194Z",
+		"modifiedBy": "0000000006D5CC14"
+	}
+*/

--- a/sumologic/sumologic_cmffgp_reslib.go
+++ b/sumologic/sumologic_cmffgp_reslib.go
@@ -1,0 +1,123 @@
+package sumologic
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func GetCmfFgpPermStmtSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"subject_id": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		"subject_type": {
+			Type:         schema.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringInSlice([]string{"role", "org"}, false),
+		},
+		"permissions": {
+			Type: schema.TypeSet,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+				ValidateFunc: validation.StringInSlice(
+					[]string{"Create", "Read", "Update", "Delete", "Manage"}, false),
+			},
+			Required: true,
+		},
+	}
+}
+
+func GetCmfFgpObjPermSetSchema() *schema.Schema {
+	return &schema.Schema{
+		Type: schema.TypeSet,
+		Elem: &schema.Resource{
+			Schema: GetCmfFgpPermStmtSchema(),
+		},
+		// NOTE(2022-05-04): ValidateFunc is not yet supported on lists or sets
+		Optional: true,
+	}
+}
+
+func ResourceToCmfFgpPermStmts(d *schema.ResourceData, targetId string) ([]CmfFgpPermStatement, error) {
+	permStmtResourceList := d.Get("obj_permission").(*schema.Set).List()
+
+	var result []CmfFgpPermStatement
+	for i := range permStmtResourceList {
+		permStmtMap := permStmtResourceList[i].(map[string]interface{})
+
+		result = append(result,
+			CmfFgpPermStatement{
+				SubjectId:   permStmtMap["subject_id"].(string),
+				SubjectType: permStmtMap["subject_type"].(string),
+				TargetId:    targetId,
+				Permissions: permissionSetToStringArray(permStmtMap["permissions"]),
+			})
+	}
+
+	// The following logic should be moved to a ValidateFunc, once ValidateFunc is supported for TypeSet
+	tfResourcePermIDSet := make(map[CmfFgpIdentifier]bool)
+	for i := range result {
+		fgpIdentifier := result[i].ToCmfFgpIdentifier()
+		if tfResourcePermIDSet[fgpIdentifier] {
+			return nil, fmt.Errorf("duplicated FGP Stmts involving %+v", fgpIdentifier)
+		} else {
+			tfResourcePermIDSet[fgpIdentifier] = true
+		}
+	}
+
+	return result, nil
+}
+
+func CmfFgpPermStmtsSetToResource(d *schema.ResourceData, permStmts []CmfFgpPermStatement) {
+
+	var permStmtResources []map[string]interface{}
+	for i := range permStmts {
+		permStmt := permStmts[i]
+		permStmtResource := make(map[string]interface{})
+		permStmtResource["subject_id"] = permStmt.SubjectId
+		permStmtResource["subject_type"] = permStmt.SubjectType
+		permStmtResource["permissions"] = permStmt.Permissions
+		permStmtResources = append(permStmtResources, permStmtResource)
+	}
+	d.Set("obj_permission", permStmtResources)
+}
+
+func ReconcileFgpPermStmtsWithEmptyPerms(tfResourcePermStmts []CmfFgpPermStatement,
+	readPermStmts []CmfFgpPermStatement) []CmfFgpPermStatement {
+	tfResourcePermIDSet := make(map[CmfFgpIdentifier]bool)
+	for i := range tfResourcePermStmts {
+		tfResourcePermIDSet[tfResourcePermStmts[i].ToCmfFgpIdentifier()] = true
+	}
+	var emptyPermStmts []CmfFgpPermStatement
+	for i := range readPermStmts {
+		readPermStmt := readPermStmts[i]
+		if !tfResourcePermIDSet[readPermStmt.ToCmfFgpIdentifier()] {
+			emptyPermStmts = append(emptyPermStmts,
+				CmfFgpPermStatement{
+					SubjectId:   readPermStmt.SubjectId,
+					SubjectType: readPermStmt.SubjectType,
+					TargetId:    readPermStmt.TargetId,
+					Permissions: make([]string, 0),
+					// using empty "Permissions" array to effectively revoke FGP for this Subject
+				})
+		}
+	}
+	if len(emptyPermStmts) == 0 {
+		return tfResourcePermStmts
+	} else {
+		return append(tfResourcePermStmts, emptyPermStmts...)
+	}
+
+}
+
+func permissionSetToStringArray(permSetIntf interface{}) []string {
+	permIntfList := permSetIntf.(*schema.Set).List()
+	result := make([]string, len(permIntfList))
+	for i := range permIntfList {
+		result[i] = permIntfList[i].(string)
+	}
+	return result
+}


### PR DESCRIPTION
SUMO-164539: adding TF support for CMF FGP under Monitor Folder

Related Test Cases added:  (updated test run: 2022/05/09 13:58:55 PST)
```
go test -v -run TestAccSumologicMonitorsLibraryFolder
2022/05/09 13:58:55 Sumo Logic Terraform Provider Version=
=== RUN   TestAccSumologicMonitorsLibraryFolder_fgpSchemaValidations
--- PASS: TestAccSumologicMonitorsLibraryFolder_fgpSchemaValidations (0.06s)
=== RUN   TestAccSumologicMonitorsLibraryFolder_createWithFGP
--- PASS: TestAccSumologicMonitorsLibraryFolder_createWithFGP (8.09s)
=== RUN   TestAccSumologicMonitorsLibraryFolder_updateWithFGP
--- PASS: TestAccSumologicMonitorsLibraryFolder_updateWithFGP (12.80s)
=== RUN   TestAccSumologicMonitorsLibraryFolder_driftingCorrectionFGP
--- PASS: TestAccSumologicMonitorsLibraryFolder_driftingCorrectionFGP (13.44s)
PASS
ok  	github.com/SumoLogic/terraform-provider-sumologic/sumologic	34.692s
```
