### PR TITLE
Added changelog entry of bug fixes for GH-610.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,8 @@ BUG FIXES:
 
 BUG FIXES:
 * Uses the recently added API support for `rule_ids` for CSE Rule Tuning Expressions to fix the resource import functionality. (GH-612)
+* Updated logging of Response to print Status instead of Status code. (GH-610)
+* Added error handler to log failed request with correct Error code in response. (GH-610)
 
 ## 2.28.1 (January 19, 2024)
 


### PR DESCRIPTION
Added bug fixes in 2.28.2 unreleased for GH-610.
Updated logging in response with key to Status from StatusCode because we were logging the value of Status but in print message using key StatusCode.
Added error handler in retrylable http client to log error messages with correct error code.
PR: [PR Link](https://github.com/SumoLogic/terraform-provider-sumologic/pull/610)