### PR TITLE
add new resource for S3 Archive source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.23.0 (Unreleased)
 FEATURES:
 * **New Resource:** sumologic_log_search (GH-432)
+* **New Resource:** sumologic_s3_archive_source (GH-524)
 
 ## 2.22.1 (May 15, 2023)
 FEATURES:

--- a/sumologic/provider.go
+++ b/sumologic/provider.go
@@ -70,6 +70,7 @@ func Provider() terraform.ResourceProvider {
 			"sumologic_polling_source":                           resourceSumologicPollingSource(),
 			"sumologic_s3_source":                                resourceSumologicGenericPollingSource(),
 			"sumologic_s3_audit_source":                          resourceSumologicGenericPollingSource(),
+			"sumologic_s3_archive_source":                        resourceSumologicGenericPollingSource(),
 			"sumologic_cloudwatch_source":                        resourceSumologicGenericPollingSource(),
 			"sumologic_aws_inventory_source":                     resourceSumologicGenericPollingSource(),
 			"sumologic_aws_xray_source":                          resourceSumologicGenericPollingSource(),

--- a/sumologic/resource_sumologic_generic_polling_source.go
+++ b/sumologic/resource_sumologic_generic_polling_source.go
@@ -25,7 +25,7 @@ func resourceSumologicGenericPollingSource() *schema.Resource {
 		Required: true,
 		ForceNew: true,
 		ValidateFunc: validation.StringInSlice([]string{"AwsS3Bucket", "AwsElbBucket", "AwsCloudFrontBucket",
-			"AwsCloudTrailBucket", "AwsS3AuditBucket", "AwsCloudWatch", "AwsInventory", "AwsXRay", "GcpMetrics"}, false),
+			"AwsCloudTrailBucket", "AwsS3AuditBucket", "AwsCloudWatch", "AwsInventory", "AwsXRay", "GcpMetrics", "AwsS3ArchiveBucket"}, false),
 	}
 	pollingSource.Schema["scan_interval"] = &schema.Schema{
 		Type:     schema.TypeInt,

--- a/sumologic/resource_sumologic_s3_archive_source_test.go
+++ b/sumologic/resource_sumologic_s3_archive_source_test.go
@@ -1,0 +1,180 @@
+package sumologic
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccSumologicS3ArchiveSource_create(t *testing.T) {
+	var s3Source PollingSource
+	var collector Collector
+	cName, cDescription, cCategory := getRandomizedParams()
+	sName, sDescription, sCategory := getRandomizedParams()
+	s3ResourceName := "sumologic_s3_archive_source.s3_archive"
+	testAwsRoleArn := os.Getenv("SUMOLOGIC_TEST_ROLE_ARN")
+	testAwsBucket := os.Getenv("SUMOLOGIC_TEST_BUCKET_NAME")
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckWithAWS(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckS3ArchiveSourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSumologicS3ArchiveSourceConfig(cName, cDescription, cCategory, sName, sDescription, sCategory, testAwsRoleArn, testAwsBucket),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckS3SourceExists(s3ResourceName, &s3Source),
+					testAccCheckS3SourceValues(&s3Source, sName, sDescription, sCategory),
+					testAccCheckCollectorExists("sumologic_collector.test", &collector),
+					testAccCheckCollectorValues(&collector, cName, cDescription, cCategory, "Etc/UTC", ""),
+					resource.TestCheckResourceAttrSet(s3ResourceName, "id"),
+					resource.TestCheckResourceAttr(s3ResourceName, "name", sName),
+					resource.TestCheckResourceAttr(s3ResourceName, "description", sDescription),
+					resource.TestCheckResourceAttr(s3ResourceName, "category", sCategory),
+					resource.TestCheckResourceAttr(s3ResourceName, "content_type", "AwsS3ArchiveBucket"),
+					resource.TestCheckResourceAttr(s3ResourceName, "path.0.type", "S3BucketPathExpression"),
+				),
+			},
+		},
+	})
+}
+func TestAccSumologicS3ArchiveSource_update(t *testing.T) {
+	var s3Source PollingSource
+	cName, cDescription, cCategory := getRandomizedParams()
+	sName, sDescription, sCategory := getRandomizedParams()
+	sNameUpdated, sDescriptionUpdated, sCategoryUpdated := getRandomizedParams()
+	s3ResourceName := "sumologic_s3_source.s3"
+	testAwsRoleArn := os.Getenv("SUMOLOGIC_TEST_ROLE_ARN")
+	testAwsBucket := os.Getenv("SUMOLOGIC_TEST_BUCKET_NAME")
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckWithAWS(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckHTTPSourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSumologicS3ArchiveSourceConfig(cName, cDescription, cCategory, sName, sDescription, sCategory, testAwsRoleArn, testAwsBucket),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckS3SourceExists(s3ResourceName, &s3Source),
+					testAccCheckS3SourceValues(&s3Source, sName, sDescription, sCategory),
+					resource.TestCheckResourceAttrSet(s3ResourceName, "id"),
+					resource.TestCheckResourceAttr(s3ResourceName, "name", sName),
+					resource.TestCheckResourceAttr(s3ResourceName, "description", sDescription),
+					resource.TestCheckResourceAttr(s3ResourceName, "category", sCategory),
+					resource.TestCheckResourceAttr(s3ResourceName, "content_type", "AwsS3ArchiveBucket"),
+					resource.TestCheckResourceAttr(s3ResourceName, "path.0.type", "S3BucketPathExpression"),
+				),
+			},
+			{
+				Config: testAccSumologicS3ArchiveSourceConfig(cName, cDescription, cCategory, sNameUpdated, sDescriptionUpdated, sCategoryUpdated, testAwsRoleArn, testAwsBucket),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckS3SourceExists(s3ResourceName, &s3Source),
+					testAccCheckS3SourceValues(&s3Source, sNameUpdated, sDescriptionUpdated, sCategoryUpdated),
+					resource.TestCheckResourceAttrSet(s3ResourceName, "id"),
+					resource.TestCheckResourceAttr(s3ResourceName, "name", sNameUpdated),
+					resource.TestCheckResourceAttr(s3ResourceName, "description", sDescriptionUpdated),
+					resource.TestCheckResourceAttr(s3ResourceName, "category", sCategoryUpdated),
+					resource.TestCheckResourceAttr(s3ResourceName, "content_type", "AwsS3ArchiveBucket"),
+					resource.TestCheckResourceAttr(s3ResourceName, "path.0.type", "S3BucketPathExpression"),
+				),
+			},
+		},
+	})
+}
+func testAccCheckS3ArchiveSourceDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "sumologic_s3_source" && rs.Type != "sumologic_cloudwatch_source" {
+			continue
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("HTTP Source destruction check: HTTP Source ID is not set")
+		}
+		id, err := strconv.Atoi(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("Encountered an error: " + err.Error())
+		}
+		collectorID, err := strconv.Atoi(rs.Primary.Attributes["collector_id"])
+		if err != nil {
+			return fmt.Errorf("Encountered an error: " + err.Error())
+		}
+		s, err := client.GetPollingSource(collectorID, id)
+		if err != nil {
+			return fmt.Errorf("Encountered an error: " + err.Error())
+		}
+		if s != nil {
+			return fmt.Errorf("Polling Source still exists")
+		}
+	}
+	return nil
+}
+func testAccCheckS3ArchiveSourceExists(n string, pollingSource *PollingSource) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Polling Source ID is not set")
+		}
+		id, err := strconv.Atoi(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("Polling Source id should be int; got %s", rs.Primary.ID)
+		}
+		collectorID, err := strconv.Atoi(rs.Primary.Attributes["collector_id"])
+		if err != nil {
+			return fmt.Errorf("Encountered an error: " + err.Error())
+		}
+		c := testAccProvider.Meta().(*Client)
+		pollingSourceResp, err := c.GetPollingSource(collectorID, id)
+		if err != nil {
+			return err
+		}
+		*pollingSource = *pollingSourceResp
+		return nil
+	}
+}
+func testAccCheckS3ArchiveSourceValues(pollingSource *PollingSource, name, description, category string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if pollingSource.Name != name {
+			return fmt.Errorf("bad name, expected \"%s\", got: %#v", name, pollingSource.Name)
+		}
+		if pollingSource.Description != description {
+			return fmt.Errorf("bad description, expected \"%s\", got: %#v", description, pollingSource.Description)
+		}
+		if pollingSource.Category != category {
+			return fmt.Errorf("bad category, expected \"%s\", got: %#v", category, pollingSource.Category)
+		}
+		return nil
+	}
+}
+func testAccSumologicS3ArchiveSourceConfig(cName, cDescription, cCategory, sName, sDescription, sCategory, testAwsRoleArn, testAwsBucket string) string {
+	return fmt.Sprintf(`
+resource "sumologic_collector" "test" {
+	name = "%s"
+	description = "%s"
+	category = "%s"
+}
+resource "sumologic_s3_archive_source" "s3" {
+	name = "%s"
+	description = "%s"
+	category = "%s"
+	content_type  = "AwsS3ArchiveBucket"
+  	scan_interval = 300000
+  	paused        = false
+	collector_id = "${sumologic_collector.test.id}"
+	authentication {
+		type = "AWSRoleBasedAuthentication"
+		role_arn = "%s"
+	  }
+	  path {
+		type = "S3BucketPathExpression"
+		bucket_name     = "%s"
+		path_expression = "*"
+	  }
+	}
+
+`, cName, cDescription, cCategory, sName, sDescription, sCategory, testAwsRoleArn, testAwsBucket)
+}

--- a/sumologic/resource_sumologic_s3_archive_source_test.go
+++ b/sumologic/resource_sumologic_s3_archive_source_test.go
@@ -46,7 +46,7 @@ func TestAccSumologicS3ArchiveSource_update(t *testing.T) {
 	cName, cDescription, cCategory := getRandomizedParams()
 	sName, sDescription, sCategory := getRandomizedParams()
 	sNameUpdated, sDescriptionUpdated, sCategoryUpdated := getRandomizedParams()
-	s3ResourceName := "sumologic_s3_source.s3"
+	s3ResourceName := "sumologic_s3_archive_source.s3_archive"
 	testAwsRoleArn := os.Getenv("SUMOLOGIC_TEST_ROLE_ARN")
 	testAwsBucket := os.Getenv("SUMOLOGIC_TEST_BUCKET_NAME")
 	resource.Test(t, resource.TestCase{
@@ -157,7 +157,7 @@ resource "sumologic_collector" "test" {
 	description = "%s"
 	category = "%s"
 }
-resource "sumologic_s3_archive_source" "s3" {
+resource "sumologic_s3_archive_source" "s3_archive" {
 	name = "%s"
 	description = "%s"
 	category = "%s"

--- a/website/docs/r/s3_archive_source.html.markdown
+++ b/website/docs/r/s3_archive_source.html.markdown
@@ -58,8 +58,6 @@ In addition to the [Common Source Properties](https://registry.terraform.io/prov
      + `type` - (Required) type of polling source. This has to be `S3BucketPathExpression` for `S3 source`.
      + `bucket_name` - (Required) The name of the bucket. 
      + `path_expression` - (Required) The path to the data.
-     + `sns_topic_or_subscription_arn` - (Computed) This is a computed field for SNS topic/subscription ARN.
-     + `use_versioned_api` - (Optional) Whether to Use AWS versioned APIs. Default is set to `true`. If you're collecting from a Cisco Umbrella bucket this must be set to `false`.
 
 ### See also
   * [Common Source Properties](https://registry.terraform.io/providers/SumoLogic/sumologic/latest/docs#common-source-properties)

--- a/website/docs/r/s3_archive_source.html.markdown
+++ b/website/docs/r/s3_archive_source.html.markdown
@@ -1,0 +1,88 @@
+---
+layout: "sumologic"
+page_title: "SumoLogic: sumologic_s3_archive_source"
+description: |-
+  Provides a Sumologic AWS S3 Archive Source.
+---
+
+# sumologic_s3_archive_source
+Provides a [Sumologic AWS S3 Archive Source][2].
+
+__IMPORTANT:__ The AWS credentials are stored in plain-text in the state. This is a potential security issue.
+
+## Example Usage
+```hcl
+
+resource "sumologic_s3_archive_source" "terraform_s3_archive_source" {
+  name          = "Amazon S3 Archive Source"
+  description   = "My description"
+  category      = "aws/s3"
+  content_type  = "AwsS3Bucket"
+  scan_interval = 300000
+  paused        = false
+  collector_id  = "${sumologic_collector.collector.id}"
+
+  authentication {
+    type = "S3BucketAuthentication"
+    access_key = "someKey"
+    secret_key = "******"
+  }
+
+  path {
+    type = "S3BucketPathExpression"
+    bucket_name     = "Bucket1"
+    path_expression = "*"
+  }
+}
+
+resource "sumologic_collector" "collector" {
+  name        = "my-collector"
+  description = "Just testing this"
+}
+```
+
+## Argument reference
+
+In addition to the [Common Source Properties](https://registry.terraform.io/providers/SumoLogic/sumologic/latest/docs#common-source-properties), the following arguments are supported:
+
+ - `content_type` - (Required) The content-type of the collected data. It should be `AwsS3ArchiveBucket` for archive source. Details can be found in the [Sumologic documentation for hosted sources][1].
+ - `scan_interval` - (Required) Time interval in milliseconds of scans for new data. The default is 300000 and the minimum value is 1000 milliseconds.
+ - `paused` - (Required) When set to true, the scanner is paused. To disable, set to false.
+ - `authentication` - (Required) Authentication details for connecting to the S3 bucket.
+     + `type` - (Required) Must be either `S3BucketAuthentication` or `AWSRoleBasedAuthentication`.
+     + `access_key` - (Required) Your AWS access key if using type `S3BucketAuthentication`.
+     + `secret_key` - (Required) Your AWS secret key if using type `S3BucketAuthentication`.
+     + `role_arn` - (Required) Your AWS role ARN if using type `AWSRoleBasedAuthentication`. This is not supported for AWS China regions.
+     + `region` - (Optional) Your AWS Bucket region.
+ - `path` - (Required) The location to scan for new data.
+     + `type` - (Required) type of polling source. This has to be `S3BucketPathExpression` for `S3 source`.
+     + `bucket_name` - (Required) The name of the bucket. 
+     + `path_expression` - (Required) The path to the data.
+     + `sns_topic_or_subscription_arn` - (Computed) This is a computed field for SNS topic/subscription ARN.
+     + `use_versioned_api` - (Optional) Whether to Use AWS versioned APIs. Default is set to `true`. If you're collecting from a Cisco Umbrella bucket this must be set to `false`.
+
+### See also
+  * [Common Source Properties](https://registry.terraform.io/providers/SumoLogic/sumologic/latest/docs#common-source-properties)
+  * [Configuring SNS Subscription](https://registry.terraform.io/providers/SumoLogic/sumologic/latest/docs#configuring-sns-subscription)
+
+## Attributes Reference
+The following attributes are exported:
+
+- `id` - The internal ID of the source.
+- `url` - The HTTP endpoint to use with [SNS to notify Sumo Logic of new files](https://help.sumologic.com/03Send-Data/Sources/02Sources-for-Hosted-Collectors/Amazon-Web-Services/AWS-S3-Source#Set_up_SNS_in_AWS_(Optional)).
+
+## Import
+S3 sources can be imported using the collector and source IDs (`collector/source`), e.g.:
+
+```hcl
+terraform import sumologic_s3_archive_source.test 123/456
+```
+
+S3 sources can be imported using the collector name and source name (`collectorName/sourceName`), e.g.:
+
+```hcl
+terraform import sumologic_s3_archive_source.test my-test-collector/my-test-source
+```
+
+[1]: https://help.sumologic.com/Send_Data/Sources/03Use_JSON_to_Configure_Sources/JSON_Parameters_for_Hosted_Sources
+[2]: https://help.sumologic.com/docs/manage/archive/#create-an-aws-s3-archivesource


### PR DESCRIPTION
This PR adds a new resource `sumologic_s3_archive_source` for AWS S3 Archive source.
 - [X] Tested locally.
 - [X] Able to create a local file source
 - [X] Able to assign new fields
 - [X] Able to delete the source

Sample resource block:
```
resource "sumologic_installed_collector" "installed_collector" {
  name        = "test-collector"
  category = "macos/test"
  ephemeral = true
}

resource "sumologic_s3_archive_source" "terraform_s3_archive_source" {
  name          = "Amazon S3 Archive Source"
  description   = "My description"
  category      = "aws/s3"
  content_type  = "AwsS3Bucket"
  scan_interval = 300000
  paused        = false
  collector_id  = "${sumologic_collector.collector.id}"

  authentication {
    type = "S3BucketAuthentication"
    access_key = "someKey"
    secret_key = "******"
  }

  path {
    type = "S3BucketPathExpression"
    bucket_name     = "Bucket1"
    path_expression = "*"
  }
}
```