### PR TITLE
INVS-1408: fix Create Match Lists item limit

### DIFF
--- a/sumologic/resource_sumologic_cse_match_list_test.go
+++ b/sumologic/resource_sumologic_cse_match_list_test.go
@@ -93,6 +93,28 @@ resource "sumologic_cse_match_list" "match_list" {
 `, nDefaultTtl, nDescription, nName, nTargetColumn, liDescription, liExpiration, liValue)
 }
 
+func testCreateCSEMatchListConfigWithOver1000Items(nDefaultTtl int, nDescription string, nName string, nTargetColumn string, liDescription string, liExpiration string, liValue string) string {
+	var str = fmt.Sprintf(`
+resource "sumologic_cse_match_list" "match_list" {
+    default_ttl = "%d"
+    description = "%s"
+    name = "%s"
+    target_column = "%s"
+    items {
+`, nDefaultTtl, nDescription, nName, nTargetColumn)
+
+	for i := 0; i < 1001; i++ {
+		str += fmt.Sprintf(
+			`[
+            description = "%s"
+            expiration = "%s"
+            value = "%s"
+        ],`, liDescription, liExpiration, liValue)
+	}
+	str += "}"
+	return str
+}
+
 func testDeleteCSEMatchListItemConfig(nDefaultTtl int, nDescription string, nName string, nTargetColumn string) string {
 	return fmt.Sprintf(`
 resource "sumologic_cse_match_list" "match_list" {

--- a/sumologic/resource_sumologic_cse_match_list_test.go
+++ b/sumologic/resource_sumologic_cse_match_list_test.go
@@ -106,10 +106,10 @@ resource "sumologic_cse_match_list" "match_list" {
 	for i := 0; i < 1001; i++ {
 		str += fmt.Sprintf(
 			`[
-            description = "%s"
+            description = "%s %d"
             expiration = "%s"
-            value = "%s"
-        ],`, liDescription, liExpiration, liValue)
+            value = "%s %d"
+        ],`, liDescription, i, liExpiration, liValue, i)
 	}
 	str += "}"
 	return str

--- a/sumologic/sumologic_cse_match_list_item.go
+++ b/sumologic/sumologic_cse_match_list_item.go
@@ -75,7 +75,7 @@ func (s *Client) CreateCSEMatchListItems(CSEMatchListItemPost []CSEMatchListItem
 	var end = 1000
 
 	//If there are more than 1000 items, send requests in batches of 1000 due to the API's maximum item limit allowed per request.
-	for end > len(CSEMatchListItemPost) {
+	for end < len(CSEMatchListItemPost) {
 		err := s.SendCreateCSEMatchListItemsRequest(CSEMatchListItemPost[start:end], MatchListID)
 		if err != nil {
 			return err

--- a/sumologic/sumologic_cse_match_list_item.go
+++ b/sumologic/sumologic_cse_match_list_item.go
@@ -75,7 +75,7 @@ func (s *Client) CreateCSEMatchListItems(CSEMatchListItemPost []CSEMatchListItem
 	var end = 1000
 
 	//If there are more than 1000 items, send requests in batches of 1000 due to the API's maximum item limit allowed per request.
-	for end >= len(CSEMatchListItemPost) {
+	for end > len(CSEMatchListItemPost) {
 		err := s.SendCreateCSEMatchListItemsRequest(CSEMatchListItemPost[start:end], MatchListID)
 		if err != nil {
 			return err

--- a/sumologic/sumologic_cse_match_list_item.go
+++ b/sumologic/sumologic_cse_match_list_item.go
@@ -49,8 +49,7 @@ func (s *Client) DeleteCSEMatchListItem(id string) error {
 	return err
 }
 
-func (s *Client) CreateCSEMatchListItems(CSEMatchListItemPost []CSEMatchListItemPost, MatchListID string) error {
-
+func (s *Client) SendCreateCSEMatchListItemsRequest(CSEMatchListItemPost []CSEMatchListItemPost, MatchListID string) error {
 	request := CSEMatchListItemRequestPost{
 		CSEMatchListItemPost: CSEMatchListItemPost,
 	}
@@ -69,6 +68,24 @@ func (s *Client) CreateCSEMatchListItems(CSEMatchListItemPost []CSEMatchListItem
 	}
 
 	return nil
+}
+
+func (s *Client) CreateCSEMatchListItems(CSEMatchListItemPost []CSEMatchListItemPost, MatchListID string) error {
+	var start = 0
+	var end = 1000
+
+	//If there are more than 1000 items, send requests in batches of 1000 due to the API's maximum item limit allowed per request.
+	for end >= len(CSEMatchListItemPost) {
+		err = SendCreateCSEMatchListItemsRequest(CSEMatchListItemPost[start:end], MatchListID)
+		if err != nil {
+			return err
+		}
+		start += 1000
+		end += 1000
+	}
+
+	return SendCreateCSEMatchListItemsRequest(CSEMatchListItemPost[start:len(CSEMatchListItemPost)], MatchListID)
+
 }
 
 func (s *Client) UpdateCSEMatchListItem(CSEMatchListItemPost CSEMatchListItemPost) error {

--- a/sumologic/sumologic_cse_match_list_item.go
+++ b/sumologic/sumologic_cse_match_list_item.go
@@ -76,7 +76,7 @@ func (s *Client) CreateCSEMatchListItems(CSEMatchListItemPost []CSEMatchListItem
 
 	//If there are more than 1000 items, send requests in batches of 1000 due to the API's maximum item limit allowed per request.
 	for end >= len(CSEMatchListItemPost) {
-		err = SendCreateCSEMatchListItemsRequest(CSEMatchListItemPost[start:end], MatchListID)
+		err := s.SendCreateCSEMatchListItemsRequest(CSEMatchListItemPost[start:end], MatchListID)
 		if err != nil {
 			return err
 		}
@@ -84,7 +84,7 @@ func (s *Client) CreateCSEMatchListItems(CSEMatchListItemPost []CSEMatchListItem
 		end += 1000
 	}
 
-	return SendCreateCSEMatchListItemsRequest(CSEMatchListItemPost[start:len(CSEMatchListItemPost)], MatchListID)
+	return s.SendCreateCSEMatchListItemsRequest(CSEMatchListItemPost[start:], MatchListID)
 
 }
 


### PR DESCRIPTION
[INVS-1408](https://jasklabs.atlassian.net/jira/software/c/projects/INVS/boards/70?modal=detail&selectedIssue=INVS-1408&assignee=627d68d38dd5f30068565c1f): The terraform resource to create a match list now sends Admiral API requests in batches of 1000 match list items to avoid timing out from a bad request response due to the 1000 item limit.