### PR TITLE
INVS-2114: Fix bad request causing timeouts when updating match list items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ ENHANCEMENTS:
 
 BUG FIXES:
 * Fix error while importing monitor having timeZone as `null` in the Email notification object. (GH-637)
-* Fix perpetual diff in Extraction Rules by normalizing the parse expression.  
+* Fix perpetual diff in Extraction Rules by normalizing the parse expression.
+* Fix `resource_sumologic_cse_match_list` timing out when updating match list items
 
 ## 2.28.3 (March 5, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ ENHANCEMENTS:
 BUG FIXES:
 * Fix error while importing monitor having timeZone as `null` in the Email notification object. (GH-637)
 * Fix perpetual diff in Extraction Rules by normalizing the parse expression.
-* Fix `resource_sumologic_cse_match_list` timing out when updating match list items
+* Fix `resource_sumologic_cse_match_list` timing out when updating match list items (GH-640)
 
 ## 2.28.3 (March 5, 2024)
 

--- a/sumologic/resource_sumologic_cse_match_list.go
+++ b/sumologic/resource_sumologic_cse_match_list.go
@@ -3,6 +3,7 @@ package sumologic
 import (
 	"fmt"
 	"log"
+	"os"
 	"regexp"
 	"time"
 
@@ -187,8 +188,9 @@ func resourceSumologicCSEMatchListCreate(d *schema.ResourceData, meta interface{
 			if err != nil {
 				return fmt.Errorf("[ERROR] An error occurred while adding match list items to match list with id %s, err: %v", id, err)
 			}
-
 		}
+
+		fmt.Fprintln(os.Stdout, "resourceSumologicCSEMatchListCreate items: ", items)
 
 		createStateConf := &resource.StateChangeConf{
 			Target: []string{
@@ -282,6 +284,8 @@ func resourceSumologicCSEMatchListUpdate(d *schema.ResourceData, meta interface{
 		}
 	}
 
+	fmt.Fprintln(os.Stdout, "resourceSumologicCSEMatchListUpdate deleteItemIds: ", deleteItemIds, "updateItems: ", updateItems, "addItems: s", addItems)
+
 	// Delete old items
 	for _, oldItem := range CSEMatchListItems.CSEMatchListItemsGetObjects {
 		if contains(deleteItemIds, oldItem.ID) {
@@ -296,7 +300,7 @@ func resourceSumologicCSEMatchListUpdate(d *schema.ResourceData, meta interface{
 	for _, updateItem := range updateItems {
 		err = c.UpdateCSEMatchListItem(updateItem)
 		if err != nil {
-			return fmt.Errorf("[ERROR] An error occurred while updating match list item with id %s, err: %v", t.ID, err)
+			return fmt.Errorf("[ERROR] An error occurred while updating match list item with id %s, err: %v", updateItem.ID, err)
 		}
 	}
 
@@ -304,9 +308,8 @@ func resourceSumologicCSEMatchListUpdate(d *schema.ResourceData, meta interface{
 	if len(addItems) > 0 {
 		err = c.CreateCSEMatchListItems(addItems, d.Id())
 		if err != nil {
-			return fmt.Errorf("[ERROR] An error occurred while adding match list items to match list id %s, err: %v", d.Id(), err)
+			return fmt.Errorf("[ERROR] An error occurred while adding match list items to match list with id %s, err: %v", d.Id(), err)
 		}
-
 	}
 
 	CSEMatchListItems, err = c.GetCSEMatchListItemsInMatchList(d.Id())

--- a/sumologic/resource_sumologic_cse_match_list.go
+++ b/sumologic/resource_sumologic_cse_match_list.go
@@ -3,7 +3,6 @@ package sumologic
 import (
 	"fmt"
 	"log"
-	"os"
 	"regexp"
 	"time"
 
@@ -190,8 +189,6 @@ func resourceSumologicCSEMatchListCreate(d *schema.ResourceData, meta interface{
 			}
 		}
 
-		fmt.Fprintln(os.Stdout, "resourceSumologicCSEMatchListCreate items: ", items)
-
 		createStateConf := &resource.StateChangeConf{
 			Target: []string{
 				fmt.Sprint(len(items)),
@@ -284,8 +281,6 @@ func resourceSumologicCSEMatchListUpdate(d *schema.ResourceData, meta interface{
 		}
 	}
 
-	fmt.Fprintln(os.Stdout, "resourceSumologicCSEMatchListUpdate deleteItemIds: ", deleteItemIds, "updateItems: ", updateItems, "addItems: s", addItems)
-
 	// Delete old items
 	for _, oldItem := range CSEMatchListItems.CSEMatchListItemsGetObjects {
 		if contains(deleteItemIds, oldItem.ID) {
@@ -312,13 +307,8 @@ func resourceSumologicCSEMatchListUpdate(d *schema.ResourceData, meta interface{
 		}
 	}
 
-	CSEMatchListItems, err = c.GetCSEMatchListItemsInMatchList(d.Id())
-	if err != nil {
-		return fmt.Errorf("[ERROR] CSE Match List items not found when looking by match list id %s, err: %v", d.Id(), err)
-	}
-
 	// Wait for update to finish
-	createStateConf := &resource.StateChangeConf{
+	updateStateConf := &resource.StateChangeConf{
 		Target: []string{
 			fmt.Sprint(len(newItems)),
 		},
@@ -336,7 +326,7 @@ func resourceSumologicCSEMatchListUpdate(d *schema.ResourceData, meta interface{
 		ContinuousTargetOccurence: 1,
 	}
 
-	_, err = createStateConf.WaitForState()
+	_, err = updateStateConf.WaitForState()
 	if err != nil {
 		return fmt.Errorf("[ERROR] Error waiting for match list with id %s to be updated: %s", d.Id(), err)
 	}

--- a/sumologic/resource_sumologic_cse_match_list_test.go
+++ b/sumologic/resource_sumologic_cse_match_list_test.go
@@ -40,7 +40,6 @@ func TestAccSumologicSCEMatchList_createAndUpdate(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCSEMatchListDestroy,
 		Steps: []resource.TestStep{
-			// Creates a match list with 1 match list item
 			{
 				Config: testCreateCSEMatchListConfig(nDefaultTtl, nDescription, nName, nTargetColumn, liDescription, liExpiration, liValue, liCount),
 				Check: resource.ComposeTestCheckFunc(
@@ -50,17 +49,6 @@ func TestAccSumologicSCEMatchList_createAndUpdate(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 				),
 			},
-			// Updates the match list, but keeps the 1 match list item the same
-			{
-				Config: testCreateCSEMatchListConfig(uDefaultTtl, uDescription, nName, nTargetColumn, liDescription, liExpiration, liValue, liCount),
-				Check: resource.ComposeTestCheckFunc(
-					testCheckCSEMatchListExists(resourceName, &matchList),
-					testCheckMatchListValues(&matchList, nDefaultTtl, nDescription, nName, nTargetColumn),
-					testCheckMatchListItemsValuesAndCount(resourceName, liDescription, liExpiration, liValue, liCount),
-					resource.TestCheckResourceAttrSet(resourceName, "id"),
-				),
-			},
-			// Deletes the 1 match list item and adds 3 new ones
 			{
 				Config: testCreateCSEMatchListConfig(uDefaultTtl, uDescription, nName, nTargetColumn, uliDescription, uliExpiration, uliValue, uliCount),
 				Check: resource.ComposeTestCheckFunc(
@@ -69,7 +57,6 @@ func TestAccSumologicSCEMatchList_createAndUpdate(t *testing.T) {
 					testCheckMatchListItemsValuesAndCount(resourceName, uliDescription, uliExpiration, uliValue, uliCount),
 				),
 			},
-			// Deletes all the match list items
 			{
 				Config: testDeleteCSEMatchListItemConfig(uDefaultTtl, uDescription, nName, nTargetColumn),
 				Check: resource.ComposeTestCheckFunc(
@@ -107,12 +94,14 @@ func testCreateCSEMatchListConfig(nDefaultTtl int, nDescription string, nName st
 	var itemsStr = ""
 
 	for i := 0; i < numItems; i++ {
+		id := uuid.New()
+
 		itemsStr += fmt.Sprintf(`
     items {
-	description = "%s %d"
+	description = "%s %d %s"
 	expiration = "%s"
-	value = "%s %d"
-    }`, liDescription, i, liExpiration, liValue, i)
+	value = "%s %d %s"
+    }`, liDescription, i, id, liExpiration, liValue, i, id)
 	}
 
 	var str = fmt.Sprintf(`

--- a/sumologic/resource_sumologic_cse_match_list_test.go
+++ b/sumologic/resource_sumologic_cse_match_list_test.go
@@ -52,11 +52,11 @@ func TestAccSumologicSCEMatchList_createAndUpdate(t *testing.T) {
 			},
 			// Updates the match list and its 1 match list item
 			{
-				Config: testCreateCSEMatchListConfig(uDefaultTtl, uDescription, nName, nTargetColumn, liDescription, liExpiration, liValue, liCount),
+				Config: testCreateCSEMatchListConfig(uDefaultTtl, uDescription, nName, nTargetColumn, liDescription, uliExpiration, liValue, liCount),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckCSEMatchListExists(resourceName, &matchList),
-					testCheckMatchListValues(&matchList, nDefaultTtl, nDescription, nName, nTargetColumn),
-					testCheckMatchListItemsValuesAndCount(resourceName, liDescription, liExpiration, liValue, liCount),
+					testCheckMatchListValues(&matchList, uDefaultTtl, uDescription, nName, nTargetColumn),
+					testCheckMatchListItemsValuesAndCount(resourceName, liDescription, uliExpiration, liValue, liCount),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 				),
 			},
@@ -107,14 +107,12 @@ func testCreateCSEMatchListConfig(nDefaultTtl int, nDescription string, nName st
 	var itemsStr = ""
 
 	for i := 0; i < numItems; i++ {
-		id := uuid.New()
-
 		itemsStr += fmt.Sprintf(`
     items {
-	description = "%s %d %s"
+	description = "%s %d"
 	expiration = "%s"
-	value = "%s %d %s"
-    }`, liDescription, i, id, liExpiration, liValue, i, id)
+	value = "%s %d"
+    }`, liDescription, i, liExpiration, liValue, i)
 	}
 
 	var str = fmt.Sprintf(`

--- a/sumologic/resource_sumologic_cse_match_list_test.go
+++ b/sumologic/resource_sumologic_cse_match_list_test.go
@@ -52,11 +52,11 @@ func TestAccSumologicSCEMatchList_createAndUpdate(t *testing.T) {
 			},
 			// Updates the match list and its 1 match list item
 			{
-				Config: testCreateCSEMatchListConfig(uDefaultTtl, uDescription, nName, nTargetColumn, liDescription, uliExpiration, liValue, liCount),
+				Config: testCreateCSEMatchListConfig(uDefaultTtl, uDescription, nName, nTargetColumn, liDescription, liExpiration, liValue, liCount),
 				Check: resource.ComposeTestCheckFunc(
 					testCheckCSEMatchListExists(resourceName, &matchList),
 					testCheckMatchListValues(&matchList, uDefaultTtl, uDescription, nName, nTargetColumn),
-					testCheckMatchListItemsValuesAndCount(resourceName, liDescription, uliExpiration, liValue, liCount),
+					testCheckMatchListItemsValuesAndCount(resourceName, liDescription, liExpiration, liValue, liCount),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 				),
 			},

--- a/sumologic/resource_sumologic_cse_match_list_test.go
+++ b/sumologic/resource_sumologic_cse_match_list_test.go
@@ -2,7 +2,6 @@ package sumologic
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
@@ -25,7 +24,7 @@ func TestAccSumologicSCEMatchList_createAndUpdate(t *testing.T) {
 	liDescription := "Match List Item Description"
 	liExpiration := "2122-02-27T04:00:00"
 	liValue := "value"
-	liCount := 1
+	liCount := 2
 
 	// Update values
 	uDefaultTtl := 3600
@@ -40,7 +39,7 @@ func TestAccSumologicSCEMatchList_createAndUpdate(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCSEMatchListDestroy,
 		Steps: []resource.TestStep{
-			// Creates a match list with 1 match list item
+			// Creates a match list with 2 match list items
 			{
 				Config: testCreateCSEMatchListConfig(nDefaultTtl, nDescription, nName, nTargetColumn, liDescription, liExpiration, liValue, liCount),
 				Check: resource.ComposeTestCheckFunc(
@@ -50,7 +49,7 @@ func TestAccSumologicSCEMatchList_createAndUpdate(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 				),
 			},
-			// Updates the match list and its 1 match list item
+			// Updates the match list and its 2 match list items
 			{
 				Config: testCreateCSEMatchListConfig(uDefaultTtl, uDescription, nName, nTargetColumn, liDescription, liExpiration, liValue, liCount),
 				Check: resource.ComposeTestCheckFunc(
@@ -60,7 +59,7 @@ func TestAccSumologicSCEMatchList_createAndUpdate(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 				),
 			},
-			// Deletes the 1 match list item and adds 3 new ones
+			// Deletes the 2 old match list items and adds 3 new ones
 			{
 				Config: testCreateCSEMatchListConfig(uDefaultTtl, uDescription, nName, nTargetColumn, uliDescription, uliExpiration, uliValue, uliCount),
 				Check: resource.ComposeTestCheckFunc(
@@ -122,8 +121,6 @@ resource "sumologic_cse_match_list" "match_list" {
     name = "%s"
     target_column = "%s" %s
 }`, nDefaultTtl, nDescription, nName, nTargetColumn, itemsStr)
-
-	fmt.Fprintln(os.Stdout, "testCreateCSEMatchListConfig: ", str)
 
 	return str
 }


### PR DESCRIPTION
INVS-2114
- Returns errors instead of just logging them in the Create/Update match list items methods, so that when something like a BAD_REQUEST occurs, we do not timeout while waiting for a successful state change confirmation that never happens.
- Before, updating match list items worked by deleting all old items and then adding all new items. This caused a bug where the terraform plan/apply, based on the item ids computed/returned by the API, was somehow determining that new items were updates to old items. It then POSTed a BAD_REQUEST with invalid `id` params by trying to provide the old ids. This fixes it so that we instead:
  1. DELETE - delete old items that aren't being updated
  2. PUT - update old items with new item values
  3. POST - add remaining new items that aren't updates