### PR TITLE
INVS-1408: resource_sumologic_cse_match_list bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ FEATURES:
 
 BUG FIXES:
 * Enforce validation of `group_by_fields` in cse_*_rule resources, on non empty string elements. (GH-535)
+* Fixes `resource_sumologic_cse_match_list` to allow for match lists with more than 1000 items to be created. (INVS-1048)
 
 ## 2.23.0 (May 24, 2023)
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ FEATURES:
 
 BUG FIXES:
 * Enforce validation of `group_by_fields` in cse_*_rule resources, on non empty string elements. (GH-535)
-* Fixes `resource_sumologic_cse_match_list` to allow for match lists with more than 1000 items to be created. (INVS-1048)
+* Fixes `resource_sumologic_cse_match_list` to allow for match lists with more than 1000 items to be created. (INVS-1408)
 
 ## 2.23.0 (May 24, 2023)
 FEATURES:

--- a/README.md
+++ b/README.md
@@ -53,8 +53,10 @@ Then run `terraform init` to initialize it.
 
 In order to run the full suite of Acceptance tests, run `make testacc`.
 
+To run a single acceptance test, run `TF_ACC=1 go test -v ./sumologic  -run TheNameOfYourTest`
+
 *Note:* 
-- Acceptance tests *create real resources*, and often cost money to run. The environment variables `SUMOLOGIC_ACCESSID`, `SUMOLOGIC_ACCESSKEY`, and `SUMOLOGIC_ENVIRONMENT` must also be set for acceptance tests to work properly.
+- Acceptance tests *create real resources*, and often cost money to run. The environment variables `SUMOLOGIC_ACCESSID`, `SUMOLOGIC_ACCESSKEY`, `SUMOLOGIC_ENVIRONMENT`, `SUMOLOGIC_BASE_URL`,  and `TF_ACC` must also be set for acceptance tests to work properly.
 - Environment variable `SUMOLOGIC_TEST_GOOGLE_APPLICATION_CREDENTIALS` must be set for gcp metrics acceptance tests to work properly (ex. below).
     - export SUMOLOGIC_TEST_GOOGLE_APPLICATION_CREDENTIALS=`cat /path/to/service_acccount.json`
     - Set Environment variable `SUMOLOGIC_ENABLE_GCP_METRICS_ACC_TESTS` to false, to disable acceptance test for Gcp Metrics. 

--- a/README.md
+++ b/README.md
@@ -53,10 +53,19 @@ Then run `terraform init` to initialize it.
 
 In order to run the full suite of Acceptance tests, run `make testacc`.
 
-To run a single acceptance test, run `TF_ACC=1 go test -v ./sumologic  -run TheNameOfYourTest`
+To run a specific acceptance test, run `go test -v ./sumologic  -run TheSpecificTestName`
 
 *Note:* 
-- Acceptance tests *create real resources*, and often cost money to run. The environment variables `SUMOLOGIC_ACCESSID`, `SUMOLOGIC_ACCESSKEY`, `SUMOLOGIC_ENVIRONMENT`, `SUMOLOGIC_BASE_URL`,  and `TF_ACC` must also be set for acceptance tests to work properly.
+- Acceptance tests *create real resources*, and often cost money to run. The environment variables `SUMOLOGIC_ACCESSID`, `SUMOLOGIC_ACCESSKEY`, `SUMOLOGIC_ENVIRONMENT` / `SUMOLOGIC_BASE_URL`,  and `TF_ACC` must also be set for acceptance tests to work properly.
+  - More information on configuration can be found at the [Terraform Provider codelabs documentation](https://github.com/Sanyaku/codelabs/blob/master/backend/pages/SumoLogicTerraformProvider.md).
+  - Stag example:
+     ```sh
+     $ export SUMOLOGIC_ACCESSID="yourAccessID"
+     $ export SUMOLOGIC_ACCESSKEY="yourAccessKey"
+     $ export SUMOLOGIC_ENVIRONMENT="stag"
+     $ export SUMOLOGIC_BASE_URL="https://stag-api.sumologic.net/api/"
+     $ export TF_ACC=1
+     ```
 - Environment variable `SUMOLOGIC_TEST_GOOGLE_APPLICATION_CREDENTIALS` must be set for gcp metrics acceptance tests to work properly (ex. below).
     - export SUMOLOGIC_TEST_GOOGLE_APPLICATION_CREDENTIALS=`cat /path/to/service_acccount.json`
     - Set Environment variable `SUMOLOGIC_ENABLE_GCP_METRICS_ACC_TESTS` to false, to disable acceptance test for Gcp Metrics. 

--- a/README.md
+++ b/README.md
@@ -53,12 +53,11 @@ Then run `terraform init` to initialize it.
 
 In order to run the full suite of Acceptance tests, run `make testacc`.
 
-To run a specific acceptance test, run `go test -v ./sumologic  -run TheSpecificTestName`
+To run a specific acceptance test, run `go test -v ./sumologic  -run YourSpecificTestName`
 
 *Note:* 
 - Acceptance tests *create real resources*, and often cost money to run. The environment variables `SUMOLOGIC_ACCESSID`, `SUMOLOGIC_ACCESSKEY`, `SUMOLOGIC_ENVIRONMENT` / `SUMOLOGIC_BASE_URL`,  and `TF_ACC` must also be set for acceptance tests to work properly.
-  - More information on configuration can be found at the [Terraform Provider codelabs documentation](https://github.com/Sanyaku/codelabs/blob/master/backend/pages/SumoLogicTerraformProvider.md).
-  - Stag example:
+  - For example, you can generate a personal access key in stag-alpha [here](https://cse-stag-alpha.stag.sumologic.net/ui/#/preferences). Once your test runs, you are then capable of viewing the real resources created by Terraform in the [stag-alpha UI](https://cse-stag-alpha.stag.sumologic.net/sec/hud?hours=24).
      ```sh
      $ export SUMOLOGIC_ACCESSID="yourAccessID"
      $ export SUMOLOGIC_ACCESSKEY="yourAccessKey"
@@ -66,6 +65,8 @@ To run a specific acceptance test, run `go test -v ./sumologic  -run TheSpecific
      $ export SUMOLOGIC_BASE_URL="https://stag-api.sumologic.net/api/"
      $ export TF_ACC=1
      ```
+  - More information on configuration can be found at the [Terraform Provider codelabs documentation](https://github.com/Sanyaku/codelabs/blob/master/backend/pages/SumoLogicTerraformProvider.md).
+
 - Environment variable `SUMOLOGIC_TEST_GOOGLE_APPLICATION_CREDENTIALS` must be set for gcp metrics acceptance tests to work properly (ex. below).
     - export SUMOLOGIC_TEST_GOOGLE_APPLICATION_CREDENTIALS=`cat /path/to/service_acccount.json`
     - Set Environment variable `SUMOLOGIC_ENABLE_GCP_METRICS_ACC_TESTS` to false, to disable acceptance test for Gcp Metrics. 

--- a/sumologic/resource_sumologic_cse_match_list.go
+++ b/sumologic/resource_sumologic_cse_match_list.go
@@ -20,12 +20,14 @@ func MatchListItemsDiffSuppressFunc(key, oldValue, newValue string, d *schema.Re
 		key = string(key[:lastDotIndex])
 	}
 
-	// Ignore item comparisons by index since we want to compare the list of items as a whole
-	if key != "items" {
-		return true
-	}
-
 	oldData, newData := d.GetChange(key)
+
+	// Case where two individual items are being compared
+	if key != "items" {
+		oldMap := oldData.(map[string]interface{})
+		newMap := newData.(map[string]interface{})
+		return reflect.DeepEqual(oldMap, newMap)
+	}
 
 	// Check if lists are null or different lengths
 	if oldData == nil || newData == nil {

--- a/sumologic/resource_sumologic_cse_match_list.go
+++ b/sumologic/resource_sumologic_cse_match_list.go
@@ -216,8 +216,6 @@ func resourceSumologicCSEMatchListCreate(d *schema.ResourceData, meta interface{
 
 	}
 
-	println("create: finished resourceSumologicCSEMatchListCreate")
-
 	return resourceSumologicCSEMatchListRead(d, meta)
 }
 
@@ -306,7 +304,6 @@ func resourceSumologicCSEMatchListUpdate(d *schema.ResourceData, meta interface{
 	}
 
 	_, err = createStateConf.WaitForState()
-
 	if err != nil {
 		return fmt.Errorf("error waiting for match list (%s) to be updated: %s", d.Id(), err)
 	}

--- a/sumologic/resource_sumologic_cse_match_list.go
+++ b/sumologic/resource_sumologic_cse_match_list.go
@@ -155,20 +155,12 @@ func setItems(d *schema.ResourceData, items []CSEMatchListItemGet) {
 }
 
 func resourceSumologicCSEMatchListDelete(d *schema.ResourceData, meta interface{}) error {
-	println("delete: started resourceSumologicCSEMatchListDelete")
-
 	c := meta.(*Client)
 	err := c.DeleteCSEMatchList(d.Id())
-
-	println("delete: finished resourceSumologicCSEMatchListDelete")
-
 	return err
-
 }
 
 func resourceSumologicCSEMatchListCreate(d *schema.ResourceData, meta interface{}) error {
-	println("create: starting resourceSumologicCSEMatchListCreate")
-
 	c := meta.(*Client)
 
 	if d.Id() == "" {
@@ -185,8 +177,6 @@ func resourceSumologicCSEMatchListCreate(d *schema.ResourceData, meta interface{
 		}
 		d.SetId(id)
 
-		//Match list items
-		//itemsData := d.Get("items").([]interface{})
 		itemsData := d.Get("items").(*schema.Set).List()
 		var items []CSEMatchListItemPost
 		for _, data := range itemsData {
@@ -236,28 +226,16 @@ func resourceToCSEMatchListItem(data interface{}) CSEMatchListItemPost {
 	item := CSEMatchListItemPost{}
 	if len(itemsSlice) > 0 {
 		itemObj := itemsSlice[0].(map[string]interface{})
-		// for _, map := range itemObj {
-		// 	println("itemObj id: ", )
-		// }
-		// b, err := json.Marshal(itemObj)
-		// if err != nil {
-		// 	log.Fatal(err)
-		// }
-		// fmt.Println("b: ", string(b))
 		item.ID = itemObj["id"].(string)
 		item.Description = itemObj["description"].(string)
 		item.Active = true
 		item.Expiration = itemObj["expiration"].(string)
 		item.Value = itemObj["value"].(string)
-		// println("resourceToCSEMatchListItem itemid1: " + itemObj["id"].(string))
-		// println("resourceToCSEMatchListItem itemid2: " + item.ID)
 	}
-	//println("resourceToCSEMatchListItem returning id", item.ID)
-	return item //, item.ID
+	return item
 }
 
 func resourceSumologicCSEMatchListUpdate(d *schema.ResourceData, meta interface{}) error {
-	println("update: starting resourceSumologicCSEMatchListUpdate")
 	CSEMatchListPost, err := resourceToCSEMatchList(d)
 	if err != nil {
 		return err
@@ -268,62 +246,41 @@ func resourceSumologicCSEMatchListUpdate(d *schema.ResourceData, meta interface{
 		return err
 	}
 
-	//Match list items
-	//itemsData := d.Get("items").([]interface{})
 	itemsData := d.Get("items").(*schema.Set).List()
-	var items []CSEMatchListItemPost
+	var newItems []CSEMatchListItemPost
 	for _, data := range itemsData {
-		//println("in itemsData, id is")
-		item := resourceToCSEMatchListItem([]interface{}{data}) //TODO remove id return
-		// item.ID = ""
-		items = append(items, item)
-		// println("appending id to itemsID: " + id)
-		// itemIds = append(itemIds, id)
+		item := resourceToCSEMatchListItem([]interface{}{data})
+		newItems = append(newItems, item)
 	}
-
-	// itemIdsString := ""
-	// for i := 0; i < len(itemIds); i++ {
-	// 	itemIdsString += itemIds[i] + " "
-	// }
-	// println("update: itemIds are " + itemIdsString)
 
 	CSEMatchListItems := getCSEMatchListItemsInMatchList(d.Id(), meta)
-	var itemIds []string
+	var oldItemIds []string
 	for _, item := range CSEMatchListItems.CSEMatchListItemsGetObjects {
-		//println("current id: ", item.ID)
-		itemIds = append(itemIds, item.ID)
+		oldItemIds = append(oldItemIds, item.ID)
 	}
 
-	currentItemCount := CSEMatchListItems.Total
-	newItemCount := len(itemsData) + currentItemCount
+	oldItemCount := CSEMatchListItems.Total
+	newItemCount := len(itemsData) + oldItemCount
 
-	println(fmt.Sprintf("current count %d, new count %d", currentItemCount, newItemCount))
-
-	if len(items) > 0 {
-		err = c.CreateCSEMatchListItems(items, d.Id())
+	//Add new items
+	if len(newItems) > 0 {
+		err = c.CreateCSEMatchListItems(newItems, d.Id())
 		if err != nil {
 			log.Printf("[WARN] An error occurred while adding match list items to match list id: %s, err: %v", d.Id(), err)
 		}
 
 	}
 
+	// Wait until all new items have finished being indexed in ES
 	CSEMatchListItems = getCSEMatchListItemsInMatchList(d.Id(), meta)
-
-	// Waits until all new items have finished being indexed in ES
-	println(fmt.Sprintf("total %d, len %d, goal %d", CSEMatchListItems.Total, len(CSEMatchListItems.CSEMatchListItemsGetObjects), newItemCount))
 	for CSEMatchListItems.Total < newItemCount {
-		println(fmt.Sprintf("update: only got %d/%d items, sleeping for 3 seconds", CSEMatchListItems.Total, newItemCount))
 		time.Sleep(3 * time.Second)
 		CSEMatchListItems = getCSEMatchListItemsInMatchList(d.Id(), meta)
 	}
 
-	println(fmt.Sprintf("update: checking %d items for deletion", len(CSEMatchListItems.CSEMatchListItemsGetObjects)))
-
-	// Delete all the old items
+	// Delete old items
 	for _, t := range CSEMatchListItems.CSEMatchListItemsGetObjects {
-		//println("update: checking id for deletion: " + t.ID)
-		if contains(itemIds, t.ID) {
-			//println("update: itemIds contains " + t.ID)
+		if contains(oldItemIds, t.ID) {
 			err = c.DeleteCSEMatchListItem(t.ID)
 			if err != nil {
 				log.Printf("[WARN] An error occurred deleting match list item with id: %s, err: %v", t.ID, err)
@@ -331,11 +288,9 @@ func resourceSumologicCSEMatchListUpdate(d *schema.ResourceData, meta interface{
 		}
 	}
 
-	println("update: finished deleting, now getting items")
-
 	createStateConf := &resource.StateChangeConf{
 		Target: []string{
-			fmt.Sprint(len(items)),
+			fmt.Sprint(len(newItems)),
 		},
 		Refresh: func() (interface{}, string, error) {
 			resp, err := c.GetCSEMatchListItemsInMatchList(d.Id())
@@ -355,8 +310,6 @@ func resourceSumologicCSEMatchListUpdate(d *schema.ResourceData, meta interface{
 	if err != nil {
 		return fmt.Errorf("error waiting for match list (%s) to be updated: %s", d.Id(), err)
 	}
-
-	println("update: finished resourceSumologicCSEMatchListUpdate")
 
 	return resourceSumologicCSEMatchListRead(d, meta)
 }

--- a/sumologic/resource_sumologic_cse_match_list.go
+++ b/sumologic/resource_sumologic_cse_match_list.go
@@ -2,10 +2,11 @@ package sumologic
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"log"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func resourceSumologicCSEMatchList() *schema.Resource {
@@ -212,6 +213,8 @@ func resourceSumologicCSEMatchListCreate(d *schema.ResourceData, meta interface{
 		}
 
 	}
+
+	fmt.Println("finished creating match list")
 
 	return resourceSumologicCSEMatchListRead(d, meta)
 }

--- a/sumologic/resource_sumologic_cse_match_list.go
+++ b/sumologic/resource_sumologic_cse_match_list.go
@@ -3,11 +3,73 @@ package sumologic
 import (
 	"fmt"
 	"log"
+	"reflect"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
+
+func MatchListItemsDiffSuppressFunc(key, oldValue, newValue string, d *schema.ResourceData) bool {
+	// Suppresses the diff shown if the items are the same but in different order
+
+	// The key is either the list itself (e.g "items") or a path to the list element (e.g. "items.0")
+	lastDotIndex := strings.LastIndex(key, ".")
+	if lastDotIndex != -1 {
+		key = string(key[:lastDotIndex])
+	}
+
+	// Ignore item comparisons by index since we want to compare the list of items as a whole
+	if key != "items" {
+		return true
+	}
+
+	oldData, newData := d.GetChange(key)
+
+	// Check if lists are null or different lengths
+	if oldData == nil || newData == nil {
+		return false
+	}
+
+	println("key: "+key, fmt.Sprintf("%T", oldData), fmt.Sprintf("%T", newData))
+
+	oldArray := oldData.([]interface{})
+	newArray := newData.([]interface{})
+
+	println("len oldArray: ", len(oldArray), " len newArray:", len(newArray))
+
+	if len(oldArray) != len(newArray) {
+		return false
+	}
+
+	// Check if the new array contains each map in the old array
+	for i := 0; i < len(oldArray); i++ {
+		newArrayContainsOldMap := false
+
+		println(fmt.Sprintf("%T", oldArray[i]))
+
+		oldMap := oldArray[i].(map[string]interface{})
+
+		println(fmt.Sprintf("oldmap %#v", oldMap))
+
+		for j := 0; j < len(newArray); j++ {
+
+			newMap := newArray[j].(map[string]interface{})
+			if reflect.DeepEqual(oldMap, newMap) {
+				println(fmt.Sprintf("newmap match %#v", newMap))
+
+				newArrayContainsOldMap = true
+				break
+			}
+		}
+
+		if !newArrayContainsOldMap {
+			return false
+		}
+	}
+	return true
+}
 
 func resourceSumologicCSEMatchList() *schema.Resource {
 	return &schema.Resource{
@@ -57,8 +119,9 @@ func resourceSumologicCSEMatchList() *schema.Resource {
 				Computed: true,
 			},
 			"items": {
-				Type:     schema.TypeList,
-				Optional: true,
+				Type:             schema.TypeList,
+				Optional:         true,
+				DiffSuppressFunc: MatchListItemsDiffSuppressFunc,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {

--- a/sumologic/resource_sumologic_cse_match_list_test.go
+++ b/sumologic/resource_sumologic_cse_match_list_test.go
@@ -93,6 +93,28 @@ resource "sumologic_cse_match_list" "match_list" {
 `, nDefaultTtl, nDescription, nName, nTargetColumn, liDescription, liExpiration, liValue)
 }
 
+func testCreateCSEMatchListConfigWithOver1000Items(nDefaultTtl int, nDescription string, nName string, nTargetColumn string, liDescription string, liExpiration string, liValue string) string {
+	var str = fmt.Sprintf(`
+resource "sumologic_cse_match_list" "match_list" {
+    default_ttl = "%d"
+    description = "%s"
+    name = "%s"
+    target_column = "%s"
+    items {
+`, nDefaultTtl, nDescription, nName, nTargetColumn)
+
+	for i := 0; i < 1001; i++ {
+		str += fmt.Sprintf(
+			`[
+            description = "%s"
+            expiration = "%s"
+            value = "%s"
+        ],`, liDescription, liExpiration, liValue)
+	}
+	str += "}"
+	return str
+}
+
 func testDeleteCSEMatchListItemConfig(nDefaultTtl int, nDescription string, nName string, nTargetColumn string) string {
 	return fmt.Sprintf(`
 resource "sumologic_cse_match_list" "match_list" {

--- a/sumologic/resource_sumologic_cse_match_list_test.go
+++ b/sumologic/resource_sumologic_cse_match_list_test.go
@@ -24,7 +24,7 @@ func TestAccSumologicSCEMatchList_createAndUpdate(t *testing.T) {
 	liDescription := "Match List Item Description"
 	liExpiration := "2122-02-27T04:00:00"
 	liValue := "value"
-	liCount := 1001
+	liCount := 3
 
 	// Update values
 	uDefaultTtl := 3600
@@ -32,7 +32,7 @@ func TestAccSumologicSCEMatchList_createAndUpdate(t *testing.T) {
 	uliDescription := "Updated Match List item Description"
 	uliExpiration := "2122-02-27T05:00:00"
 	uliValue := "updated value"
-	uliCount := 1001
+	uliCount := 3
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -110,8 +110,6 @@ resource "sumologic_cse_match_list" "match_list" {
     name = "%s"
     target_column = "%s" %s
 }`, nDefaultTtl, nDescription, nName, nTargetColumn, itemsStr)
-
-	fmt.Println(str)
 
 	return str
 }

--- a/sumologic/resource_sumologic_cse_match_list_test.go
+++ b/sumologic/resource_sumologic_cse_match_list_test.go
@@ -32,7 +32,7 @@ func TestAccSumologicSCEMatchList_createAndUpdate(t *testing.T) {
 		CheckDestroy: testAccCSEMatchListDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testCreateCSEMatchListConfig(nDefaultTtl, nDescription, nName, nTargetColumn, liDescription, liExpiration, liValue, 51),
+				Config: testCreateCSEMatchListConfig(nDefaultTtl, nDescription, nName, nTargetColumn, liDescription, liExpiration, liValue, 1000),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckCSEMatchListExists(resourceName, &matchList),
 					testCheckMatchListValues(&matchList, nDefaultTtl, nDescription, nName, nTargetColumn),
@@ -40,7 +40,7 @@ func TestAccSumologicSCEMatchList_createAndUpdate(t *testing.T) {
 				),
 			},
 			{
-				Config: testCreateCSEMatchListConfig(uDefaultTtl, uDescription, nName, nTargetColumn, uliDescription, liExpiration, liValue, 51),
+				Config: testCreateCSEMatchListConfig(uDefaultTtl, uDescription, nName, nTargetColumn, uliDescription, liExpiration, liValue, 1000),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckCSEMatchListExists(resourceName, &matchList),
 					testCheckMatchListValues(&matchList, uDefaultTtl, uDescription, nName, nTargetColumn),
@@ -87,10 +87,10 @@ func testCreateCSEMatchListConfig(nDefaultTtl int, nDescription string, nName st
 
 		itemsStr += fmt.Sprintf(`
     items {
-	description = "%s %d"
+	description = "%s %d %s"
 	expiration = "%s"
 	value = "%s %d %s"
-    }`, liDescription, i, liExpiration, liValue, i, id)
+    }`, liDescription, i, id, liExpiration, liValue, i, id)
 	}
 
 	var str = fmt.Sprintf(`

--- a/sumologic/resource_sumologic_cse_match_list_test.go
+++ b/sumologic/resource_sumologic_cse_match_list_test.go
@@ -45,6 +45,13 @@ func TestAccSumologicSCEMatchList_createAndUpdate(t *testing.T) {
 				),
 			},
 			{
+				Config: testCreateCSEMatchListConfigWithOver1000Items(uDefaultTtl, uDescription, nName, nTargetColumn, uliDescription, liExpiration, liValue),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckCSEMatchListExists(resourceName, &matchList),
+					testCheckMatchListValues(&matchList, uDefaultTtl, uDescription, nName, nTargetColumn),
+				),
+			},
+			{
 				Config: testDeleteCSEMatchListItemConfig(uDefaultTtl, uDescription, nName, nTargetColumn),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckMatchListItemsEmpty(resourceName),

--- a/sumologic/resource_sumologic_cse_match_list_test.go
+++ b/sumologic/resource_sumologic_cse_match_list_test.go
@@ -2,6 +2,7 @@ package sumologic
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -14,17 +15,25 @@ func TestAccSumologicSCEMatchList_createAndUpdate(t *testing.T) {
 	SkipCseTest(t)
 
 	var matchList CSEMatchListGet
+	resourceName := "sumologic_cse_match_list.match_list"
+
+	// Create values
+	nName := fmt.Sprintf("Terraform Test Match List %s", uuid.New())
 	nDefaultTtl := 10800
-	nDescription := "New Match List Description"
-	nName := fmt.Sprintf("Match List Name %s", uuid.New())
+	nDescription := "Match List Description"
 	nTargetColumn := "SrcIp"
 	liDescription := "Match List Item Description"
-	liValue := "value"
 	liExpiration := "2122-02-27T04:00:00"
+	liValue := "value"
+	liCount := 1001
+
+	// Update values
 	uDefaultTtl := 3600
 	uDescription := "Updated Match List Description"
 	uliDescription := "Updated Match List item Description"
-	resourceName := "sumologic_cse_match_list.match_list"
+	uliExpiration := "2122-02-27T05:00:00"
+	uliValue := "updated value"
+	uliCount := 1001
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -32,24 +41,26 @@ func TestAccSumologicSCEMatchList_createAndUpdate(t *testing.T) {
 		CheckDestroy: testAccCSEMatchListDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testCreateCSEMatchListConfig(nDefaultTtl, nDescription, nName, nTargetColumn, liDescription, liExpiration, liValue, 1000),
+				Config: testCreateCSEMatchListConfig(nDefaultTtl, nDescription, nName, nTargetColumn, liDescription, liExpiration, liValue, liCount),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckCSEMatchListExists(resourceName, &matchList),
 					testCheckMatchListValues(&matchList, nDefaultTtl, nDescription, nName, nTargetColumn),
+					testCheckMatchListItemsValuesAndCount(resourceName, liDescription, liExpiration, liValue, liCount),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 				),
 			},
 			{
-				Config: testCreateCSEMatchListConfig(uDefaultTtl, uDescription, nName, nTargetColumn, uliDescription, liExpiration, liValue, 1000),
+				Config: testCreateCSEMatchListConfig(uDefaultTtl, uDescription, nName, nTargetColumn, uliDescription, uliExpiration, uliValue, uliCount),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckCSEMatchListExists(resourceName, &matchList),
 					testCheckMatchListValues(&matchList, uDefaultTtl, uDescription, nName, nTargetColumn),
+					testCheckMatchListItemsValuesAndCount(resourceName, uliDescription, uliExpiration, uliValue, uliCount),
 				),
 			},
 			{
 				Config: testDeleteCSEMatchListItemConfig(uDefaultTtl, uDescription, nName, nTargetColumn),
 				Check: resource.ComposeTestCheckFunc(
-					testCheckMatchListItemsEmpty(resourceName),
+					testCheckMatchListItemsValuesAndCount(resourceName, "", "", "", 0),
 				),
 			},
 		},
@@ -139,31 +150,6 @@ func testCheckCSEMatchListExists(n string, matchList *CSEMatchListGet) resource.
 	}
 }
 
-func testCheckMatchListItemsEmpty(n string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("match List ID is not set")
-		}
-
-		c := testAccProvider.Meta().(*Client)
-		matchListResp, err := c.GetCSEMatchListItemsInMatchList(rs.Primary.ID)
-		if err != nil {
-			return err
-		}
-
-		if len(matchListResp.CSEMatchListItemsGetObjects) != 0 {
-			return fmt.Errorf("match list items not empty")
-		}
-
-		return nil
-	}
-}
-
 func testCheckMatchListValues(matchList *CSEMatchListGet, nDefaultTtl int, nDescription string, nName string, nTargetColumn string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if matchList.DefaultTtl != nDefaultTtl {
@@ -179,6 +165,50 @@ func testCheckMatchListValues(matchList *CSEMatchListGet, nDefaultTtl int, nDesc
 			return fmt.Errorf("bad target column, expected \"%s\", got: %#v", nName, matchList.Name)
 		}
 
+		return nil
+	}
+}
+
+func testCheckMatchListItemsValuesAndCount(resourceName string, expectedDescription string, expectedExpiration string, expectedValue string, expectedCount int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("not found: %s", resourceName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("expected match list ID to be non-empty, but found empty string instead")
+		}
+
+		c := testAccProvider.Meta().(*Client)
+		matchListResp, err := c.GetCSEMatchListItemsInMatchList(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		actualCount := len(matchListResp.CSEMatchListItemsGetObjects)
+		if actualCount != expectedCount {
+			return fmt.Errorf("expected %d match list items, but found %d instead", expectedCount, actualCount)
+		}
+
+		if expectedCount == 0 {
+			return nil
+		}
+
+		for _, item := range matchListResp.CSEMatchListItemsGetObjects {
+			if item.ID == "" {
+				return fmt.Errorf("expected match list item ID to be non-empty, but found empty string instead")
+			}
+			if !strings.Contains(item.Meta.Description, expectedDescription) {
+				return fmt.Errorf("expected match list item description to contain \"%s\", but found \"%s\" instead", expectedDescription, item.Meta.Description)
+			}
+			if item.Expiration != expectedExpiration {
+				return fmt.Errorf("expected expiration to be \"%s\", but found \"%s\" instead", expectedExpiration, item.Expiration)
+			}
+			if !strings.Contains(item.Value, expectedValue) {
+				return fmt.Errorf("expected match list item value to contain \"%s\", but found \"%s\" instead", expectedValue, item.Value)
+			}
+		}
 		return nil
 	}
 }

--- a/sumologic/resource_sumologic_cse_match_list_test.go
+++ b/sumologic/resource_sumologic_cse_match_list_test.go
@@ -30,7 +30,7 @@ func TestAccSumologicSCEMatchList_createAndUpdate(t *testing.T) {
 		CheckDestroy: testAccCSEMatchListDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testCreateCSEMatchListConfig(nDefaultTtl, nDescription, nName, nTargetColumn, liDescription, liExpiration, liValue, 15),
+				Config: testCreateCSEMatchListConfig(nDefaultTtl, nDescription, nName, nTargetColumn, liDescription, liExpiration, liValue, 11),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckCSEMatchListExists(resourceName, &matchList),
 					testCheckMatchListValues(&matchList, nDefaultTtl, nDescription, nName, nTargetColumn),
@@ -38,7 +38,7 @@ func TestAccSumologicSCEMatchList_createAndUpdate(t *testing.T) {
 				),
 			},
 			{
-				Config: testCreateCSEMatchListConfig(uDefaultTtl, uDescription, nName, nTargetColumn, uliDescription, liExpiration, liValue, 15),
+				Config: testCreateCSEMatchListConfig(uDefaultTtl, uDescription, nName, nTargetColumn, uliDescription, liExpiration, liValue, 11),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckCSEMatchListExists(resourceName, &matchList),
 					testCheckMatchListValues(&matchList, uDefaultTtl, uDescription, nName, nTargetColumn),
@@ -96,6 +96,8 @@ resource "sumologic_cse_match_list" "match_list" {
     name = "%s"
     target_column = "%s" %s
 }`, nDefaultTtl, nDescription, nName, nTargetColumn, itemsStr)
+
+	fmt.Println(str)
 
 	return str
 }

--- a/sumologic/resource_sumologic_cse_match_list_test.go
+++ b/sumologic/resource_sumologic_cse_match_list_test.go
@@ -19,9 +19,9 @@ func TestAccSumologicSCEMatchList_createAndUpdate(t *testing.T) {
 	liDescription := "Match List Item Description"
 	liValue := "value"
 	liExpiration := "2122-02-27T04:00:00"
-	uDefaultTtl := 3600
-	uDescription := "Updated Match List Description"
-	uliDescription := "Updated Match List item Description"
+	// uDefaultTtl := 3600
+	// uDescription := "Updated Match List Description"
+	// uliDescription := "Updated Match List item Description"
 	resourceName := "sumologic_cse_match_list.match_list"
 
 	resource.Test(t, resource.TestCase{
@@ -37,19 +37,19 @@ func TestAccSumologicSCEMatchList_createAndUpdate(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 				),
 			},
-			{
-				Config: testCreateCSEMatchListConfig(uDefaultTtl, uDescription, nName, nTargetColumn, uliDescription, liExpiration, liValue, 11),
-				Check: resource.ComposeTestCheckFunc(
-					testCheckCSEMatchListExists(resourceName, &matchList),
-					testCheckMatchListValues(&matchList, uDefaultTtl, uDescription, nName, nTargetColumn),
-				),
-			},
-			{
-				Config: testDeleteCSEMatchListItemConfig(uDefaultTtl, uDescription, nName, nTargetColumn),
-				Check: resource.ComposeTestCheckFunc(
-					testCheckMatchListItemsEmpty(resourceName),
-				),
-			},
+			// {
+			// 	Config: testCreateCSEMatchListConfig(uDefaultTtl, uDescription, nName, nTargetColumn, uliDescription, liExpiration, liValue, 11),
+			// 	Check: resource.ComposeTestCheckFunc(
+			// 		testCheckCSEMatchListExists(resourceName, &matchList),
+			// 		testCheckMatchListValues(&matchList, uDefaultTtl, uDescription, nName, nTargetColumn),
+			// 	),
+			// },
+			// {
+			// 	Config: testDeleteCSEMatchListItemConfig(uDefaultTtl, uDescription, nName, nTargetColumn),
+			// 	Check: resource.ComposeTestCheckFunc(
+			// 		testCheckMatchListItemsEmpty(resourceName),
+			// 	),
+			// },
 		},
 	})
 }

--- a/sumologic/resource_sumologic_cse_match_list_test.go
+++ b/sumologic/resource_sumologic_cse_match_list_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )

--- a/sumologic/resource_sumologic_cse_match_list_test.go
+++ b/sumologic/resource_sumologic_cse_match_list_test.go
@@ -106,10 +106,10 @@ resource "sumologic_cse_match_list" "match_list" {
 	for i := 0; i < 1001; i++ {
 		str += fmt.Sprintf(
 			`[
-            description = "%s"
+            description = "%s %d"
             expiration = "%s"
-            value = "%s"
-        ],`, liDescription, liExpiration, liValue)
+            value = "%s %d"
+        ],`, liDescription, i, liExpiration, liValue, i)
 	}
 	str += "}"
 	return str

--- a/sumologic/resource_sumologic_cse_match_list_test.go
+++ b/sumologic/resource_sumologic_cse_match_list_test.go
@@ -30,7 +30,7 @@ func TestAccSumologicSCEMatchList_createAndUpdate(t *testing.T) {
 		CheckDestroy: testAccCSEMatchListDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testCreateCSEMatchListConfig(nDefaultTtl, nDescription, nName, nTargetColumn, liDescription, liExpiration, liValue),
+				Config: testCreateCSEMatchListConfig(nDefaultTtl, nDescription, nName, nTargetColumn, liDescription, liExpiration, liValue, 15),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckCSEMatchListExists(resourceName, &matchList),
 					testCheckMatchListValues(&matchList, nDefaultTtl, nDescription, nName, nTargetColumn),
@@ -38,53 +38,7 @@ func TestAccSumologicSCEMatchList_createAndUpdate(t *testing.T) {
 				),
 			},
 			{
-				Config: testCreateCSEMatchListConfig(uDefaultTtl, uDescription, nName, nTargetColumn, uliDescription, liExpiration, liValue),
-				Check: resource.ComposeTestCheckFunc(
-					testCheckCSEMatchListExists(resourceName, &matchList),
-					testCheckMatchListValues(&matchList, uDefaultTtl, uDescription, nName, nTargetColumn),
-				),
-			},
-			{
-				Config: testDeleteCSEMatchListItemConfig(uDefaultTtl, uDescription, nName, nTargetColumn),
-				Check: resource.ComposeTestCheckFunc(
-					testCheckMatchListItemsEmpty(resourceName),
-				),
-			},
-		},
-	})
-}
-
-func TestAccSumologicSCEMatchList_createAndUpdateWithOver1000Items(t *testing.T) {
-	SkipCseTest(t)
-
-	var matchList CSEMatchListGet
-	nDefaultTtl := 10800
-	nDescription := "New Match List Description"
-	nName := "Match List Name 1000"
-	nTargetColumn := "SrcIp"
-	liDescription := "Match List Item Description"
-	liValue := "value"
-	liExpiration := "2122-02-27T04:00:00"
-	uDefaultTtl := 3600
-	uDescription := "Updated Match List Description"
-	uliDescription := "Updated Match List item Description"
-	resourceName := "sumologic_cse_match_list.match_list"
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCSEMatchListDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testCreateCSEMatchListConfigWithOver1000Items(nDefaultTtl, nDescription, nName, nTargetColumn, liDescription, liExpiration, liValue),
-				Check: resource.ComposeTestCheckFunc(
-					testCheckCSEMatchListExists(resourceName, &matchList),
-					testCheckMatchListValues(&matchList, nDefaultTtl, nDescription, nName, nTargetColumn),
-					resource.TestCheckResourceAttrSet(resourceName, "id"),
-				),
-			},
-			{
-				Config: testCreateCSEMatchListConfigWithOver1000Items(uDefaultTtl, uDescription, nName, nTargetColumn, uliDescription, liExpiration, liValue),
+				Config: testCreateCSEMatchListConfig(uDefaultTtl, uDescription, nName, nTargetColumn, uliDescription, liExpiration, liValue, 15),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckCSEMatchListExists(resourceName, &matchList),
 					testCheckMatchListValues(&matchList, uDefaultTtl, uDescription, nName, nTargetColumn),
@@ -123,26 +77,10 @@ func testAccCSEMatchListDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testCreateCSEMatchListConfig(nDefaultTtl int, nDescription string, nName string, nTargetColumn string, liDescription string, liExpiration string, liValue string) string {
-	return fmt.Sprintf(`
-resource "sumologic_cse_match_list" "match_list" {
-	default_ttl = "%d"
-	description = "%s"
-	name = "%s"
-	target_column = "%s"
-	items {
-		description = "%s"
-		expiration = "%s"
-		value = "%s"
-	}
-}
-`, nDefaultTtl, nDescription, nName, nTargetColumn, liDescription, liExpiration, liValue)
-}
-
-func testCreateCSEMatchListConfigWithOver1000Items(nDefaultTtl int, nDescription string, nName string, nTargetColumn string, liDescription string, liExpiration string, liValue string) string {
+func testCreateCSEMatchListConfig(nDefaultTtl int, nDescription string, nName string, nTargetColumn string, liDescription string, liExpiration string, liValue string, numItems int) string {
 	var itemsStr = ""
 
-	for i := 0; i < 5; i++ {
+	for i := 0; i < numItems; i++ {
 		itemsStr += fmt.Sprintf(`
     items {
 	description = "%s %d"

--- a/sumologic/sumologic_client.go
+++ b/sumologic/sumologic_client.go
@@ -219,6 +219,9 @@ func (s *Client) Put(urlPath string, payload interface{}) ([]byte, error) {
 	_, etag, _ := s.Get(sumoURL.String())
 
 	body, _ := json.Marshal(payload)
+
+	println(string(body))
+
 	req, err := createNewRequest(http.MethodPut, sumoURL.String(), bytes.NewBuffer(body), s.AccessID, s.AccessKey, s.AuthJwt)
 	if err != nil {
 		return nil, err

--- a/sumologic/sumologic_client.go
+++ b/sumologic/sumologic_client.go
@@ -220,8 +220,6 @@ func (s *Client) Put(urlPath string, payload interface{}) ([]byte, error) {
 
 	body, _ := json.Marshal(payload)
 
-	println(string(body))
-
 	req, err := createNewRequest(http.MethodPut, sumoURL.String(), bytes.NewBuffer(body), s.AccessID, s.AccessKey, s.AuthJwt)
 	if err != nil {
 		return nil, err

--- a/sumologic/sumologic_cse_match_list_item.go
+++ b/sumologic/sumologic_cse_match_list_item.go
@@ -75,7 +75,7 @@ func (s *Client) CreateCSEMatchListItems(CSEMatchListItemPost []CSEMatchListItem
 	var end = 1000
 
 	//If there are more than 1000 items, send requests in batches of 1000 due to the API's maximum item limit allowed per request.
-	for end > len(CSEMatchListItemPost) {
+	for end < len(CSEMatchListItemPost) {
 		err := s.SendCreateCSEMatchListItemsRequest(CSEMatchListItemPost[start:end], MatchListID)
 		if err != nil {
 			return err

--- a/sumologic/sumologic_cse_match_list_item.go
+++ b/sumologic/sumologic_cse_match_list_item.go
@@ -75,7 +75,7 @@ func (s *Client) CreateCSEMatchListItems(CSEMatchListItemPost []CSEMatchListItem
 	var end = 1000
 
 	//If there are more than 1000 items, send requests in batches of 1000 due to the API's maximum item limit allowed per request.
-	for end >= len(CSEMatchListItemPost) {
+	for end > len(CSEMatchListItemPost) {
 		err := s.SendCreateCSEMatchListItemsRequest(CSEMatchListItemPost[start:end], MatchListID)
 		if err != nil {
 			return err

--- a/sumologic/sumologic_cse_match_list_item.go
+++ b/sumologic/sumologic_cse_match_list_item.go
@@ -85,8 +85,6 @@ func (s *Client) SendCreateCSEMatchListItemsRequest(CSEMatchListItemPost []CSEMa
 		return err
 	}
 
-	fmt.Printf("SendCreateCSEMatchListItemsRequest: sent request for %d items\n", len(CSEMatchListItemPost))
-
 	err = json.Unmarshal(responseBody, &response)
 
 	if err != nil {
@@ -100,7 +98,7 @@ func (s *Client) CreateCSEMatchListItems(CSEMatchListItemPost []CSEMatchListItem
 	var start = 0
 	var end = 1000
 
-	//If there are more than 1000 items, send requests in batches of 1000 due to the API's maximum item limit allowed per request.
+	//If there are more than 1000 items, send requests in batches of 1000
 	for end < len(CSEMatchListItemPost) {
 		err := s.SendCreateCSEMatchListItemsRequest(CSEMatchListItemPost[start:end], MatchListID)
 		if err != nil {

--- a/sumologic/sumologic_cse_match_list_item.go
+++ b/sumologic/sumologic_cse_match_list_item.go
@@ -52,18 +52,12 @@ func (s *Client) GetCSEMatchListItemsInMatchList(MatchListId string) (*CSEMatchL
 		return nil, err
 	}
 
-	println(fmt.Sprintf("get: GetCSEMatchListItemsInMatchList response total: %d", response.Total))
-
 	// When the match list has over 1000 items, fetch items from the remaining pages
 	for offset = limit; offset < response.Total; offset += limit {
-		println(fmt.Sprintf("Checking next page from %d to %d", offset, offset+1000))
-
 		nextPageResponse, err := s.SendGetCSEMatchListItemsRequest(MatchListId, offset)
 		if err != nil {
 			return nil, err
 		}
-
-		println(fmt.Sprintf("Next page has %d items", len(nextPageResponse.CSEMatchListItemsGetObjects)))
 
 		for i := 0; i < len(nextPageResponse.CSEMatchListItemsGetObjects); i++ {
 			response.CSEMatchListItemsGetObjects = append(response.CSEMatchListItemsGetObjects, nextPageResponse.CSEMatchListItemsGetObjects[i])
@@ -96,7 +90,6 @@ func (s *Client) SendCreateCSEMatchListItemsRequest(CSEMatchListItemPost []CSEMa
 	err = json.Unmarshal(responseBody, &response)
 
 	if err != nil {
-		fmt.Println(err)
 		return err
 	}
 

--- a/sumologic/sumologic_cse_match_list_item.go
+++ b/sumologic/sumologic_cse_match_list_item.go
@@ -49,8 +49,7 @@ func (s *Client) DeleteCSEMatchListItem(id string) error {
 	return err
 }
 
-func (s *Client) CreateCSEMatchListItems(CSEMatchListItemPost []CSEMatchListItemPost, MatchListID string) error {
-
+func (s *Client) SendCreateCSEMatchListItemsRequest(CSEMatchListItemPost []CSEMatchListItemPost, MatchListID string) error {
 	request := CSEMatchListItemRequestPost{
 		CSEMatchListItemPost: CSEMatchListItemPost,
 	}
@@ -69,6 +68,24 @@ func (s *Client) CreateCSEMatchListItems(CSEMatchListItemPost []CSEMatchListItem
 	}
 
 	return nil
+}
+
+func (s *Client) CreateCSEMatchListItems(CSEMatchListItemPost []CSEMatchListItemPost, MatchListID string) error {
+	var start = 0
+	var end = 1000
+
+	//If there are more than 1000 items, send requests in batches of 1000 due to the API's maximum item limit allowed per request.
+	for end >= len(CSEMatchListItemPost) {
+		err = SendCreateCSEMatchListItemsRequest(CSEMatchListItemPost[start:end], MatchListID)
+		if err != nil {
+			return err
+		}
+		start += 1000
+		end += 1000
+	}
+
+	return SendCreateCSEMatchListItemsRequest(CSEMatchListItemPost[start:len(CSEMatchListItemPost)], MatchListID)
+
 }
 
 func (s *Client) UpdateCSEMatchListItem(CSEMatchListItemPost CSEMatchListItemPost) error {

--- a/sumologic/sumologic_cse_match_list_item.go
+++ b/sumologic/sumologic_cse_match_list_item.go
@@ -53,7 +53,6 @@ func (s *Client) SendCreateCSEMatchListItemsRequest(CSEMatchListItemPost []CSEMa
 	request := CSEMatchListItemRequestPost{
 		CSEMatchListItemPost: CSEMatchListItemPost,
 	}
-	fmt.Printf("request for %d items sent\n", len(CSEMatchListItemPost))
 
 	var response CSEMatchListItemResponse
 
@@ -61,6 +60,8 @@ func (s *Client) SendCreateCSEMatchListItemsRequest(CSEMatchListItemPost []CSEMa
 	if err != nil {
 		return err
 	}
+
+	fmt.Printf("create request for %d items was sent\n", len(CSEMatchListItemPost))
 
 	err = json.Unmarshal(responseBody, &response)
 

--- a/sumologic/sumologic_cse_match_list_item.go
+++ b/sumologic/sumologic_cse_match_list_item.go
@@ -53,6 +53,7 @@ func (s *Client) SendCreateCSEMatchListItemsRequest(CSEMatchListItemPost []CSEMa
 	request := CSEMatchListItemRequestPost{
 		CSEMatchListItemPost: CSEMatchListItemPost,
 	}
+	fmt.Printf("request for %d items sent\n", len(CSEMatchListItemPost))
 
 	var response CSEMatchListItemResponse
 
@@ -64,6 +65,7 @@ func (s *Client) SendCreateCSEMatchListItemsRequest(CSEMatchListItemPost []CSEMa
 	err = json.Unmarshal(responseBody, &response)
 
 	if err != nil {
+		fmt.Println(err)
 		return err
 	}
 

--- a/sumologic/sumologic_cse_match_list_item.go
+++ b/sumologic/sumologic_cse_match_list_item.go
@@ -76,7 +76,7 @@ func (s *Client) CreateCSEMatchListItems(CSEMatchListItemPost []CSEMatchListItem
 
 	//If there are more than 1000 items, send requests in batches of 1000 due to the API's maximum item limit allowed per request.
 	for end >= len(CSEMatchListItemPost) {
-		err = SendCreateCSEMatchListItemsRequest(CSEMatchListItemPost[start:end], MatchListID)
+		err := s.SendCreateCSEMatchListItemsRequest(CSEMatchListItemPost[start:end], MatchListID)
 		if err != nil {
 			return err
 		}
@@ -84,7 +84,7 @@ func (s *Client) CreateCSEMatchListItems(CSEMatchListItemPost []CSEMatchListItem
 		end += 1000
 	}
 
-	return SendCreateCSEMatchListItemsRequest(CSEMatchListItemPost[start:len(CSEMatchListItemPost)], MatchListID)
+	return s.SendCreateCSEMatchListItemsRequest(CSEMatchListItemPost[start:], MatchListID)
 
 }
 


### PR DESCRIPTION
[INVS-1408](https://sumologic.atlassian.net/jira/software/c/projects/INVS/boards/407?modal=detail&selectedIssue=INVS-1408&assignee=627d68d38dd5f30068565c1f): Addresses several bugs when creating/updating match lists with multiple match list items.
- Fixes a customer-reported timeout issue that occurs when > 1000 items are provided
- Fixes a terraform diff issue that occurs when > 10 items are provided
- Fixes a terraform query default limit issue that occurs when fetching > 50 items
- Fixes a terraform query pagination issue that occurs when fetching > 1000 items
- Fixes an update match list issue where old and new item ids were not properly being compared
- Fixes an update match list issue where the deletion step is not properly waited on
- Adds the ability to scale the number of items up or down in the acceptance test
- Adds proper item checks to the acceptance test
- Updates the readme with information on manually running acceptance tests

Testing:
- Ran the acceptance test against stag-alpha with a heck ton of print statements to verify everything was working as expected, and set the number of created and updated list item counts `liCount` & `uliCount` to 1001. Confirmed the process worked in the UI &  that the now more-robust acceptance test criteria passed.
- Note: the default timeout of acceptance tests is 10 min. Since the delete process for this many items takes quite some time, the test timeout period must be increased. For reference, setting both counts to 1001 took ~25 minutes for the test to complete.
> - e.g run `go test -timeout 30m -v ./sumologic  -run TestAccSumologicSCEMatchList_createAndUpdate`
- Otherwise, to avoid slowing down & timing out the rest of the test suite/CICD pipeline, `liCount` and `uliCount` have been left at 3.
