### PR TITLE
Fix code block formatting

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -154,7 +154,7 @@ The following properties are common to ALL sources and can be used to configure 
        regexp = "(\\d{16})"
        mask = "MaskedID"
      }
-    ```  
+  ```  
 - `cutoff_timestamp` - (Optional) Only collect data more recent than this timestamp, specified as milliseconds since epoch (13 digit). 
 - `cutoff_relative_time` - (Optional) Can be specified instead of cutoffTimestamp to provide a relative offset with respect to the current time. Example: use -1h, -1d, or -1w to collect data that's less than one hour, one day, or one week old, respectively.
 - `fields` - (Optional) Map containing key/value pairs.


### PR DESCRIPTION
Fix improper indenting of the closing ticks around the Filter usage code block, which is leading to improper formatting within the terraform doc pages.