### PR TITLE
return error in case of unable to read collector

### DIFF
--- a/sumologic/resource_sumologic_collector.go
+++ b/sumologic/resource_sumologic_collector.go
@@ -70,6 +70,7 @@ func resourceSumologicCollectorRead(d *schema.ResourceData, meta interface{}) er
 		collector, err = c.GetCollector(id)
 		if err != nil {
 			log.Printf("[WARN] Collector not found when looking by id: %d, err: %v", id, err)
+			return err
 		}
 	}
 


### PR DESCRIPTION
recently, we found a bug, where if we are not able to read a collector for eg. due to 5xx, TF would consider that the collector does not exist and clean up the collector resource. That also cleans up the attached sources since the sources have a parent-child entity relationship.