### PR TITLE
SUMO-228138: Retryable http client in Sumologic TF provider masking error code bug fix.

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,12 +3,17 @@ package main
 import (
 	"github.com/SumoLogic/terraform-provider-sumologic/sumologic"
 	"github.com/hashicorp/terraform-plugin-sdk/plugin"
+	"log"
 )
 
 var version string // provider version is passed as compile time argument
 var defaultVersion = "dev"
 
 func main() {
+	// Remove any date and time prefix in log package function output to
+	// prevent duplicate timestamp and incorrect log level setting
+	// See: https://developer.hashicorp.com/terraform/plugin/log/writing#duplicate-timestamp-and-incorrect-level-messages
+	log.SetFlags(log.Flags() &^ (log.Ldate | log.Ltime))
 	if version == "" {
 		sumologic.ProviderVersion = defaultVersion
 	} else {

--- a/sumologic/sumologic_client.go
+++ b/sumologic/sumologic_client.go
@@ -10,7 +10,6 @@ import (
 	"log"
 	"net/http"
 	"net/url"
-	"strconv"
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
@@ -64,7 +63,7 @@ func createNewRequest(method, url string, body io.Reader, accessID string, acces
 func logRequestAndResponse(req *http.Request, resp *http.Response) {
 	var maskedHeader = req.Header.Clone()
 	maskedHeader.Set("Authorization", "xxxxxxxxxxx")
-	log.Printf("[DEBUG] Request: [Method=%s] [URL=%s] [Headers=%s]. Response: [Status=%s] [Number of Retries=%s]\n", req.Method, req.URL, maskedHeader, resp.Status, resp.Header.Get("numberOfRetries"))
+	log.Printf("[DEBUG] Request: [Method=%s] [URL=%s] [Headers=%s]. Response: [Status=%s]\n", req.Method, req.URL, maskedHeader, resp.Status)
 }
 
 func (s *Client) PostWithCookies(urlPath string, payload interface{}) ([]byte, []*http.Cookie, error) {
@@ -331,7 +330,6 @@ func (s *Client) Delete(urlPath string) ([]byte, error) {
 
 func ErrorHandler(resp *http.Response, err error, numTries int) (*http.Response, error) {
 	log.Printf("[ERROR] Request %s failed after %d attempts with response: [%s]", resp.Request.URL, numTries, resp.Status)
-	resp.Header.Add("numberOfRetries", strconv.Itoa(numTries))
 	return resp, err
 }
 

--- a/sumologic/sumologic_client.go
+++ b/sumologic/sumologic_client.go
@@ -330,7 +330,7 @@ func (s *Client) Delete(urlPath string) ([]byte, error) {
 }
 
 func ErrorHandler(resp *http.Response, err error, numTries int) (*http.Response, error) {
-	log.Printf("[DEBUG] Resquest Failed after %d number of retries with Response: [%s]", numTries, resp.Status)
+	log.Printf("[ERROR] Request %s failed after %d attempts with response: [%s]", resp.Request.URL, numTries, resp.Status)
 	resp.Header.Add("numberOfRetries", strconv.Itoa(numTries))
 	return resp, err
 }

--- a/sumologic/sumologic_client.go
+++ b/sumologic/sumologic_client.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"strconv"
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
@@ -63,7 +64,7 @@ func createNewRequest(method, url string, body io.Reader, accessID string, acces
 func logRequestAndResponse(req *http.Request, resp *http.Response) {
 	var maskedHeader = req.Header.Clone()
 	maskedHeader.Set("Authorization", "xxxxxxxxxxx")
-	log.Printf("[DEBUG] Request: [Method=%s] [URL=%s] [Headers=%s]. Response: [StatusCode=%s]\n", req.Method, req.URL, maskedHeader, resp.Status)
+	log.Printf("[DEBUG] Request: [Method=%s] [URL=%s] [Headers=%s]. Response: [Status=%s] [Number of Retries=%s]\n", req.Method, req.URL, maskedHeader, resp.Status, resp.Header.Get("numberOfRetries"))
 }
 
 func (s *Client) PostWithCookies(urlPath string, payload interface{}) ([]byte, []*http.Cookie, error) {
@@ -328,12 +329,18 @@ func (s *Client) Delete(urlPath string) ([]byte, error) {
 	return d, nil
 }
 
+func ErrorHandler(resp *http.Response, err error, numTries int) (*http.Response, error) {
+	log.Printf("[DEBUG] Resquest Failed after %d number of retries with Response: [%s]", numTries, resp.Status)
+	resp.Header.Add("numberOfRetries", strconv.Itoa(numTries))
+	return resp, err
+}
+
 func NewClient(accessID, accessKey, authJwt, environment, base_url string, admin bool) (*Client, error) {
 	retryClient := retryablehttp.NewClient()
 	retryClient.RetryMax = 10
 	// Disable DEBUG logs (https://github.com/hashicorp/go-retryablehttp/issues/31)
 	retryClient.Logger = nil
-
+	retryClient.ErrorHandler = ErrorHandler
 	client := Client{
 		AccessID:      accessID,
 		AccessKey:     accessKey,


### PR DESCRIPTION
Sumo logic provider does not show the error code contained in the HTTP response,  but only prints out generic: “failed after 11 attempts“. This was thrown by the HTTP client and was not handled. By adding an error handler in the retryable client it can be handled. 
Jira Ticket:-[SUMO-228138](https://sumologic.atlassian.net/browse/SUMO-228138)

Logs printing after changes and testing in error handler: `[ERROR] Request https://long-api.sumologic.net/api/v1/monitors/root failed after 2 attempts with response: [500 Internal Server Error]
`

Logs printing after changes and testing in API logs:
` [DEBUG] Request: [Method=GET] [URL=https://long-api.sumologic.net/api/v1/monitors/root] [Headers=map[Authorization:[xxxxxxxxxxx] Content-Type:[application/json] User-Agent:[SumoLogicTerraformProvider/dev]]]. Response: [Status=500 Internal Server Error]
`