### PR TITLE
INVS-1962-cse-tag-schema-fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.28.2 (Unreleased)
-
+BUG FIXES:
+* Fixes bug in `resource_sumologic_cse_tag_schema` where no link or label being passed in value option objects. ( GH-614)
 
 ## 2.28.1 (January 19, 2024)
 

--- a/sumologic/sumologic_cse_tag_schema.go
+++ b/sumologic/sumologic_cse_tag_schema.go
@@ -90,6 +90,6 @@ type CSETagSchema struct {
 
 type ValueOption struct {
 	Value string `json:"value"`
-	Label string `json:"label,omitempty"`
-	Link  string `json:"link,omitempty"`
+	Label string `json:"label"`
+	Link  string `json:"link"`
 }


### PR DESCRIPTION
One client reported tag_schema resource not working. While investigating saw the reason behind was not specifying `link` for value options. Which were omitted when doing the API call.