### PR TITLE
INVS-278: Fix CSE match list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 2.16.0 (Unreleased)
 
+## 2.15.1 (Unreleased)
+
+BUG FIXES:
+* Fix bug in cse match list items creation (was timing out due to StateChangeConf on an infinite loop) (GH-377)
 
 ## 2.15.0 (May 13, 2022)
 

--- a/sumologic/sumologic_cse_match_list_item.go
+++ b/sumologic/sumologic_cse_match_list_item.go
@@ -25,8 +25,7 @@ func (s *Client) GetCSEMatchListItem(id string) (*CSEMatchListItemGet, error) {
 }
 
 func (s *Client) GetCSEMatchListItemsInMatchList(MatchListId string) (*CSEMatchListItemsInMatchListGet, error) {
-
-	data, _, err := s.Get(fmt.Sprintf("sec/v1/match-list-items?listIds[%s]", MatchListId))
+	data, _, err := s.Get(fmt.Sprintf("sec/v1/match-list-items?listIds=%s", MatchListId))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fix bug in cse match list items creation (was timing out due to StateChangeConf on an infinite loop)