### PR TITLE
Adding Jira webhook_type to connections docs

### DIFF
--- a/website/docs/r/connection.html.markdown
+++ b/website/docs/r/connection.html.markdown
@@ -49,7 +49,7 @@ The following arguments are supported:
 - `custom_headers` - (Optional) Map of custom webhook headers
 - `default_payload` - (Required) Default payload of the webhook.
 - `connection_subtype` - (Optional) The subtype of the connection. Valid values are `Incident` and `Event`. NOTE: This is only used for the `ServiceNow` webhook type.
-- `webhook_type` - (Optional) Type of webhook. Valid values are `AWSLambda`, `Azure`, `Datadog`, `HipChat`, `PagerDuty`, `Slack`, `Webhook`, `NewRelic`, `MicrosoftTeams`, `ServiceNow`, and `SumoCloudSOAR`. Default: `Webhook`
+- `webhook_type` - (Optional) Type of webhook. Valid values are `AWSLambda`, `Azure`, `Datadog`, `HipChat`, `Jira`, `PagerDuty`, `Slack`, `Webhook`, `NewRelic`, `MicrosoftTeams`, `ServiceNow`, and `SumoCloudSOAR`. Default: `Webhook`
 
 Additional data provided in state
 


### PR DESCRIPTION
It is just missing in the documentation. Validations already support it:
```
ValidateFunc: validation.StringInSlice([]string{"AWSLambda", "Azure", "Datadog", "HipChat", "PagerDuty", "Slack", "Webhook", "NewRelic", "Jira", "Opsgenie", "MicrosoftTeams", "ServiceNow", "SumoCloudSOAR"}, false)
```
(from `./sumologic/resource_sumologic_connection.go`)