### PR TITLE
SUMO-236305 change hook to go mod tidy -compat=1.17

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,7 +2,7 @@
 # behavior.
 before:
   hooks:
-    - go mod tidy
+    - go mod tidy -compat=1.17
 builds:
 - env:
     - CGO_ENABLED=0


### PR DESCRIPTION
After some trial and error, running `go mod tidy` with the `-compat=1.17` was necessary to generate the workable set of module versions in https://github.com/SumoLogic/terraform-provider-sumologic/pull/627

But our `goreleaser` job then failed, with a series of errors like:
```
github.com/SumoLogic/terraform-provider-sumologic/sumologic imports
	github.com/hashicorp/terraform-plugin-sdk/helper/resource imports
	github.com/hashicorp/terraform-plugin-sdk/internal/configs imports
	github.com/spf13/afero imports
	github.com/spf13/afero/mem loaded from github.com/spf13/afero@v1.2.2,
	but go 1.16 would select v1.9.2

To upgrade to the versions selected by go 1.16:
	go mod tidy -go=1.16 && go mod tidy -go=1.17
If reproducibility with go 1.16 is not needed:
	go mod tidy -compat=1.17
```
These suggestions didn't help; the issue was that this job was still using the plain `go mod tidy`. Adding the `-compat=1.17` option to the hook in the `goreleaser` config, so it would run it the same way and get matching results, resolved this.

There were still several failed runs, each with ~1 different individual test failure, but it eventually passed.