### PR TITLE
DET-362: Add rule tuning expression import.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 2.28.2 (Unreleased)
 
+BUG FIXES:
+* Uses the recently added API support for `rule_ids` for CSE Rule Tuning Expressions to fix the resource import functionality. (GH-612)
 
 ## 2.28.1 (January 19, 2024)
 

--- a/sumologic/resource_sumologic_cse_rule_tuning_expression.go
+++ b/sumologic/resource_sumologic_cse_rule_tuning_expression.go
@@ -41,7 +41,7 @@ func resourceSumologicCSERuleTuningExpression() *schema.Resource {
 				Required: true,
 			},
 			"rule_ids": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Required: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -98,7 +98,7 @@ func resourceSumologicCSERuleTuningExpressionCreate(d *schema.ResourceData, meta
 			Enabled:     d.Get("enabled").(bool),
 			Exclude:     d.Get("exclude").(bool),
 			IsGlobal:    d.Get("is_global").(bool),
-			RuleIds:     resourceRuleIdsToStringArray(d.Get("rule_ids").([]interface{})),
+			RuleIds:     resourceRuleIdsToStringArray(d.Get("rule_ids").(*schema.Set)),
 		})
 
 		if err != nil {
@@ -125,11 +125,11 @@ func resourceSumologicCSERuleTuningExpressionUpdate(d *schema.ResourceData, meta
 	return resourceSumologicCSERuleTuningExpressionRead(d, meta)
 }
 
-func resourceRuleIdsToStringArray(resourceRuleIds []interface{}) []string {
-	ruleIds := make([]string, len(resourceRuleIds))
-
-	for i, ruleId := range resourceRuleIds {
-		ruleIds[i] = ruleId.(string)
+func resourceRuleIdsToStringArray(resourceRuleIds *schema.Set) []string {
+	rawRuleIds := resourceRuleIds.List()
+	ruleIds := make([]string, len(rawRuleIds))
+	for i, v := range rawRuleIds {
+		ruleIds[i] = v.(string)
 	}
 
 	return ruleIds
@@ -149,6 +149,6 @@ func resourceToCSERuleTuningExpression(d *schema.ResourceData) (CSERuleTuningExp
 		Enabled:     d.Get("enabled").(bool),
 		Exclude:     d.Get("exclude").(bool),
 		IsGlobal:    d.Get("is_global").(bool),
-		RuleIds:     resourceRuleIdsToStringArray(d.Get("rule_ids").([]interface{})),
+		RuleIds:     resourceRuleIdsToStringArray(d.Get("rule_ids").(*schema.Set)),
 	}, nil
 }

--- a/sumologic/resource_sumologic_cse_rule_tuning_expression.go
+++ b/sumologic/resource_sumologic_cse_rule_tuning_expression.go
@@ -75,7 +75,7 @@ func resourceSumologicCSERuleTuningExpressionRead(d *schema.ResourceData, meta i
 	d.Set("enabled", CSERuleTuningExpressionGet.Enabled)
 	d.Set("exclude", CSERuleTuningExpressionGet.Exclude)
 	d.Set("is_global", CSERuleTuningExpressionGet.IsGlobal)
-	d.Set("rule_Ids", CSERuleTuningExpressionGet.RuleIds)
+	d.Set("rule_ids", CSERuleTuningExpressionGet.RuleIds)
 
 	return nil
 }

--- a/sumologic/resource_sumologic_cse_rule_tuning_expression_test.go
+++ b/sumologic/resource_sumologic_cse_rule_tuning_expression_test.go
@@ -2,6 +2,7 @@ package sumologic
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -18,7 +19,7 @@ func TestAccSumologicSCERuleTuningExpression_create(t *testing.T) {
 	nEnabled := true
 	nExclude := true
 	nIsGlobal := false
-	nRuleIds := []string{"LEGACY-S00084"}
+	nRuleIds := []string{"LEGACY-S00084", "THRESHOLD-S00514", "AGGREGATION-S00002"}
 	resourceName := "sumologic_cse_rule_tuning_expression.rule_tuning_expression"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -66,6 +67,11 @@ func testAccCSERuleTuningExpressionDestroy(s *terraform.State) error {
 }
 
 func testCreateCSERuleTuningExpressionConfig(nName string, nDescription string, nExpression string, nEnabled bool, nExclude bool, nIsGlobal bool, nRuleIds []string) string {
+	quotedRuleIds := make([]string, len(nRuleIds))
+	for i, id := range nRuleIds {
+		quotedRuleIds[i] = fmt.Sprintf(`"%s"`, id)
+	}
+
 	return fmt.Sprintf(`
 resource "sumologic_cse_rule_tuning_expression" "rule_tuning_expression" {
 	name = "%s"
@@ -74,9 +80,9 @@ resource "sumologic_cse_rule_tuning_expression" "rule_tuning_expression" {
 	enabled = "%t"
 	exclude = "%t"
 	is_global = "%t"
-	rule_ids = ["%s"]
+	rule_ids = [%s]
 }
-`, nName, nDescription, nExpression, nEnabled, nExclude, nIsGlobal, nRuleIds[0])
+`, nName, nDescription, nExpression, nEnabled, nExclude, nIsGlobal, strings.Join(quotedRuleIds, ", "))
 }
 
 func testCheckCSERuleTuningExpressionExists(n string, ruleTuningExpression *CSERuleTuningExpression) resource.TestCheckFunc {

--- a/sumologic/resource_sumologic_cse_rule_tuning_expression_test.go
+++ b/sumologic/resource_sumologic_cse_rule_tuning_expression_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAccSumologicSCERuleTuningExpression_create(t *testing.T) {
@@ -30,7 +31,7 @@ func TestAccSumologicSCERuleTuningExpression_create(t *testing.T) {
 				Config: testCreateCSERuleTuningExpressionConfig(nName, nDescription, nExpression, nEnabled, nExclude, nIsGlobal, nRuleIds),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckCSERuleTuningExpressionExists(resourceName, &ruleTuningExpression),
-					testCheckRuleTuningExpressionValues(&ruleTuningExpression, nName, nDescription, nExpression, nEnabled, nExclude, nIsGlobal),
+					testCheckRuleTuningExpressionValues(t, &ruleTuningExpression, nName, nDescription, nExpression, nEnabled, nExclude, nIsGlobal, nRuleIds),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 				),
 			},
@@ -108,27 +109,15 @@ func testCheckCSERuleTuningExpressionExists(n string, ruleTuningExpression *CSER
 	}
 }
 
-func testCheckRuleTuningExpressionValues(ruleTuningExpression *CSERuleTuningExpression, nName string, nDescription string, nExpression string, nEnabled bool, nExclude bool, nIsGlobal bool) resource.TestCheckFunc {
+func testCheckRuleTuningExpressionValues(t *testing.T, ruleTuningExpression *CSERuleTuningExpression, nName string, nDescription string, nExpression string, nEnabled bool, nExclude bool, nIsGlobal bool, nRuleIds []string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if ruleTuningExpression.Name != nName {
-			return fmt.Errorf("bad name, expected \"%s\", got: %#v", nName, ruleTuningExpression.Name)
-		}
-		if ruleTuningExpression.Description != nDescription {
-			return fmt.Errorf("bad description, expected \"%s\", got: %#v", nDescription, ruleTuningExpression.Description)
-		}
-		if ruleTuningExpression.Expression != nExpression {
-			return fmt.Errorf("bad expression, expected \"%s\", got: %#v", nExpression, ruleTuningExpression.Expression)
-		}
-		if ruleTuningExpression.Enabled != nEnabled {
-			return fmt.Errorf("bad enabled flag, expected \"%t\", got: %#v", nEnabled, ruleTuningExpression.Enabled)
-		}
-		if ruleTuningExpression.Exclude != nExclude {
-			return fmt.Errorf("bad exclude flag, expected \"%t\", got: %#v", nExclude, ruleTuningExpression.Exclude)
-		}
-		if ruleTuningExpression.IsGlobal != nIsGlobal {
-			return fmt.Errorf("bad isGlobal flag, expected \"%t\", got: %#v", nIsGlobal, ruleTuningExpression.IsGlobal)
-		}
-
+		assert.Equal(t, nName, ruleTuningExpression.Name)
+		assert.Equal(t, nDescription, ruleTuningExpression.Description)
+		assert.Equal(t, nExpression, ruleTuningExpression.Expression)
+		assert.Equal(t, nEnabled, ruleTuningExpression.Enabled)
+		assert.Equal(t, nExclude, ruleTuningExpression.Exclude)
+		assert.Equal(t, nIsGlobal, ruleTuningExpression.IsGlobal)
+		assert.ElementsMatch(t, nRuleIds, ruleTuningExpression.RuleIds)
 		return nil
 	}
 }

--- a/sumologic/resource_sumologic_cse_rule_tuning_expression_test.go
+++ b/sumologic/resource_sumologic_cse_rule_tuning_expression_test.go
@@ -33,6 +33,11 @@ func TestAccSumologicSCERuleTuningExpression_create(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }


### PR DESCRIPTION
Adds support for CSE Rule Tuning Expression import. Uses the recently added API support for `rule_ids` field in the `GET` response.

Note: It changes the schema type for `rule_ids` from `TypeList` to `TypeSet` to handle order independence. State representation for the currently used terraform plugin SDK does not distinguish between those two types:
```
"rule_ids":["AGGREGATION-S00002","LEGACY-S00084","THRESHOLD-S00514"]
```

Steps used to test backward compatibility:

1. Create Rule Tuning Expression (`terraform apply` with prepared Rule Tuning Expression) with the `master` version of Sumologic provder.
2. Upgrade Sumologic provider 
3. Run `terraform plan`:
```
sumologic_cse_rule_tuning_expression.rule_tuning_expression: Refreshing state... [id=85]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```
