### PR TITLE
SUMO-201782: remove regex check from terraform partition dataTier field

### DIFF
--- a/sumologic/resource_sumologic_partition.go
+++ b/sumologic/resource_sumologic_partition.go
@@ -32,8 +32,6 @@ func resourceSumologicPartition() *schema.Resource {
 			"analytics_tier": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringInSlice([]string{"continuous", "frequent", "infrequent"}, false),
-				Default:      "continuous",
 			},
 			"retention_period": {
 				Type:         schema.TypeInt,


### PR DESCRIPTION
https://github.com/Sanyaku/sumologic/pull/116697

We have moved the dataTier validation to the API layer to validate which tier are allowed for a customer based on if they are flex customer or not. So removing the regex checks form the terraform provider.