### PR TITLE
Refactor ResolvableTimeRange into a util class

### DIFF
--- a/sumologic/resource_sumologic_dashboard.go
+++ b/sumologic/resource_sumologic_dashboard.go
@@ -8,25 +8,6 @@ import (
 )
 
 var (
-	validCompleteLiteralTimeRangeValues = []string{
-		"today",
-		"yesterday",
-		"previous_week",
-		"previous_month",
-	}
-
-	validLiteralTimeRangeValues = []string{
-		"now",
-		"second",
-		"minute",
-		"hour",
-		"day",
-		"today",
-		"week",
-		"month",
-		"year",
-	}
-
 	validMetricsAggregationDataValues = []string{
 		"Count",
 		"Minimum",
@@ -105,7 +86,7 @@ func resourceSumologicDashboard() *schema.Resource {
 				Required: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
-					Schema: getTimeRangeSchema(),
+					Schema: GetTimeRangeSchema(),
 				},
 			},
 			"panel": {
@@ -231,7 +212,7 @@ func getSumoSearchPanelSchema() map[string]*schema.Schema {
 			Optional: true,
 			MaxItems: 1,
 			Elem: &schema.Resource{
-				Schema: getTimeRangeSchema(),
+				Schema: GetTimeRangeSchema(),
 			},
 		},
 		"coloring_rule": {
@@ -546,122 +527,11 @@ func getColoringRulesSchema() map[string]*schema.Schema {
 	}
 }
 
-func getTimeRangeSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		"complete_literal_time_range": {
-			Type:     schema.TypeList,
-			Optional: true,
-			MaxItems: 1,
-			Elem: &schema.Resource{
-				Schema: getCompleteLiteralTimeRangeSchema(),
-			},
-		},
-		"begin_bounded_time_range": {
-			Type:     schema.TypeList,
-			Optional: true,
-			MaxItems: 1,
-			Elem: &schema.Resource{
-				Schema: getBeginBoundedTimeRangeSchema(),
-			},
-		},
-	}
-}
-
-func getCompleteLiteralTimeRangeSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		"range_name": {
-			Type:         schema.TypeString,
-			Required:     true,
-			ValidateFunc: validation.StringInSlice(validCompleteLiteralTimeRangeValues, false),
-		},
-	}
-}
-
-func getBeginBoundedTimeRangeSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		"from": {
-			Type:     schema.TypeList,
-			Required: true,
-			MaxItems: 1,
-			Elem: &schema.Resource{
-				Schema: getTimeRangeBoundarySchema(),
-			},
-		},
-		"to": {
-			Type:     schema.TypeList,
-			Optional: true,
-			MaxItems: 1,
-			Elem: &schema.Resource{
-				Schema: getTimeRangeBoundarySchema(),
-			},
-		},
-	}
-}
-
-func getTimeRangeBoundarySchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		"epoch_time_range": {
-			Type:     schema.TypeList,
-			Optional: true,
-			MaxItems: 1,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"epoch_millis": {
-						Type:     schema.TypeInt,
-						Required: true,
-					},
-				},
-			},
-		},
-		"iso8601_time_range": {
-			Type:     schema.TypeList,
-			Optional: true,
-			MaxItems: 1,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"iso8601_time": {
-						Type:         schema.TypeString,
-						Required:     true,
-						ValidateFunc: validation.IsRFC3339Time,
-					},
-				},
-			},
-		},
-		"literal_time_range": {
-			Type:     schema.TypeList,
-			Optional: true,
-			MaxItems: 1,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"range_name": {
-						Type:         schema.TypeString,
-						Required:     true,
-						ValidateFunc: validation.StringInSlice(validLiteralTimeRangeValues, false),
-					},
-				},
-			},
-		},
-		"relative_time_range": {
-			Type:     schema.TypeList,
-			Optional: true,
-			MaxItems: 1,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"relative_time": {
-						Type:     schema.TypeString,
-						Required: true,
-					},
-				},
-			},
-		},
-	}
-}
-
 func resourceToDashboard(d *schema.ResourceData) Dashboard {
 	var timeRange interface{}
 	if val, ok := d.GetOk("time_range"); ok {
 		tfTimeRange := val.([]interface{})[0]
-		timeRange = getTimeRange(tfTimeRange.(map[string]interface{}))
+		timeRange = GetTimeRange(tfTimeRange.(map[string]interface{}))
 	}
 
 	var topologyLabel *TopologyLabel
@@ -774,7 +644,7 @@ func getSumoSearchPanel(tfSearchPanel map[string]interface{}) interface{} {
 	}
 	if val := tfSearchPanel["time_range"].([]interface{}); len(val) == 1 {
 		tfTimeRange := val[0]
-		searchPanel.TimeRange = getTimeRange(tfTimeRange.(map[string]interface{}))
+		searchPanel.TimeRange = GetTimeRange(tfTimeRange.(map[string]interface{}))
 	}
 
 	tfQueries := tfSearchPanel["query"].([]interface{})
@@ -884,72 +754,6 @@ func getMetricsQueryOperator(tfQueryOperator map[string]interface{}) MetricsQuer
 	operator.Parameters = parameters
 
 	return operator
-}
-
-func getTimeRange(tfTimeRange map[string]interface{}) interface{} {
-	if val := tfTimeRange["complete_literal_time_range"].([]interface{}); len(val) == 1 {
-		if literalRange, ok := val[0].(map[string]interface{}); ok {
-			return CompleteLiteralTimeRange{
-				Type:      "CompleteLiteralTimeRange",
-				RangeName: literalRange["range_name"].(string),
-			}
-		}
-	} else if val := tfTimeRange["begin_bounded_time_range"].([]interface{}); len(val) == 1 {
-		if boundedRange, ok := val[0].(map[string]interface{}); ok {
-			from := boundedRange["from"].([]interface{})
-			boundaryStart := from[0].(map[string]interface{})
-			var boundaryEnd map[string]interface{}
-			if to := boundedRange["to"].([]interface{}); len(to) == 1 {
-				boundaryEnd = to[0].(map[string]interface{})
-			}
-
-			return BeginBoundedTimeRange{
-				Type: "BeginBoundedTimeRange",
-				From: getTimeRangeBoundary(boundaryStart),
-				To:   getTimeRangeBoundary(boundaryEnd),
-			}
-		}
-	}
-
-	return nil
-}
-
-func getTimeRangeBoundary(tfRangeBoundary map[string]interface{}) interface{} {
-	if len(tfRangeBoundary) == 0 {
-		return nil
-	}
-
-	if val := tfRangeBoundary["epoch_time_range"].([]interface{}); len(val) == 1 {
-		if epochBoundary, ok := val[0].(map[string](interface{})); ok {
-			return EpochTimeRangeBoundary{
-				Type:        "EpochTimeRangeBoundary",
-				EpochMillis: int64(epochBoundary["epoch_millis"].(int)),
-			}
-		}
-	} else if val := tfRangeBoundary["iso8601_time_range"].([]interface{}); len(val) == 1 {
-		if iso8601Boundary, ok := val[0].(map[string](interface{})); ok {
-			return Iso8601TimeRangeBoundary{
-				Type:        "Iso8601TimeRangeBoundary",
-				Iso8601Time: iso8601Boundary["iso8601_time"].(string),
-			}
-		}
-	} else if val := tfRangeBoundary["literal_time_range"].([]interface{}); len(val) == 1 {
-		if literalBoundary, ok := val[0].(map[string](interface{})); ok {
-			return LiteralTimeRangeBoundary{
-				Type:      "LiteralTimeRangeBoundary",
-				RangeName: literalBoundary["range_name"].(string),
-			}
-		}
-	} else if val := tfRangeBoundary["relative_time_range"].([]interface{}); len(val) == 1 {
-		if relativeBoundary, ok := val[0].(map[string](interface{})); ok {
-			return RelativeTimeRangeBoundary{
-				Type:         "RelativeTimeRangeBoundary",
-				RelativeTime: relativeBoundary["relative_time"].(string),
-			}
-		}
-	}
-
-	return nil
 }
 
 func getTopologyLabel(tfTopologyLabel map[string]interface{}) *TopologyLabel {
@@ -1122,7 +926,7 @@ func setDashboard(d *schema.ResourceData, dashboard *Dashboard) error {
 		return err
 	}
 
-	timeRange := getTerraformTimeRange(dashboard.TimeRange.(map[string]interface{}))
+	timeRange := GetTerraformTimeRange(dashboard.TimeRange.(map[string]interface{}))
 	if err := d.Set("time_range", timeRange); err != nil {
 		return err
 	}
@@ -1162,14 +966,6 @@ func setDashboard(d *schema.ResourceData, dashboard *Dashboard) error {
 	return nil
 }
 
-type TerraformObject [1]map[string]interface{}
-
-func makeTerraformObject() TerraformObject {
-	terraformObject := [1]map[string]interface{}{}
-	terraformObject[0] = make(map[string]interface{})
-	return terraformObject
-}
-
 func getTerraformTopologyLabel(topologyLabel *TopologyLabel) []map[string]interface{} {
 	// API returns an empty data map if we don't set topologyLabelMap.
 	if len(topologyLabel.Data) == 0 {
@@ -1191,58 +987,6 @@ func getTerraformTopologyLabel(topologyLabel *TopologyLabel) []map[string]interf
 	return tfTopologyLabel
 }
 
-func getTerraformTimeRange(timeRange map[string]interface{}) []map[string]interface{} {
-	tfTimeRange := []map[string]interface{}{}
-	tfTimeRange = append(tfTimeRange, make(map[string]interface{}))
-
-	if timeRange["type"] == "BeginBoundedTimeRange" {
-		boundedTimeRange := makeTerraformObject()
-
-		from := timeRange["from"].(map[string]interface{})
-		rangeBoundary := getTerraformTimeRangeBoundary(from)
-		boundedTimeRange[0]["from"] = rangeBoundary
-
-		if to := timeRange["to"]; to != nil {
-			rangeBoundary := getTerraformTimeRangeBoundary(to.(map[string]interface{}))
-			boundedTimeRange[0]["to"] = rangeBoundary
-		}
-
-		tfTimeRange[0]["begin_bounded_time_range"] = boundedTimeRange
-	} else if timeRange["type"] == "CompleteLiteralTimeRange" {
-		rangeName := timeRange["rangeName"]
-
-		completeLiteralTimeRange := makeTerraformObject()
-		completeLiteralTimeRange[0]["range_name"] = rangeName
-		tfTimeRange[0]["complete_literal_time_range"] = completeLiteralTimeRange
-	}
-
-	return tfTimeRange
-}
-
-func getTerraformTimeRangeBoundary(timeRangeBoundary map[string]interface{}) TerraformObject {
-	tfTimeRangeBoundary := makeTerraformObject()
-
-	if timeRangeBoundary["type"] == "RelativeTimeRangeBoundary" {
-		relativeRange := makeTerraformObject()
-		relativeRange[0]["relative_time"] = timeRangeBoundary["relativeTime"]
-		tfTimeRangeBoundary[0]["relative_time_range"] = relativeRange
-	} else if timeRangeBoundary["type"] == "EpochTimeRangeBoundary" {
-		epochRange := makeTerraformObject()
-		epochRange[0]["epoch_millis"] = timeRangeBoundary["epochMillis"]
-		tfTimeRangeBoundary[0]["epoch_time_range"] = epochRange
-	} else if timeRangeBoundary["type"] == "Iso8601TimeRangeBoundary" {
-		iso8601Range := makeTerraformObject()
-		iso8601Range[0]["iso8601_time"] = timeRangeBoundary["iso8601Time"]
-		tfTimeRangeBoundary[0]["iso8601_time_range"] = iso8601Range
-	} else if timeRangeBoundary["type"] == "LiteralTimeRangeBoundary" {
-		literalRange := makeTerraformObject()
-		literalRange[0]["range_name"] = timeRangeBoundary["rangeName"]
-		tfTimeRangeBoundary[0]["literal_time_range"] = literalRange
-	}
-
-	return tfTimeRangeBoundary
-}
-
 func getTerraformPanels(panels []interface{}) []map[string]interface{} {
 	tfPanels := make([]map[string]interface{}, len(panels))
 
@@ -1262,7 +1006,7 @@ func getTerraformPanels(panels []interface{}) []map[string]interface{} {
 }
 
 func getTerraformTextPanel(textPanel map[string]interface{}) TerraformObject {
-	tfTextPanel := makeTerraformObject()
+	tfTextPanel := MakeTerraformObject()
 
 	tfTextPanel[0]["key"] = textPanel["key"]
 	if title, ok := textPanel["title"]; ok {
@@ -1280,7 +1024,7 @@ func getTerraformTextPanel(textPanel map[string]interface{}) TerraformObject {
 }
 
 func getTerraformSearchPanel(searchPanel map[string]interface{}) TerraformObject {
-	tfSearchPanel := makeTerraformObject()
+	tfSearchPanel := MakeTerraformObject()
 
 	tfSearchPanel[0]["key"] = searchPanel["key"]
 	if title, ok := searchPanel["title"]; ok {
@@ -1298,10 +1042,10 @@ func getTerraformSearchPanel(searchPanel map[string]interface{}) TerraformObject
 		tfSearchPanel[0]["description"] = description
 	}
 	if timeRange := searchPanel["timeRange"]; timeRange != nil {
-		tfSearchPanel[0]["time_range"] = getTerraformTimeRange(timeRange.(map[string]interface{}))
+		tfSearchPanel[0]["time_range"] = GetTerraformTimeRange(timeRange.(map[string]interface{}))
 	}
 	if coloringRules := searchPanel["coloringRules"]; coloringRules != nil {
-		tfSearchPanel[0]["coloring_rule"] = getTerraformTimeRange(coloringRules.(map[string]interface{}))
+		tfSearchPanel[0]["coloring_rule"] = GetTerraformTimeRange(coloringRules.(map[string]interface{}))
 	}
 	if linkedDashboards := searchPanel["linkedDashboards"]; linkedDashboards != nil {
 		tfSearchPanel[0]["linked_dashboard"] = getTerraformLinkedDashboards(linkedDashboards.([]interface{}))
@@ -1331,7 +1075,7 @@ func getTerraformSearchPanelQuery(queries []interface{}) []map[string]interface{
 }
 
 func getTerraformMetricsQueryDataScheme(queryData map[string]interface{}) TerraformObject {
-	tfMetricsQueryData := makeTerraformObject()
+	tfMetricsQueryData := MakeTerraformObject()
 
 	tfMetricsQueryData[0]["metric"] = queryData["metric"]
 	if aggregationType, ok := queryData["aggregationType"]; ok {
@@ -1402,7 +1146,7 @@ func getTerraformLayout(layout map[string]interface{}) []map[string]interface{} 
 	tfLayout = append(tfLayout, make(map[string]interface{}))
 
 	if layout["layoutType"] == "Grid" {
-		gridLayout := makeTerraformObject()
+		gridLayout := MakeTerraformObject()
 
 		layoutStructures := layout["layoutStructures"].([]interface{})
 		tfLayoutStructures := make([]map[string]interface{}, len(layoutStructures))
@@ -1435,19 +1179,19 @@ func getTerraformVariables(variables []Variable) []map[string]interface{} {
 }
 
 func getTerraformVariableSourceDefinition(sourceDefinition map[string]interface{}) TerraformObject {
-	tfSourceDefinition := makeTerraformObject()
+	tfSourceDefinition := MakeTerraformObject()
 
 	if sourceDefinition["variableSourceType"] == "MetadataVariableSourceDefinition" {
-		metadataDefinition := makeTerraformObject()
+		metadataDefinition := MakeTerraformObject()
 		metadataDefinition[0]["filter"] = sourceDefinition["filter"]
 		metadataDefinition[0]["key"] = sourceDefinition["key"]
 		tfSourceDefinition[0]["metadata_variable_source_definition"] = metadataDefinition
 	} else if sourceDefinition["variableSourceType"] == "CsvVariableSourceDefinition" {
-		csvDefinition := makeTerraformObject()
+		csvDefinition := MakeTerraformObject()
 		csvDefinition[0]["values"] = sourceDefinition["values"]
 		tfSourceDefinition[0]["csv_variable_source_definition"] = csvDefinition
 	} else if sourceDefinition["variableSourceType"] == "LogQueryVariableSourceDefinition" {
-		logQueryDefinition := makeTerraformObject()
+		logQueryDefinition := MakeTerraformObject()
 		logQueryDefinition[0]["query"] = sourceDefinition["query"]
 		logQueryDefinition[0]["field"] = sourceDefinition["field"]
 		tfSourceDefinition[0]["log_query_variable_source_definition"] = logQueryDefinition

--- a/sumologic/sumologic_dashboard.go
+++ b/sumologic/sumologic_dashboard.go
@@ -72,38 +72,6 @@ type TopologyLabel struct {
 	Data map[string][]string `json:"data"`
 }
 
-// TimeRange related structs
-type CompleteLiteralTimeRange struct {
-	Type      string `json:"type"`
-	RangeName string `json:"rangeName"`
-}
-
-type BeginBoundedTimeRange struct {
-	Type string      `json:"type"`
-	From interface{} `json:"from"`
-	To   interface{} `json:"to"`
-}
-
-type RelativeTimeRangeBoundary struct {
-	Type         string `json:"type"`
-	RelativeTime string `json:"relativeTime"`
-}
-
-type EpochTimeRangeBoundary struct {
-	Type        string `json:"type"`
-	EpochMillis int64  `json:"epochMillis"`
-}
-
-type Iso8601TimeRangeBoundary struct {
-	Type        string `json:"type"`
-	Iso8601Time string `json:"iso8601Time"`
-}
-
-type LiteralTimeRangeBoundary struct {
-	Type      string `json:"type"`
-	RangeName string `json:"rangeName"`
-}
-
 // Panel related structs
 type TextPanel struct {
 	Id                                     string `json:"id,omitempty"`

--- a/sumologic/util.go
+++ b/sumologic/util.go
@@ -1,0 +1,296 @@
+package sumologic
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+var (
+	ValidCompleteLiteralTimeRangeValues = []string{
+		"today",
+		"yesterday",
+		"previous_week",
+		"previous_month",
+	}
+
+	ValidLiteralTimeRangeValues = []string{
+		"now",
+		"second",
+		"minute",
+		"hour",
+		"day",
+		"today",
+		"week",
+		"month",
+		"year",
+	}
+)
+
+type TerraformObject [1]map[string]interface{}
+
+// TimeRange related structs
+type CompleteLiteralTimeRange struct {
+	Type      string `json:"type"`
+	RangeName string `json:"rangeName"`
+}
+
+type BeginBoundedTimeRange struct {
+	Type string      `json:"type"`
+	From interface{} `json:"from"`
+	To   interface{} `json:"to"`
+}
+
+type RelativeTimeRangeBoundary struct {
+	Type         string `json:"type"`
+	RelativeTime string `json:"relativeTime"`
+}
+
+type EpochTimeRangeBoundary struct {
+	Type        string `json:"type"`
+	EpochMillis int64  `json:"epochMillis"`
+}
+
+type Iso8601TimeRangeBoundary struct {
+	Type        string `json:"type"`
+	Iso8601Time string `json:"iso8601Time"`
+}
+
+type LiteralTimeRangeBoundary struct {
+	Type      string `json:"type"`
+	RangeName string `json:"rangeName"`
+}
+
+func MakeTerraformObject() TerraformObject {
+	terraformObject := [1]map[string]interface{}{}
+	terraformObject[0] = make(map[string]interface{})
+	return terraformObject
+}
+
+func GetTimeRangeSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"complete_literal_time_range": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: GetCompleteLiteralTimeRangeSchema(),
+			},
+		},
+		"begin_bounded_time_range": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: GetBeginBoundedTimeRangeSchema(),
+			},
+		},
+	}
+}
+
+func GetCompleteLiteralTimeRangeSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"range_name": {
+			Type:         schema.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringInSlice(ValidCompleteLiteralTimeRangeValues, false),
+		},
+	}
+}
+
+func GetBeginBoundedTimeRangeSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"from": {
+			Type:     schema.TypeList,
+			Required: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: GetTimeRangeBoundarySchema(),
+			},
+		},
+		"to": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: GetTimeRangeBoundarySchema(),
+			},
+		},
+	}
+}
+
+func GetTimeRangeBoundarySchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"epoch_time_range": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"epoch_millis": {
+						Type:     schema.TypeInt,
+						Required: true,
+					},
+				},
+			},
+		},
+		"iso8601_time_range": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"iso8601_time": {
+						Type:         schema.TypeString,
+						Required:     true,
+						ValidateFunc: validation.IsRFC3339Time,
+					},
+				},
+			},
+		},
+		"literal_time_range": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"range_name": {
+						Type:         schema.TypeString,
+						Required:     true,
+						ValidateFunc: validation.StringInSlice(ValidLiteralTimeRangeValues, false),
+					},
+				},
+			},
+		},
+		"relative_time_range": {
+			Type:     schema.TypeList,
+			Optional: true,
+			MaxItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"relative_time": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+				},
+			},
+		},
+	}
+}
+
+func GetTerraformTimeRange(timeRange map[string]interface{}) []map[string]interface{} {
+	tfTimeRange := []map[string]interface{}{}
+	tfTimeRange = append(tfTimeRange, make(map[string]interface{}))
+
+	if timeRange["type"] == "BeginBoundedTimeRange" {
+		boundedTimeRange := MakeTerraformObject()
+
+		from := timeRange["from"].(map[string]interface{})
+		rangeBoundary := GetTerraformTimeRangeBoundary(from)
+		boundedTimeRange[0]["from"] = rangeBoundary
+
+		if to := timeRange["to"]; to != nil {
+			rangeBoundary := GetTerraformTimeRangeBoundary(to.(map[string]interface{}))
+			boundedTimeRange[0]["to"] = rangeBoundary
+		}
+
+		tfTimeRange[0]["begin_bounded_time_range"] = boundedTimeRange
+	} else if timeRange["type"] == "CompleteLiteralTimeRange" {
+		rangeName := timeRange["rangeName"]
+
+		completeLiteralTimeRange := MakeTerraformObject()
+		completeLiteralTimeRange[0]["range_name"] = rangeName
+		tfTimeRange[0]["complete_literal_time_range"] = completeLiteralTimeRange
+	}
+
+	return tfTimeRange
+}
+
+func GetTerraformTimeRangeBoundary(timeRangeBoundary map[string]interface{}) TerraformObject {
+	tfTimeRangeBoundary := MakeTerraformObject()
+
+	if timeRangeBoundary["type"] == "RelativeTimeRangeBoundary" {
+		relativeRange := MakeTerraformObject()
+		relativeRange[0]["relative_time"] = timeRangeBoundary["relativeTime"]
+		tfTimeRangeBoundary[0]["relative_time_range"] = relativeRange
+	} else if timeRangeBoundary["type"] == "EpochTimeRangeBoundary" {
+		epochRange := MakeTerraformObject()
+		epochRange[0]["epoch_millis"] = timeRangeBoundary["epochMillis"]
+		tfTimeRangeBoundary[0]["epoch_time_range"] = epochRange
+	} else if timeRangeBoundary["type"] == "Iso8601TimeRangeBoundary" {
+		iso8601Range := MakeTerraformObject()
+		iso8601Range[0]["iso8601_time"] = timeRangeBoundary["iso8601Time"]
+		tfTimeRangeBoundary[0]["iso8601_time_range"] = iso8601Range
+	} else if timeRangeBoundary["type"] == "LiteralTimeRangeBoundary" {
+		literalRange := MakeTerraformObject()
+		literalRange[0]["range_name"] = timeRangeBoundary["rangeName"]
+		tfTimeRangeBoundary[0]["literal_time_range"] = literalRange
+	}
+
+	return tfTimeRangeBoundary
+}
+
+func GetTimeRange(tfTimeRange map[string]interface{}) interface{} {
+	if val := tfTimeRange["complete_literal_time_range"].([]interface{}); len(val) == 1 {
+		if literalRange, ok := val[0].(map[string]interface{}); ok {
+			return CompleteLiteralTimeRange{
+				Type:      "CompleteLiteralTimeRange",
+				RangeName: literalRange["range_name"].(string),
+			}
+		}
+	} else if val := tfTimeRange["begin_bounded_time_range"].([]interface{}); len(val) == 1 {
+		if boundedRange, ok := val[0].(map[string]interface{}); ok {
+			from := boundedRange["from"].([]interface{})
+			boundaryStart := from[0].(map[string]interface{})
+			var boundaryEnd map[string]interface{}
+			if to := boundedRange["to"].([]interface{}); len(to) == 1 {
+				boundaryEnd = to[0].(map[string]interface{})
+			}
+
+			return BeginBoundedTimeRange{
+				Type: "BeginBoundedTimeRange",
+				From: GetTimeRangeBoundary(boundaryStart),
+				To:   GetTimeRangeBoundary(boundaryEnd),
+			}
+		}
+	}
+
+	return nil
+}
+
+func GetTimeRangeBoundary(tfRangeBoundary map[string]interface{}) interface{} {
+	if len(tfRangeBoundary) == 0 {
+		return nil
+	}
+
+	if val := tfRangeBoundary["epoch_time_range"].([]interface{}); len(val) == 1 {
+		if epochBoundary, ok := val[0].(map[string](interface{})); ok {
+			return EpochTimeRangeBoundary{
+				Type:        "EpochTimeRangeBoundary",
+				EpochMillis: int64(epochBoundary["epoch_millis"].(int)),
+			}
+		}
+	} else if val := tfRangeBoundary["iso8601_time_range"].([]interface{}); len(val) == 1 {
+		if iso8601Boundary, ok := val[0].(map[string](interface{})); ok {
+			return Iso8601TimeRangeBoundary{
+				Type:        "Iso8601TimeRangeBoundary",
+				Iso8601Time: iso8601Boundary["iso8601_time"].(string),
+			}
+		}
+	} else if val := tfRangeBoundary["literal_time_range"].([]interface{}); len(val) == 1 {
+		if literalBoundary, ok := val[0].(map[string](interface{})); ok {
+			return LiteralTimeRangeBoundary{
+				Type:      "LiteralTimeRangeBoundary",
+				RangeName: literalBoundary["range_name"].(string),
+			}
+		}
+	} else if val := tfRangeBoundary["relative_time_range"].([]interface{}); len(val) == 1 {
+		if relativeBoundary, ok := val[0].(map[string](interface{})); ok {
+			return RelativeTimeRangeBoundary{
+				Type:         "RelativeTimeRangeBoundary",
+				RelativeTime: relativeBoundary["relative_time"].(string),
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Refactoring into a util class so that we can reuse it across multiple resources.

Ran dashboards acceptance tests.
```
=== RUN   TestAccSumologicDashboard_basic
--- PASS: TestAccSumologicDashboard_basic (3.34s)
=== RUN   TestAccSumologicDashboard_create
--- PASS: TestAccSumologicDashboard_create (3.66s)
=== RUN   TestAccSumologicDashboard_update
--- PASS: TestAccSumologicDashboard_update (6.53s)
PASS
ok      github.com/SumoLogic/terraform-provider-sumologic/sumologic     14.436s
```