### PR TITLE
SUMO-201782: remove regex check from terrafrom partition data dier field

### DIFF
--- a/sumologic/resource_sumologic_partition.go
+++ b/sumologic/resource_sumologic_partition.go
@@ -30,8 +30,8 @@ func resourceSumologicPartition() *schema.Resource {
 				ValidateFunc: validation.StringLenBetween(1, 16384),
 			},
 			"analytics_tier": {
-				Type:         schema.TypeString,
-				Optional:     true,
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 			"retention_period": {
 				Type:         schema.TypeInt,

--- a/sumologic/resource_sumologic_partition.go
+++ b/sumologic/resource_sumologic_partition.go
@@ -32,8 +32,6 @@ func resourceSumologicPartition() *schema.Resource {
 			"analytics_tier": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringInSlice([]string{"continuous", "frequent", "infrequent"}, false),
-				Default:      "continuous",
 			},
 			"retention_period": {
 				Type:         schema.TypeInt,

--- a/sumologic/resource_sumologic_partition_test.go
+++ b/sumologic/resource_sumologic_partition_test.go
@@ -91,6 +91,7 @@ resource "sumologic_partition" "foo" {
     routing_expression = "_sourcecategory=*/Terraform"
     is_compliant = false
     retention_period = 30
+    analytics_tier = "continuous"
 }
 `, testName)
 }
@@ -102,6 +103,7 @@ resource "sumologic_partition" "foo" {
     routing_expression = "_sourcecategory=*/Terraform"
 	retention_period = 365
 	is_compliant = false
+	analytics_tier = "continuous"
 }
 `, testName)
 }

--- a/website/docs/r/partition.html.markdown
+++ b/website/docs/r/partition.html.markdown
@@ -27,7 +27,7 @@ The following arguments are supported:
 
 - `name` - (Required, Forces new resource) The name of the partition.
 - `routing_expression` - (Required) The query that defines the data to be included in the partition.
-- `analytics_tier` - (Required) The Cloud Flex analytics tier for your data; only relevant if your account has basic analytics enabled. Possible values are: `continuous`, `frequent`, `infrequent`
+- `analytics_tier` - (Optional) The cloud flex analytics tier for your data; only relevant if your account has basic analytics enabled. If no value is supplied, partition will be created in continuous tier. Other possible values are : "frequent" and "infrequent".
 - `retention_period` - (Optional) The number of days to retain data in the partition, or -1 to use the default value for your account. Only relevant if your account has variable retention enabled.
 - `is_compliant` - (Optional) Whether the partition is compliant or not. Mark a partition as compliant if it contains data used for compliance or audit purpose. Retention for a compliant partition can only be increased and cannot be reduced after the partition is marked compliant. A partition once marked compliant, cannot be marked non-compliant later.
 - `reduce_retention_period_immediately` - (Optional) This is required on update if the newly specified retention period is less than the existing retention period. In such a situation, a value of true says that data between the existing retention period and the new retention period should be deleted immediately; if false, such data will be deleted after seven days. This property is optional and ignored if the specified retentionPeriod is greater than or equal to the current retention period.


### PR DESCRIPTION
https://github.com/Sanyaku/sumologic/pull/116697

We have moved the dataTier validation to the API layer to validate which tier are allowed for a customer based on if they are flex customer or not. So removing the regex checks form the terraform provider. Also updated desc for analyticsTier field in partition.