### PR TITLE
Fixed typo in cse_tag_schema

### DIFF
--- a/website/docs/r/cse_tag_schema.html.markdown
+++ b/website/docs/r/cse_tag_schema.html.markdown
@@ -17,7 +17,7 @@ resource "sumologic_cse_tag_schema" "tag_schema" {
 	free_form = "true"	    
 	value_options {
     	value = "option value"
-    	label = option label"
+    	label = "option label"
 		link = "http://foo.bar.com"
     }
 }


### PR DESCRIPTION
Fixes typo in cse_tag_schema documentation

closes #609 