### PR TITLE
INVS-680: Fix hard fail on empty tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 FEATURES:
 * Add new optional `resolution_window` field to resource/sumologic_monitor (GH-418)
 BUG FIXES:
-* cse rules hard failing if passing tags with empty strings. (GH-444)
+* cse rules hard failing if passing tags with empty strings. (GH-445)
 
 ## 2.19.0 (September 20, 2022)
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 2.19.1 (Unreleased)
 FEATURES:
 * Add new optional `resolution_window` field to resource/sumologic_monitor (GH-418)
+BUG FIXES:
+* cse rules hard failing if passing tags with empty strings. (GH-444)
 
 ## 2.19.0 (September 20, 2022)
 FEATURES:

--- a/sumologic/resource_sumologic_cse_aggregation_rule.go
+++ b/sumologic/resource_sumologic_cse_aggregation_rule.go
@@ -2,6 +2,7 @@ package sumologic
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"log"
 )
 
@@ -85,7 +86,8 @@ func resourceSumologicCSEAggregationRule() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Schema{
-					Type: schema.TypeString,
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringIsNotEmpty,
 				},
 			},
 			"trigger_expression": {

--- a/sumologic/resource_sumologic_cse_chain_rule.go
+++ b/sumologic/resource_sumologic_cse_chain_rule.go
@@ -2,6 +2,7 @@ package sumologic
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"log"
 )
 
@@ -73,7 +74,8 @@ func resourceSumologicCSEChainRule() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Schema{
-					Type: schema.TypeString,
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringIsNotEmpty,
 				},
 			},
 			"window_size": {

--- a/sumologic/resource_sumologic_cse_match_rule.go
+++ b/sumologic/resource_sumologic_cse_match_rule.go
@@ -2,6 +2,7 @@ package sumologic
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"log"
 )
 
@@ -50,7 +51,8 @@ func resourceSumologicCSEMatchRule() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Schema{
-					Type: schema.TypeString,
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringIsNotEmpty,
 				},
 			},
 		},

--- a/sumologic/resource_sumologic_cse_threshold_rule.go
+++ b/sumologic/resource_sumologic_cse_threshold_rule.go
@@ -2,6 +2,7 @@ package sumologic
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"log"
 )
 
@@ -69,7 +70,8 @@ func resourceSumologicCSEThresholdRule() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Schema{
-					Type: schema.TypeString,
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringIsNotEmpty,
 				},
 			},
 			"window_size": {

--- a/sumologic/sumologic_cse_rule_common.go
+++ b/sumologic/sumologic_cse_rule_common.go
@@ -71,7 +71,9 @@ func resourceToStringArray(resourceStrings []interface{}) []string {
 	result := make([]string, len(resourceStrings))
 
 	for i, resourceString := range resourceStrings {
-		result[i] = resourceString.(string)
+		if resourceString != nil {
+			result[i] = resourceString.(string)
+		}
 	}
 
 	return result

--- a/sumologic/sumologic_cse_rule_common.go
+++ b/sumologic/sumologic_cse_rule_common.go
@@ -71,9 +71,7 @@ func resourceToStringArray(resourceStrings []interface{}) []string {
 	result := make([]string, len(resourceStrings))
 
 	for i, resourceString := range resourceStrings {
-		if resourceString != nil {
-			result[i] = resourceString.(string)
-		}
+		result[i] = resourceString.(string)
 	}
 
 	return result


### PR DESCRIPTION
In the Go programming language, nil is a zero value. An empty string is the zero value for strings.

```
goroutine 113 [running]:
github.com/SumoLogic/terraform-provider-sumologic/sumologic.resourceToStringArray({0x1400095de40, 0x1, 0x1})
        github.com/SumoLogic/terraform-provider-sumologic/sumologic/sumologic_cse_rule_common.go:74 +0xf0
github.com/SumoLogic/terraform-provider-sumologic/sumologic.resourceSumologicCSEMatchRuleCreate(0x1400021cfc0, {0x101377f80, 0x1400012cd80})
        github.com/SumoLogic/terraform-provider-sumologic/sumologic/resource_sumologic_cse_match_rule.go:114 +0x3f4
github.com/hashicorp/terraform-plugin-sdk/helper/schema.(*Resource).Apply(0x140000adcc0, 0x14000150b90, 0x1400072a8e0, {0x101377f80, 0x1400012cd80})
        github.com/hashicorp/terraform-plugin-sdk@v1.17.2/helper/schema/resource.go:320 +0x528
github.com/hashicorp/terraform-plugin-sdk/helper/schema.(*Provider).Apply(0x1400009c200, 0x1400087ba40, 0x14000150b90, 0x1400072a8e0)
        github.com/hashicorp/terraform-plugin-sdk@v1.17.2/helper/schema/provider.go:294 +0x88
github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin.(*GRPCProviderServer).ApplyResourceChange(0x14000584010, {0x1013a5d70, 0x1400094ab70}, 0x1400021c380)
        github.com/hashicorp/terraform-plugin-sdk@v1.17.2/internal/helper/plugin/grpc_provider.go:895 +0x8cc
github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5._Provider_ApplyResourceChange_Handler({0x10134a7e0, 0x14000584010}, {0x1013a5d70, 0x1400094ab70}, 0x1400012c6c0, 0x0)
        github.com/hashicorp/terraform-plugin-sdk@v1.17.2/internal/tfplugin5/tfplugin5.pb.go:3305 +0x1c0
google.golang.org/grpc.(*Server).processUnaryRPC(0x14000399c00, {0x1013b4368, 0x140001f8900}, 0x1400000a480, 0x1400010def0, 0x1019defa0, 0x0)
        google.golang.org/grpc@v1.39.0/server.go:1292 +0xc04
google.golang.org/grpc.(*Server).handleStream(0x14000399c00, {0x1013b4368, 0x140001f8900}, 0x1400000a480, 0x0)
        google.golang.org/grpc@v1.39.0/server.go:1617 +0xa34
google.golang.org/grpc.(*Server).serveStreams.func1.2(0x14000117030, 0x14000399c00, {0x1013b4368, 0x140001f8900}, 0x1400000a480)
        google.golang.org/grpc@v1.39.0/server.go:940 +0x94
created by google.golang.org/grpc.(*Server).serveStreams.func1
        google.golang.org/grpc@v1.39.0/server.go:938 +0x1f0
```