### PR TITLE
SUMO-200871 fixing the regex for not allowing leading and trailing whitespaces in monitor name and desc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.18.2 (September 1, 2022)
+
+BUG FIXES:
+* Fix bug for validation for monitor name and description regex (GH-428)
+
 ## 2.18.1 (August 31, 2022)
 
 BUG FIXES:

--- a/sumologic/resource_sumologic_monitors_library_monitor.go
+++ b/sumologic/resource_sumologic_monitors_library_monitor.go
@@ -275,7 +275,7 @@ func resourceSumologicMonitorsLibraryMonitor() *schema.Resource {
 			"description": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[^\ ].*[^\ ]$`), "description must not contain leading or trailing spaces"),
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`(?s)^[^\ ].*[^\ ]$`), "description must not contain leading or trailing spaces"),
 			},
 
 			"created_at": {
@@ -332,7 +332,7 @@ func resourceSumologicMonitorsLibraryMonitor() *schema.Resource {
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[^\ ].*[^\ ]$`), "name must not contain leading or trailing spaces"),
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`(?s)^[^\ ].*[^\ ]$`), "name must not contain leading or trailing spaces"),
 			},
 
 			"post_request_map": {


### PR DESCRIPTION
Terraform [regex](https://www.terraform.io/language/functions/regex) doesn't match newline with `.`. It needs a special matching flag for it. Adding it to validation regexes. 