### PR TITLE
Suppress partition resource changed for TF for total_bytes prop

### DIFF
--- a/sumologic/resource_sumologic_partition.go
+++ b/sumologic/resource_sumologic_partition.go
@@ -50,6 +50,9 @@ func resourceSumologicPartition() *schema.Resource {
 			"total_bytes": {
 				Type:     schema.TypeInt,
 				Computed: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return true
+				},
 			},
 			"data_forwarding_id": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
Always return `true` to ignore TF resource change(`terraform plan`) check on total_bytes field as it will keep changing with data ingested in partition. 