### PR TITLE
Add import by name for v2 ingest budgets

### DIFF
--- a/sumologic/resource_sumologic_ingest_budget_v2.go
+++ b/sumologic/resource_sumologic_ingest_budget_v2.go
@@ -141,6 +141,22 @@ func resourceSumologicIngestBudgetV2Update(d *schema.ResourceData, meta interfac
 	return resourceSumologicIngestBudgetV2Read(d, meta)
 }
 
+func resourceSumologicIngestBudgetV2Import(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	c := meta.(*Client)
+
+	name := d.Id()
+
+	ingestBudgetV2, err := c.FindIngestBudget(name)
+
+	if err != nil {
+		return nil, err
+	}
+
+	d.SetId(ingestBudgetV2.ID)
+
+	return []*schema.ResourceData{d}, nil
+}
+
 func resourceToIngestBudgetV2(d *schema.ResourceData) IngestBudgetV2 {
 
 	return IngestBudgetV2{

--- a/sumologic/resource_sumologic_ingest_budget_v2.go
+++ b/sumologic/resource_sumologic_ingest_budget_v2.go
@@ -146,7 +146,7 @@ func resourceSumologicIngestBudgetV2Import(d *schema.ResourceData, meta interfac
 
 	name := d.Id()
 
-	ingestBudgetV2, err := c.FindIngestBudget(name)
+	ingestBudgetV2, err := c.FindIngestBudgetV2(name)
 
 	if err != nil {
 		return nil, err

--- a/sumologic/resource_sumologic_ingest_budget_v2_test.go
+++ b/sumologic/resource_sumologic_ingest_budget_v2_test.go
@@ -44,6 +44,7 @@ func TestAccSumologicIngestBudgetV2_basic(t *testing.T) {
 				ResourceName:      "sumologic_ingest_budget_v2.foo",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateId:     testName,
 			},
 		},
 	})


### PR DESCRIPTION
Allow importing v2 budget via name

### Issue related to

Related to [473](https://github.com/SumoLogic/terraform-provider-sumologic/issues/473)