### PR TITLE
INVS-1489: Enforce group_by_fields validation in cse_*_rule resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ FEATURES:
 * **New Resource:** sumologic_cse_outlier_rule (GH-532)
 * Add new optional `global_signal_suppression_window` field to sumologic_cse_insights_configuration (TRIDENT-18052)
 
+BUG FIXES:
+* Enforce validation of `group_by_fields` in cse_*_rule resources, on non empty string elements. (GH-535)
+
 ## 2.23.0 (May 24, 2023)
 FEATURES:
 * **New Resource:** sumologic_log_search (GH-432)

--- a/sumologic/resource_sumologic_cse_aggregation_rule.go
+++ b/sumologic/resource_sumologic_cse_aggregation_rule.go
@@ -58,7 +58,8 @@ func resourceSumologicCSEAggregationRule() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Schema{
-					Type: schema.TypeString,
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringIsNotEmpty,
 				},
 			},
 			"is_prototype": {

--- a/sumologic/resource_sumologic_cse_chain_rule.go
+++ b/sumologic/resource_sumologic_cse_chain_rule.go
@@ -46,7 +46,8 @@ func resourceSumologicCSEChainRule() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Schema{
-					Type: schema.TypeString,
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringIsNotEmpty,
 				},
 			},
 			"is_prototype": {

--- a/sumologic/resource_sumologic_cse_first_seen_rule.go
+++ b/sumologic/resource_sumologic_cse_first_seen_rule.go
@@ -42,7 +42,8 @@ func resourceSumologicCSEFirstSeenRule() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Schema{
-					Type: schema.TypeString,
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringIsNotEmpty,
 				},
 			},
 			"is_prototype": {

--- a/sumologic/resource_sumologic_cse_outlier_rule.go
+++ b/sumologic/resource_sumologic_cse_outlier_rule.go
@@ -67,7 +67,8 @@ func resourceSumologicCSEOutlierRule() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Schema{
-					Type: schema.TypeString,
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringIsNotEmpty,
 				},
 			},
 			"is_prototype": {

--- a/sumologic/resource_sumologic_cse_threshold_rule.go
+++ b/sumologic/resource_sumologic_cse_threshold_rule.go
@@ -43,7 +43,8 @@ func resourceSumologicCSEThresholdRule() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Schema{
-					Type: schema.TypeString,
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringIsNotEmpty,
 				},
 			},
 			"is_prototype": {


### PR DESCRIPTION
even tho group_by_fields is optional, I need to add validation for elements not being empty strings