### PR TITLE
Update sumologic_sources.go

### DIFF
--- a/sumologic/sumologic_sources.go
+++ b/sumologic/sumologic_sources.go
@@ -74,7 +74,7 @@ func resourceSumologicSource() *schema.Resource {
 			"timezone": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "Etc/UTC",
+				Default:  nil,
 			},
 			"automatic_date_parsing": {
 				Type:     schema.TypeBool,

--- a/sumologic/sumologic_sources.go
+++ b/sumologic/sumologic_sources.go
@@ -74,7 +74,7 @@ func resourceSumologicSource() *schema.Resource {
 			"timezone": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  nil,
+				Default:  "",
 			},
 			"automatic_date_parsing": {
 				Type:     schema.TypeBool,


### PR DESCRIPTION
Fixes #259. Timezone is an optional field and default should be NIL. When set to NIL the timezone will be taken from the Collector, which is the standard default when a timezone is not set on a source. 