### PR TITLE
INVS-1778: Request custom target column names to determine match list state when appropriate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## 2.27.1 (Unreleased)
+## 2.27.1 (November 14, 2023)
+BUG FIXES: 
+* Fixes `resource_sumologic_cse_match_list` constant change when defining a match list containing a custom column using the custom columns name instead of ID (GH-591)
 
 ## 2.27.0 (September 28, 2023)
 FEATURES:

--- a/sumologic/resource_sumologic_cse_match_list.go
+++ b/sumologic/resource_sumologic_cse_match_list.go
@@ -3,6 +3,7 @@ package sumologic
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -93,7 +94,11 @@ func resourceSumologicCSEMatchListRead(d *schema.ResourceData, meta interface{})
 	var CSEMatchList *CSEMatchListGet
 	id := d.Id()
 
-	CSEMatchList, err := c.GetCSEMatchList(id)
+	// Determine whether the target column is defined using its ID or its name
+	definedTargetColumnIsId, _ := regexp.MatchString("^-?[0-9]*$", d.Get("target_column").(string))
+	definedTargetColumnIsName := !definedTargetColumnIsId
+
+	CSEMatchList, err := c.GetCSEMatchList(id, definedTargetColumnIsName)
 	if err != nil {
 		log.Printf("[WARN] CSE Match List not found when looking by id: %s, err: %v", id, err)
 

--- a/sumologic/resource_sumologic_cse_match_list_test.go
+++ b/sumologic/resource_sumologic_cse_match_list_test.go
@@ -78,7 +78,7 @@ func testAccCSEMatchListDestroy(s *terraform.State) error {
 			return fmt.Errorf("CSE Match List destruction check: CSE Match List ID is not set")
 		}
 
-		s, err := client.GetCSEMatchList(rs.Primary.ID)
+		s, err := client.GetCSEMatchList(rs.Primary.ID, false)
 		if err != nil {
 			return fmt.Errorf("Encountered an error: " + err.Error())
 		}
@@ -136,7 +136,8 @@ func testCheckCSEMatchListExists(n string, matchList *CSEMatchListGet) resource.
 			return fmt.Errorf("match List ID is not set")
 		}
 		c := testAccProvider.Meta().(*Client)
-		matchListResp, err := c.GetCSEMatchList(rs.Primary.ID)
+
+		matchListResp, err := c.GetCSEMatchList(rs.Primary.ID, false)
 		if err != nil {
 			return err
 		}

--- a/sumologic/resource_sumologic_cse_outlier_rule_test.go
+++ b/sumologic/resource_sumologic_cse_outlier_rule_test.go
@@ -3,12 +3,14 @@ package sumologic
 import (
 	"bytes"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
 	"text/template"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAccSumologicCSEOutlierRule_createAndUpdate(t *testing.T) {
@@ -27,7 +29,7 @@ func TestAccSumologicCSEOutlierRule_createAndUpdate(t *testing.T) {
 		GroupByFields:       []string{"user_username"},
 		IsPrototype:         false,
 		MatchExpression:     `objectType="Network"`,
-		Name:                "OutlierRuleTerraformTest",
+		Name:                fmt.Sprintf("OutlierRuleTerraformTest %s", uuid.New()),
 		NameExpression:      "OutlierRuleTerraformTest - {{ user_username }}",
 		RetentionWindowSize: "1209600000",
 		Severity:            1,

--- a/sumologic/resource_sumologic_permissions_test.go
+++ b/sumologic/resource_sumologic_permissions_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
@@ -18,7 +19,7 @@ func TestAccPermission_create(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSumologicPermissionCreate(
-					otherResource, false, "create", "role", "sumologic_role.permission_test_role"),
+					otherResource, false, "create", "role", fmt.Sprintf("sumologic_role.permission_test_role_%s", uuid.New())),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPermissionExists("sumologic_content_permission.content_permission_test", &response, t),
 					testAccCheckPermissionAttributes("sumologic_content_permission.content_permission_test"),
@@ -43,7 +44,8 @@ func TestAccPermission_update(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSumologicPermissionCreate(
-					otherResource, false, "create", "role", "sumologic_role.permission_test_role"),
+					otherResource, false, "create", "role", fmt.Sprintf("sumologic_role.permission_test_role_%s", uuid.New()),
+				),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPermissionExists("sumologic_content_permission.content_permission_test", &response, t),
 					testAccCheckPermissionAttributes("sumologic_content_permission.content_permission_test"),
@@ -78,7 +80,7 @@ func TestAccPermission_delete(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSumologicPermissionCreate(
-					otherResource, false, "create", "role", "sumologic_role.permission_test_role"),
+					otherResource, false, "create", "role", fmt.Sprintf("sumologic_role.permission_test_role_%s", uuid.New())),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPermissionExists("sumologic_content_permission.content_permission_test", &response, t),
 					testAccCheckPermissionAttributes("sumologic_content_permission.content_permission_test"),

--- a/sumologic/resource_sumologic_permissions_test.go
+++ b/sumologic/resource_sumologic_permissions_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
@@ -19,7 +18,7 @@ func TestAccPermission_create(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSumologicPermissionCreate(
-					otherResource, false, "create", "role", fmt.Sprintf("sumologic_role.permission_test_role_%s", uuid.New())),
+					otherResource, false, "create", "role", "sumologic_role.permission_test_role"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPermissionExists("sumologic_content_permission.content_permission_test", &response, t),
 					testAccCheckPermissionAttributes("sumologic_content_permission.content_permission_test"),
@@ -44,8 +43,7 @@ func TestAccPermission_update(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSumologicPermissionCreate(
-					otherResource, false, "create", "role", fmt.Sprintf("sumologic_role.permission_test_role_%s", uuid.New()),
-				),
+					otherResource, false, "create", "role", "sumologic_role.permission_test_role"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPermissionExists("sumologic_content_permission.content_permission_test", &response, t),
 					testAccCheckPermissionAttributes("sumologic_content_permission.content_permission_test"),
@@ -80,7 +78,7 @@ func TestAccPermission_delete(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSumologicPermissionCreate(
-					otherResource, false, "create", "role", fmt.Sprintf("sumologic_role.permission_test_role_%s", uuid.New())),
+					otherResource, false, "create", "role", "sumologic_role.permission_test_role"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPermissionExists("sumologic_content_permission.content_permission_test", &response, t),
 					testAccCheckPermissionAttributes("sumologic_content_permission.content_permission_test"),

--- a/sumologic/resource_sumologic_user_test.go
+++ b/sumologic/resource_sumologic_user_test.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
@@ -164,11 +165,13 @@ func TestAccSumologicUser_update(t *testing.T) {
 }
 
 func testAccCheckSumologicUserConfigImported(firstName string, lastName string, email string, isActive bool, transferTo string) string {
+	testUuid := uuid.New()
+
 	return fmt.Sprintf(`
 resource "sumologic_role" "testRole" {
-	name = "testRole Name"
+	name = "testRole Name %s"
 	capabilities = []
-	description = "testRole Description"
+	description = "testRole Description %s"
 	filter_predicate = ""
 }
 resource "sumologic_user" "foo" {
@@ -179,15 +182,17 @@ resource "sumologic_user" "foo" {
       is_active = %t
       transfer_to = "%s"
 }
-`, firstName, lastName, email, isActive, transferTo)
+`, testUuid, testUuid, firstName, lastName, email, isActive, transferTo)
 }
 
 func testAccSumologicUser(firstName string, lastName string, email string, isActive bool, transferTo string) string {
+	testUuid := uuid.New()
+
 	return fmt.Sprintf(`
 resource "sumologic_role" "testRole" {
-	name = "testRole Name"
+	name = "testRole Name %s"
 	capabilities = []
-	description = "testRole Description"
+	description = "testRole Description %s"
 	filter_predicate = ""
 }
 resource "sumologic_user" "test" {
@@ -198,15 +203,17 @@ resource "sumologic_user" "test" {
     is_active = %t
     transfer_to = "%s"
 }
-`, firstName, lastName, email, isActive, transferTo)
+`, testUuid, testUuid, firstName, lastName, email, isActive, transferTo)
 }
 
 func testAccSumologicUserUpdate(firstName string, lastName string, email string, isActive bool, transferTo string) string {
+	testUuid := uuid.New()
+
 	return fmt.Sprintf(`
 resource "sumologic_role" "testRole" {
-	name = "testRole Name"
+	name = "testRole Name %s"
 	capabilities = []
-	description = "testRole Description"
+	description = "testRole Description %s"
 	filter_predicate = ""
 }
 resource "sumologic_user" "test" {
@@ -217,7 +224,7 @@ resource "sumologic_user" "test" {
       is_active = %t
       transfer_to = "%s"
 }
-`, firstName, lastName, email, isActive, transferTo)
+`, testUuid, testUuid, firstName, lastName, email, isActive, transferTo)
 }
 
 func testAccCheckUserAttributes(name string) resource.TestCheckFunc {

--- a/sumologic/sumologic_cse_match_list.go
+++ b/sumologic/sumologic_cse_match_list.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 )
 
-func (s *Client) GetCSEMatchList(id string) (*CSEMatchListGet, error) {
-	data, _, err := s.Get(fmt.Sprintf("sec/v1/match-lists/%s", id))
+func (s *Client) GetCSEMatchList(id string, getCustomTargetColumnName bool) (*CSEMatchListGet, error) {
+	data, _, err := s.Get(fmt.Sprintf("sec/v1/match-lists/%s?getTargetCustomColumnName=%t", id, getCustomTargetColumnName))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Because the API returns the custom column ID instead of the custom column name in the `target_column` value, if the TF user creates a match list using a custom column name (which is allowed by the API), it detects that the match list is constantly out of sync and needs to update the state. 

This change utilizes a new query parameter that allows the caller to request that the custom column name be returned instead of the ID when looking up a match list. 