### PR TITLE
Check for errors before logging the response.

### DIFF
--- a/sumologic/sumologic_client.go
+++ b/sumologic/sumologic_client.go
@@ -87,11 +87,11 @@ func (s *Client) PostWithCookies(urlPath string, payload interface{}) ([]byte, [
 
 	<-rateLimiter.C
 	resp, err := s.httpClient.Do(req)
-	logRequestAndResponse(req, resp)
 
 	if err != nil {
 		return nil, nil, err
 	}
+	logRequestAndResponse(req, resp)
 	defer resp.Body.Close()
 
 	respCookie := resp.Cookies()
@@ -127,11 +127,11 @@ func (s *Client) GetWithCookies(urlPath string, cookies []*http.Cookie) ([]byte,
 
 	<-rateLimiter.C
 	resp, err := s.httpClient.Do(req)
-	logRequestAndResponse(req, resp)
 
 	if err != nil {
 		return nil, "", err
 	}
+	logRequestAndResponse(req, resp)
 	defer resp.Body.Close()
 
 	d, err := ioutil.ReadAll(resp.Body)
@@ -164,11 +164,11 @@ func (s *Client) Post(urlPath string, payload interface{}) ([]byte, error) {
 
 	<-rateLimiter.C
 	resp, err := s.httpClient.Do(req)
-	logRequestAndResponse(req, resp)
 
 	if err != nil {
 		return nil, err
 	}
+	logRequestAndResponse(req, resp)
 	defer resp.Body.Close()
 
 	d, err := ioutil.ReadAll(resp.Body)
@@ -197,11 +197,11 @@ func (s *Client) PostRawPayload(urlPath string, payload string) ([]byte, error) 
 
 	<-rateLimiter.C
 	resp, err := s.httpClient.Do(req)
-	logRequestAndResponse(req, resp)
 
 	if err != nil {
 		return nil, err
 	}
+	logRequestAndResponse(req, resp)
 
 	d, _ := ioutil.ReadAll(resp.Body)
 
@@ -231,11 +231,11 @@ func (s *Client) Put(urlPath string, payload interface{}) ([]byte, error) {
 
 	<-rateLimiter.C
 	resp, err := s.httpClient.Do(req)
-	logRequestAndResponse(req, resp)
 
 	if err != nil {
 		return nil, err
 	}
+	logRequestAndResponse(req, resp)
 	defer resp.Body.Close()
 
 	d, err := ioutil.ReadAll(resp.Body)
@@ -269,11 +269,11 @@ func (s *Client) GetWithErrOpt(urlPath string, return404Err bool) ([]byte, strin
 
 	<-rateLimiter.C
 	resp, err := s.httpClient.Do(req)
-	logRequestAndResponse(req, resp)
-
 	if err != nil {
 		return nil, "", err
 	}
+	logRequestAndResponse(req, resp)
+
 	defer resp.Body.Close()
 
 	d, err := ioutil.ReadAll(resp.Body)
@@ -309,11 +309,11 @@ func (s *Client) Delete(urlPath string) ([]byte, error) {
 
 	<-rateLimiter.C
 	resp, err := s.httpClient.Do(req)
-	logRequestAndResponse(req, resp)
 
 	if err != nil {
 		return nil, err
 	}
+	logRequestAndResponse(req, resp)
 	defer resp.Body.Close()
 
 	d, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
When there was an HTTP error (e.g. timeout), we would get an error like this, because we read fields from `resp` that was nil:

```
panic: runtime error: invalid memory address or nil pointer dereference
```