### PR TITLE
Add local file source for installed collector

### DIFF
--- a/sumologic/provider.go
+++ b/sumologic/provider.go
@@ -106,6 +106,7 @@ func Provider() terraform.ResourceProvider {
 			"sumologic_policies":                                 resourceSumologicPolicies(),
 			"sumologic_hierarchy":                                resourceSumologicHierarchy(),
 			"sumologic_content_permission":                       resourceSumologicPermissions(),
+			"sumologic_local_file_source":                        resourceSumologicLocalFileSource(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"sumologic_cse_log_mapping_vendor_product": dataSourceCSELogMappingVendorAndProduct(),

--- a/sumologic/resource_sumologic_local_file_source.go
+++ b/sumologic/resource_sumologic_local_file_source.go
@@ -1,0 +1,116 @@
+package sumologic
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceSumologicLocalFileSource() *schema.Resource {
+	localFileSource := resourceSumologicSource()
+	localFileSource.Create = resourceSumologicLocalFileSourceCreate
+	localFileSource.Read = resourceSumologicLocalFileSourceRead
+	localFileSource.Update = resourceSumologicLocalFileSourceUpdate
+	localFileSource.Importer = &schema.ResourceImporter{
+		State: resourceSumologicSourceImport,
+	}
+
+	localFileSource.Schema["path_expression"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Required: true,
+	}
+
+	localFileSource.Schema["encoding"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Optional: true,
+		Default:  "UTF-8",
+	}
+
+	localFileSource.Schema["deny_list"] = &schema.Schema{
+		Type:     schema.TypeSet,
+		Optional: true,
+		Elem:     &schema.Schema{Type: schema.TypeString},
+	}
+
+	return localFileSource
+}
+
+func resourceSumologicLocalFileSourceCreate(d *schema.ResourceData, meta interface{}) error {
+	c := meta.(*Client)
+
+	if d.Id() == "" {
+		source := resourceToLocalFileSource(d)
+
+		id, err := c.CreateLocalFileSource(source, d.Get("collector_id").(int))
+
+		if err != nil {
+			return err
+		}
+
+		d.SetId(strconv.Itoa(id))
+	}
+
+	return resourceSumologicLocalFileSourceRead(d, meta)
+}
+
+func resourceSumologicLocalFileSourceUpdate(d *schema.ResourceData, meta interface{}) error {
+	c := meta.(*Client)
+
+	source := resourceToLocalFileSource(d)
+
+	err := c.UpdateLocalFileSource(source, d.Get("collector_id").(int))
+
+	if err != nil {
+		return err
+	}
+
+	return resourceSumologicLocalFileSourceRead(d, meta)
+}
+
+func resourceToLocalFileSource(d *schema.ResourceData) LocalFileSource {
+	rawDenyList := d.Get("deny_list").(*schema.Set).List()
+	var denylist []string
+	for _, j := range rawDenyList {
+		denylist = append(denylist, j.(string))
+	}
+	source := resourceToSource(d)
+	source.Type = "LocalFile"
+
+	localFileSource := LocalFileSource{
+		Source:         source,
+		PathExpression: d.Get("path_expression").(string),
+		Encoding:       d.Get("encoding").(string),
+		DenyList:       denylist,
+	}
+
+	return localFileSource
+}
+
+func resourceSumologicLocalFileSourceRead(d *schema.ResourceData, meta interface{}) error {
+	c := meta.(*Client)
+
+	id, _ := strconv.Atoi(d.Id())
+	source, err := c.GetLocalFileSource(d.Get("collector_id").(int), id)
+
+	if err != nil {
+		return err
+	}
+
+	if source == nil {
+		log.Printf("[WARN] LocalFile source not found, removing from state: %v - %v", id, err)
+		d.SetId("")
+
+		return nil
+	}
+
+	if err := resourceSumologicSourceRead(d, source.Source); err != nil {
+		return fmt.Errorf("%s", err)
+	}
+	d.Set("path_expression", source.PathExpression)
+	d.Set("encoding", source.Encoding)
+	d.Set("deny_list", source.DenyList)
+
+	return nil
+}

--- a/sumologic/sumologic_local_file_source.go
+++ b/sumologic/sumologic_local_file_source.go
@@ -1,0 +1,81 @@
+package sumologic
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type LocalFileSource struct {
+	Source
+	PathExpression string   `json:"pathExpression,omitempty"`
+	Encoding       string   `json:"encoding,omitempty"`
+	DenyList       []string `json:"denylist,omitempty"`
+}
+
+func (s *Client) CreateLocalFileSource(source LocalFileSource, collectorID int) (int, error) {
+
+	type LocalFileSourceMessage struct {
+		Source LocalFileSource `json:"source"`
+	}
+
+	request := LocalFileSourceMessage{
+		Source: source,
+	}
+
+	urlPath := fmt.Sprintf("v1/collectors/%d/sources", collectorID)
+	body, err := s.Post(urlPath, request)
+
+	if err != nil {
+		return -1, err
+	}
+
+	var response LocalFileSourceMessage
+
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		return -1, err
+	}
+
+	return response.Source.ID, nil
+}
+
+func (s *Client) GetLocalFileSource(collectorID, sourceID int) (*LocalFileSource, error) {
+
+	body, _, err := s.Get(fmt.Sprintf("v1/collectors/%d/sources/%d", collectorID, sourceID))
+	if err != nil {
+		return nil, err
+	}
+
+	if body == nil {
+		return nil, nil
+	}
+
+	type LocalFileSourceResponse struct {
+		Source LocalFileSource `json:"source"`
+	}
+
+	var response LocalFileSourceResponse
+
+	err = json.Unmarshal(body, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	return &response.Source, nil
+}
+
+func (s *Client) UpdateLocalFileSource(source LocalFileSource, collectorID int) error {
+
+	type LocalFileSourceMessage struct {
+		Source LocalFileSource `json:"source"`
+	}
+
+	request := LocalFileSourceMessage{
+		Source: source,
+	}
+
+	urlPath := fmt.Sprintf("v1/collectors/%d/sources/%d", collectorID, source.ID)
+	_, err := s.Put(urlPath, request)
+
+	return err
+}

--- a/website/docs/r/local_file_source.html.markdown
+++ b/website/docs/r/local_file_source.html.markdown
@@ -11,19 +11,19 @@ Provides a [Sumologic Local File Source][1].
 ## Example Usage
 ```hcl
 resource "sumologic_installed_collector" "installed_collector" {
-  name        = "test-collector"
-  category = "macos/test"
-  ephemeral = true
+  name       = "test-collector"
+  category   = "macos/test"
+  ephemeral  = true
 }
 
 resource "sumologic_local_file_source" "local" {
-	name = "localfile-mac"
-	description = "test"
-	category = "test"
-	collector_id = "${sumologic_installed_collector.installed_collector.id}"
-  path_expression = "/Applications/Sumo Logic Collector/logs/*.log.*"
+  name             = "localfile-mac"
+  description      = "test"
+  category         = "test"
+  collector_id     = "${sumologic_installed_collector.installed_collector.id}"
+  path_expression  = "/Applications/Sumo Logic Collector/logs/*.log.*"
 }
-```
+  ```
 
 ## Argument Reference
 

--- a/website/docs/r/local_file_source.html.markdown
+++ b/website/docs/r/local_file_source.html.markdown
@@ -23,7 +23,6 @@ resource "sumologic_local_file_source" "local" {
 	collector_id = "${sumologic_installed_collector.installed_collector.id}"
   path_expression = "/Applications/Sumo Logic Collector/logs/*.log.*"
 }
-}
 ```
 
 ## Argument Reference

--- a/website/docs/r/local_file_source.html.markdown
+++ b/website/docs/r/local_file_source.html.markdown
@@ -1,0 +1,65 @@
+---
+layout: "sumologic"
+page_title: "SumoLogic: sumologic_local_file_source"
+description: |-
+  Provides a Sumologic Local File Source.
+---
+
+# sumologic_local_file_source
+Provides a [Sumologic Local File Source][1].
+
+## Example Usage
+```hcl
+resource "sumologic_installed_collector" "installed_collector" {
+  name        = "test-collector"
+  category = "macos/test"
+  ephemeral = true
+}
+
+resource "sumologic_local_file_source" "local" {
+	name = "localfile-mac"
+	description = "test"
+	category = "test"
+	collector_id = "${sumologic_installed_collector.installed_collector.id}"
+  path_expression = "/Applications/Sumo Logic Collector/logs/*.log.*"
+}
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+  * `name` - (Required) The name of the local file source. This is required, and has to be unique. Changing this will force recreation the source.
+  * `path_expression` - (Required) A valid path expression (full path) of the file to collect. For files on Windows systems (not including Windows Events), enter the absolute path including the drive letter. Escape special characters and spaces with a backslash (). If you are collecting from Windows using CIFS/SMB, see Prerequisites for Windows Log Collection. Use a single asterisk wildcard [*] for file or folder names. Example:[var/foo/*.log]. Use two asterisks [**]to recurse within directories and subdirectories. Example: [var/*/.log].
+  * `description` - (Optional) The description of the source.
+  * `category` - (Optional) The default source category for the source.
+  * `fields` - (Optional) Map containing [key/value pairs][2].
+  * `denylist` - (Optional) Comma-separated list of valid path expressions from which logs will not be collected.
+    Example: "denylist":["/var/log/**/*.bak","/var/oldlog/*.log"]
+  * `encoding` - (Optional) Defines the encoding form. Default is "UTF-8". Other supported encodings are listed [here][3].
+
+### See also
+  * [Common Source Properties](https://github.com/terraform-providers/terraform-provider-sumologic/tree/master/website#common-source-properties)
+
+## Attributes Reference
+The following attributes are exported:
+
+  * `id` - The internal ID of the local file source.
+
+## Import
+Local file sources can be imported using the collector and source IDs, e.g.:
+
+```hcl
+terraform import sumologic_local_file_source.test 123/456
+```
+
+Local file sources can also be imported using the collector name and source name, e.g.:
+
+```hcl
+terraform import sumologic_local_file_source.test my-test-collector/my-test-source
+```
+
+[1]: https://help.sumologic.com/docs/send-data/installed-collectors/sources/local-file-source/
+[2]: https://help.sumologic.com/Manage/Fields
+[3]: https://help.sumologic.com/docs/send-data/installed-collectors/sources/local-file-source/#supported-encoding-for-local-file-sources


### PR DESCRIPTION
This PR adds the `sumologic_local_file_source` resource to be managed by Terraform.

- [X] Tested locally by importing an existing local file source.
- [X] Able to create a local file source
- [X] Able to assign new fields
- [X] Able to delete the source

Import statement: `terraform import sumologic_local_file_source.test $collectorId/$sourceId`

Sample resource block:
```
resource "sumologic_installed_collector" "installed_collector" {
  name        = "test-collector"
  category = "macos/test"
  ephemeral = true
}

resource "sumologic_local_file_source" "local" {
	name = "localfile-mac"
	description = "test"
	category = "test"
	collector_id = "${sumologic_installed_collector.installed_collector.id}"
  path_expression = "/Applications/Sumo Logic Collector/logs/*.log.*"
}

```