### PR TITLE
SUMO-237698: handle null in email notification timezone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ENHANCEMENTS:
 * Added support for custom window sizes for the CSE Rules (Aggregation, Chain, Threshold). (GH-623)
 
+BUG FIXES:
+* Fix error while importing monitor having timeZone as `null` in its Email notification object ()
+
 ## 2.28.3 (March 5, 2024)
 
 BUG FIXES:

--- a/sumologic/resource_sumologic_monitors_library_monitor.go
+++ b/sumologic/resource_sumologic_monitors_library_monitor.go
@@ -846,7 +846,9 @@ func resourceSumologicMonitorsLibraryMonitorRead(d *schema.ResourceData, meta in
 			internalNotification["subject"] = internalNotificationDict["subject"].(string)
 			internalNotification["recipients"] = internalNotificationDict["recipients"].([]interface{})
 			internalNotification["message_body"] = internalNotificationDict["messageBody"].(string)
-			internalNotification["time_zone"] = internalNotificationDict["timeZone"].(string)
+			if internalNotificationDict["timeZone"] != nil {
+				internalNotification["time_zone"] = internalNotificationDict["timeZone"].(string)
+			}
 		} else {
 			internalNotification["action_type"] = "NamedConnectionAction"
 			internalNotification["connection_id"] = internalNotificationDict["connectionId"].(string)


### PR DESCRIPTION
While importing a monitor with `timezone: null`, error was being thrown as handling was not there. 