### PR TITLE
SUMO-221183 Fix the kinesis log third party reference

### DIFF
--- a/sumologic/resource_sumologic_kinesis_log_source.go
+++ b/sumologic/resource_sumologic_kinesis_log_source.go
@@ -36,13 +36,14 @@ func resourceSumologicKinesisLogSource() *schema.Resource {
 	}
 	kinesisLogSource.Schema["authentication"] = &schema.Schema{
 		Type:     schema.TypeList,
-		Required: true,
+		Optional: true,
 		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"type": {
 					Type:         schema.TypeString,
-					Required:     true,
+					Optional:     true,
+					Default:      "NoAuthentication",
 					ValidateFunc: validation.StringInSlice([]string{"S3BucketAuthentication", "AWSRoleBasedAuthentication", "NoAuthentication"}, false),
 				},
 				"access_key": {
@@ -63,13 +64,14 @@ func resourceSumologicKinesisLogSource() *schema.Resource {
 
 	kinesisLogSource.Schema["path"] = &schema.Schema{
 		Type:     schema.TypeList,
-		Required: true,
+		Optional: true,
 		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"type": {
 					Type:         schema.TypeString,
-					Required:     true,
+					Optional:     true,
+					Default:      "NoPathExpression",
 					ValidateFunc: validation.StringInSlice([]string{"KinesisLogPath", "NoPathExpression"}, false),
 				},
 				"bucket_name": {
@@ -83,7 +85,6 @@ func resourceSumologicKinesisLogSource() *schema.Resource {
 				"scan_interval": {
 					Type:     schema.TypeInt,
 					Optional: true,
-					Default:  300000,
 				},
 			},
 		},
@@ -147,13 +148,6 @@ func resourceSumologicKinesisLogSourceRead(d *schema.ResourceData, meta interfac
 		return nil
 	}
 
-	kinesisLogResources := source.ThirdPartyRef.Resources
-	path := getKinesisLogThirdPartyPathAttributes(kinesisLogResources)
-
-	if err := d.Set("path", path); err != nil {
-		return err
-	}
-
 	if err := resourceSumologicSourceRead(d, source.Source); err != nil {
 		return fmt.Errorf("%s", err)
 	}
@@ -202,19 +196,19 @@ func getKinesisLogPathSettings(d *schema.ResourceData) (KinesisLogPath, error) {
 		path := paths[0].(map[string]interface{})
 		switch pathType := path["type"].(string); pathType {
 		case "KinesisLogPath":
-			pathSettings.Type = pathType
+			pathSettings.Type = "KinesisLogPath"
 			pathSettings.BucketName = path["bucket_name"].(string)
 			pathSettings.PathExpression = path["path_expression"].(string)
 			pathSettings.ScanInterval = path["scan_interval"].(int)
 		case "NoPathExpression":
-			pathSettings.Type = pathType
+			pathSettings.Type = "NoPathExpression"
 		default:
 			errorMessage := fmt.Sprintf("[ERROR] Unknown resourceType in path: %v", pathType)
 			log.Print(errorMessage)
 			return pathSettings, errors.New(errorMessage)
 		}
 	} else {
-		return pathSettings, errors.New(fmt.Sprintf("[ERROR] no path specification in kinesis log Soruce"))
+		pathSettings.Type = "NoPathExpression"
 	}
 	return pathSettings, nil
 }
@@ -246,6 +240,8 @@ func getKinesisLogAuthentication(d *schema.ResourceData) (PollingAuthentication,
 			log.Print(errorMessage)
 			return authSettings, errors.New(errorMessage)
 		}
+	} else {
+		authSettings.Type = "NoAuthentication"
 	}
 
 	return authSettings, nil

--- a/website/docs/r/kinesis_log_source.html.markdown
+++ b/website/docs/r/kinesis_log_source.html.markdown
@@ -66,12 +66,12 @@ __IMPORTANT:__ The AWS credentials are stored in plain-text in the state. This i
 In addition to the common properties, the following arguments are supported:
 
  - `content_type` - (Required) The content-type of the collected data. Details can be found in the [Sumologic documentation for hosted sources][1].
- - `authentication` - (Required) Authentication details for connecting to the S3 bucket.
+ - `authentication` - (Optional) Authentication details for connecting to the S3 bucket.
      + `type` - (Required) Must be either `S3BucketAuthentication` or `AWSRoleBasedAuthentication` or `NoAuthentication`
      + `access_key` - (Required) Your AWS access key if using type `S3BucketAuthentication`
      + `secret_key` - (Required) Your AWS secret key if using type `S3BucketAuthentication`
      + `role_arn` - (Required) Your AWS role ARN if using type `AWSRoleBasedAuthentication`
- - `path` - (Required) The location of S3 bucket for failed Kinesis log data.
+ - `path` - (Optional) The location of S3 bucket for failed Kinesis log data.
      + `type` - (Required) Must be either `KinesisLogPath` or `NoPathExpression`
      + `bucket_name` - (Optional) The name of the bucket. This is needed if using type `KinesisLogPath`. 
      + `path_expression` - (Optional) The path to the data. This is needed if using type `KinesisLogPath`. For Kinesis log source, it must include `http-endpoint-failed/`.


### PR DESCRIPTION
Due to the reported issue: https://github.com/SumoLogic/terraform-provider-sumologic/issues/523

We want to change `authentication` and `path` back to optional fields. Customer can skip giving these two fields if they don't need to enable log replay for kinesis log source. We will give it the default value to `NoAuthentication` and `NoPathExpression`.

I have already tested with following locally and sources can be created/updated/read correctly:
```
resource "sumologic_kinesis_log_source" "kinesis_log_s3_access" {
  name = "yuting-test-kinesis-tf"
  description = "test kinesis source with replay"
  content_type  = "KinesisLog"
  collector_id = "109499115"
  authentication {
      type = "S3BucketAuthentication"
      access_key = "XXXXX"
      secret_key = "XXXX"
  }
  path {
      type = "KinesisLogPath"
      bucket_name     = "test-bucket"
      path_expression = "http-endpoint-failed/*"
      scan_interval   = 30000
  }
}

resource "sumologic_kinesis_log_source" "kinesis_log_no_access" {
  name = "yutingtest-kinesis-tf-no-access"
  description = "test kinesis source with no replay"
  content_type  = "KinesisLog"
  collector_id = "109499115"
  authentication {
    type = "NoAuthentication"
  }
  path {
    type = "NoPathExpression"
  }
}

resource "sumologic_kinesis_log_source" "kinesis_log_empty" {
  name = "yuting-test-kinesis-tf-empty"
  description = "test kinesis source with no replay"
  content_type  = "KinesisLog"
  collector_id = "109499115"
}
```