### PR TITLE
allow locator field in DefaultDateFormat to be empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 2.17.0 (Unreleased)
 
+BUG FIXES:
+* Allow locator field in DefaultDateFormat to be empty (GH-384)
 
 ## 2.16.0 (May 20, 2022)
 

--- a/sumologic/sumologic_sources.go
+++ b/sumologic/sumologic_sources.go
@@ -34,7 +34,7 @@ type Source struct {
 
 type DefaultDateFormat struct {
 	Format  string `json:"format"`
-	Locator string `json:"locator"`
+	Locator string `json:"locator,omitempty"`
 }
 
 type Filter struct {


### PR DESCRIPTION
Currently specifying the `defaultDateFormats` block without the `locator` ends up in error even though the field is marked as optional [here](https://github.com/SumoLogic/terraform-provider-sumologic/blob/master/sumologic/sumologic_sources.go#L115).

```
│ Error: {
│  "status" : 400,
│  "id" : "xxxxxx",
│  "code" : "collectors.validation.fields.invalid",
│  "message" : "Timestamp locator regex does not contain a single unnamed capture group: ''."
│ }

```

This PR fixes it.
```

resource "sumologic_collector" "collector" {
  name        = "my-collector"
  description = "Just testing this"
}


resource "sumologic_http_source" "http_source" {
    name         = "httpsource"
    collector_id = "${sumologic_collector.collector.id}"
    default_date_formats {
    format = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
    }
}

```