### PR TITLE
DET-347: support for suppression_window_size in CSE rules.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 2.28.4 (Unreleased)
 
+FEATURES:
+* Added support for signal suppression window size in CSE Rules. (GH-641)
+
 ENHANCEMENTS:
 * Added support for custom window sizes for the CSE Rules (Aggregation, Chain, Threshold). (GH-623)
 
@@ -30,13 +33,13 @@ BUG FIXES:
 FEATURES:
 * resource/sumologic_monitor: Added support for setting `time_zone` at Monitor level for notifications content (GH-586)
 
-BUG FIXES: 
+BUG FIXES:
 * Fixes `resource_sumologic_cse_match_list` constant change when defining a match list containing a custom column using the custom columns name instead of ID (GH-591)
 
 ## 2.27.0 (September 28, 2023)
 FEATURES:
 * **New Resource:** sumologic_cse_tag_schema (GH-575)
-* **New Resource:** sumologic_cse_context_action (GH-573) 
+* **New Resource:** sumologic_cse_context_action (GH-573)
 
 ENHANCEMENTS:
 * resource/sumologic_cse_inventory_entity_group_configuration: Add new fields to support enhanced functionality. (GH-495)

--- a/sumologic/resource_sumologic_cse_aggregation_rule_test.go
+++ b/sumologic/resource_sumologic_cse_aggregation_rule_test.go
@@ -206,7 +206,7 @@ func testCreateCSEAggregationRuleConfig(t *testing.T, payload *CSEAggregationRul
 			{{ if eq .WindowSize "CUSTOM" }}
 			window_size_millis = "{{ .WindowSizeMilliseconds }}"
 			{{ end }}
-			{{ if ne .SuppressionWindowSize nil }}
+			{{ if .SuppressionWindowSize }}
 			suppression_window_size = {{ .SuppressionWindowSize }}
 			{{ end }}
 		}

--- a/sumologic/resource_sumologic_cse_aggregation_rule_test.go
+++ b/sumologic/resource_sumologic_cse_aggregation_rule_test.go
@@ -22,6 +22,8 @@ func TestAccSumologicCSEAggregationRule_createAndUpdateWithCustomWindowSize(t *t
 
 	updatedPayload := payload
 	updatedPayload.WindowSizeMilliseconds = "14400000" // 4h
+	updatedSuppressionWindow := 5 * 60 * 60 * 1000
+	updatedPayload.SuppressionWindowSize = &updatedSuppressionWindow
 
 	var aggregationRule CSEAggregationRule
 	resourceName := "sumologic_cse_aggregation_rule.aggregation_rule"
@@ -60,10 +62,14 @@ func TestAccSumologicCSEAggregationRule_createAndUpdateToCustomWindowSize(t *tes
 	payload := getCSEAggregationRuleTestPayload()
 	payload.WindowSize = "T30M"
 	payload.WindowSizeMilliseconds = "irrelevant"
+	suppressionWindow := 35 * 60 * 1000
+	payload.SuppressionWindowSize = &suppressionWindow
 
 	updatedPayload := payload
 	updatedPayload.WindowSize = "CUSTOM"
 	updatedPayload.WindowSizeMilliseconds = "14400000" // 4h
+	updatedSuppressionWindow := 5 * 60 * 60 * 1000
+	updatedPayload.SuppressionWindowSize = &updatedSuppressionWindow
 
 	var aggregationRule CSEAggregationRule
 	resourceName := "sumologic_cse_aggregation_rule.aggregation_rule"
@@ -102,10 +108,14 @@ func TestAccSumologicCSEAggregationRule_createAndUpdate(t *testing.T) {
 	payload := getCSEAggregationRuleTestPayload()
 	payload.WindowSize = "T30M"
 	payload.WindowSizeMilliseconds = "irrelevant"
+	suppressionWindow := 35 * 60 * 1000
+	payload.SuppressionWindowSize = &suppressionWindow
 
 	updatedPayload := payload
 	updatedPayload.Name = fmt.Sprintf("Updated Aggregation Rule %s", uuid.New())
 	updatedPayload.WindowSize = "T12H"
+	updatedSuppressionWindow := 13 * 60 * 60 * 1000
+	updatedPayload.SuppressionWindowSize = &updatedSuppressionWindow
 
 	var aggregationRule CSEAggregationRule
 	resourceName := "sumologic_cse_aggregation_rule.aggregation_rule"
@@ -196,6 +206,9 @@ func testCreateCSEAggregationRuleConfig(t *testing.T, payload *CSEAggregationRul
 			{{ if eq .WindowSize "CUSTOM" }}
 			window_size_millis = "{{ .WindowSizeMilliseconds }}"
 			{{ end }}
+			{{ if ne .SuppressionWindowSize nil }}
+			suppression_window_size = {{ .SuppressionWindowSize }}
+			{{ end }}
 		}
 	`
 
@@ -239,6 +252,7 @@ func getCSEAggregationRuleTestPayload() CSEAggregationRule {
 		Tags:                   []string{"foo"},
 		WindowSize:             windowSizeField("CUSTOM"),
 		WindowSizeMilliseconds: "10800000",
+		SuppressionWindowSize:  nil,
 	}
 }
 
@@ -285,6 +299,7 @@ func testCheckCSEAggregationRuleValues(t *testing.T, expected *CSEAggregationRul
 		if strings.EqualFold(actual.WindowSizeName, "CUSTOM") {
 			assert.Equal(t, expected.WindowSizeMilliseconds, string(actual.WindowSize))
 		}
+		assert.Equal(t, expected.SuppressionWindowSize, actual.SuppressionWindowSize)
 		return nil
 	}
 }

--- a/sumologic/resource_sumologic_cse_chain_rule_test.go
+++ b/sumologic/resource_sumologic_cse_chain_rule_test.go
@@ -22,6 +22,8 @@ func TestAccSumologicCSEChainRule_createAndUpdateWithCustomWindowSize(t *testing
 
 	updatedPayload := payload
 	updatedPayload.WindowSizeMilliseconds = "14400000" // 4h
+	updatedSuppressionWindow := 15000000
+	updatedPayload.SuppressionWindowSize = &updatedSuppressionWindow
 
 	var chainRule CSEChainRule
 	resourceName := "sumologic_cse_chain_rule.chain_rule"
@@ -60,10 +62,14 @@ func TestAccSumologicCSEChainRule_createAndUpdateToCustomWindowSize(t *testing.T
 	payload := getCSEChainRuleTestPayload()
 	payload.WindowSize = "T30M"
 	payload.WindowSizeMilliseconds = "irrelevant"
+	suppressionWindow := 2000000
+	payload.SuppressionWindowSize = &suppressionWindow
 
 	updatedPayload := payload
 	updatedPayload.WindowSize = "CUSTOM"
 	updatedPayload.WindowSizeMilliseconds = "14400000" // 4h
+	updatedSuppressionWindow := 20000000
+	updatedPayload.SuppressionWindowSize = &updatedSuppressionWindow
 
 	var chainRule CSEChainRule
 	resourceName := "sumologic_cse_chain_rule.chain_rule"
@@ -102,10 +108,14 @@ func TestAccSumologicCSEChainRule_createAndUpdate(t *testing.T) {
 	payload := getCSEChainRuleTestPayload()
 	payload.WindowSize = "T30M"
 	payload.WindowSizeMilliseconds = "irrelevant"
+	suppressionWindow := 35 * 60 * 1000
+	payload.SuppressionWindowSize = &suppressionWindow
 
 	updatedPayload := payload
 	updatedPayload.Name = fmt.Sprintf("Updated Chain Rule %s", uuid.New())
 	updatedPayload.WindowSize = "T12H"
+	updatedSuppressionWindow := 13 * 60 * 60 * 1000
+	updatedPayload.SuppressionWindowSize = &updatedSuppressionWindow
 
 	var chainRule CSEChainRule
 	resourceName := "sumologic_cse_chain_rule.chain_rule"
@@ -189,6 +199,9 @@ func testCreateCSEChainRuleConfig(t *testing.T, payload *CSEChainRule) string {
 			{{ if eq .WindowSize "CUSTOM" }}
 			window_size_millis = "{{ .WindowSizeMilliseconds }}"
 			{{ end }}
+			{{ if ne .SuppressionWindowSize nil }}
+			suppression_window_size = {{ .SuppressionWindowSize }}
+			{{ end }}
 		}
 		`
 
@@ -221,6 +234,7 @@ func getCSEChainRuleTestPayload() CSEChainRule {
 		Tags:                   []string{"foo"},
 		WindowSize:             windowSizeField("CUSTOM"),
 		WindowSizeMilliseconds: "10800000",
+		SuppressionWindowSize:  nil,
 	}
 }
 
@@ -264,6 +278,7 @@ func testCheckCSEChainRuleValues(t *testing.T, expected *CSEChainRule, actual *C
 		if strings.EqualFold(actual.WindowSizeName, "CUSTOM") {
 			assert.Equal(t, expected.WindowSizeMilliseconds, string(actual.WindowSize))
 		}
+		assert.Equal(t, expected.SuppressionWindowSize, actual.SuppressionWindowSize)
 		return nil
 	}
 }

--- a/sumologic/resource_sumologic_cse_chain_rule_test.go
+++ b/sumologic/resource_sumologic_cse_chain_rule_test.go
@@ -199,7 +199,7 @@ func testCreateCSEChainRuleConfig(t *testing.T, payload *CSEChainRule) string {
 			{{ if eq .WindowSize "CUSTOM" }}
 			window_size_millis = "{{ .WindowSizeMilliseconds }}"
 			{{ end }}
-			{{ if ne .SuppressionWindowSize nil }}
+			{{ if .SuppressionWindowSize }}
 			suppression_window_size = {{ .SuppressionWindowSize }}
 			{{ end }}
 		}

--- a/sumologic/resource_sumologic_cse_first_seen_rule_test.go
+++ b/sumologic/resource_sumologic_cse_first_seen_rule_test.go
@@ -3,12 +3,13 @@ package sumologic
 import (
 	"bytes"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
 	"text/template"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAccSumologicCSEFirstSeenRule_createAndUpdate(t *testing.T) {
@@ -23,15 +24,16 @@ func TestAccSumologicCSEFirstSeenRule_createAndUpdate(t *testing.T) {
 			{EntityType: "_username", Expression: "user_username"},
 			{EntityType: "_hostname", Expression: "dstDevice_hostname"},
 		},
-		FilterExpression:    `objectType="Network"`,
-		GroupByFields:       []string{"user_username"},
-		IsPrototype:         false,
-		Name:                "FirstSeenRuleTerraformTest",
-		NameExpression:      "FirstSeenRuleTerraformTest - {{ user_username }}",
-		RetentionWindowSize: "86400000",
-		Severity:            1,
-		ValueFields:         []string{"dstDevice_hostname"},
-		Version:             1,
+		FilterExpression:      `objectType="Network"`,
+		GroupByFields:         []string{"user_username"},
+		IsPrototype:           false,
+		Name:                  "FirstSeenRuleTerraformTest",
+		NameExpression:        "FirstSeenRuleTerraformTest - {{ user_username }}",
+		RetentionWindowSize:   "86400000",
+		Severity:              1,
+		ValueFields:           []string{"dstDevice_hostname"},
+		Version:               1,
+		SuppressionWindowSize: nil,
 	}
 	updatedPayload := payload
 	updatedPayload.Enabled = false
@@ -115,6 +117,9 @@ resource "sumologic_cse_first_seen_rule" "first_seen_rule" {
   retention_window_size = "{{ .RetentionWindowSize }}"
   severity              = {{ .Severity }}
   value_fields          = {{ quoteStringArray .ValueFields }}
+	{{ if ne .SuppressionWindowSize nil }}
+	suppression_window_size = {{ .SuppressionWindowSize }}
+	{{ end }}
 }
 `))
 	var buffer bytes.Buffer
@@ -162,6 +167,7 @@ func testCheckFirstSeenRuleValues(t *testing.T, expected *CSEFirstSeenRule, actu
 		assert.Equal(t, expected.RetentionWindowSize, actual.RetentionWindowSize)
 		assert.Equal(t, expected.Severity, actual.Severity)
 		assert.Equal(t, expected.ValueFields, actual.ValueFields)
+		assert.Equal(t, expected.SuppressionWindowSize, actual.SuppressionWindowSize)
 
 		return nil
 	}

--- a/sumologic/resource_sumologic_cse_first_seen_rule_test.go
+++ b/sumologic/resource_sumologic_cse_first_seen_rule_test.go
@@ -117,7 +117,7 @@ resource "sumologic_cse_first_seen_rule" "first_seen_rule" {
   retention_window_size = "{{ .RetentionWindowSize }}"
   severity              = {{ .Severity }}
   value_fields          = {{ quoteStringArray .ValueFields }}
-	{{ if ne .SuppressionWindowSize nil }}
+	{{ if .SuppressionWindowSize }}
 	suppression_window_size = {{ .SuppressionWindowSize }}
 	{{ end }}
 }

--- a/sumologic/resource_sumologic_cse_match_rule.go
+++ b/sumologic/resource_sumologic_cse_match_rule.go
@@ -1,9 +1,10 @@
 package sumologic
 
 import (
+	"log"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-	"log"
 )
 
 func resourceSumologicCSEMatchRule() *schema.Resource {
@@ -55,6 +56,12 @@ func resourceSumologicCSEMatchRule() *schema.Resource {
 					ValidateFunc: validation.StringIsNotEmpty,
 				},
 			},
+			"suppression_window_size": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(0, 7*24*60*60*1000),
+				ForceNew:     false,
+			},
 		},
 	}
 }
@@ -87,6 +94,9 @@ func resourceSumologicCSEMatchRuleRead(d *schema.ResourceData, meta interface{})
 	d.Set("severity_mapping", severityMappingToResource(CSEMatchRuleGet.SeverityMapping))
 	d.Set("summary_expression", CSEMatchRuleGet.SummaryExpression)
 	d.Set("tags", CSEMatchRuleGet.Tags)
+	if CSEMatchRuleGet.SuppressionWindowSize != nil {
+		d.Set("suppression_window_size", CSEMatchRuleGet.SuppressionWindowSize)
+	}
 
 	return nil
 }
@@ -102,6 +112,12 @@ func resourceSumologicCSEMatchRuleCreate(d *schema.ResourceData, meta interface{
 	c := meta.(*Client)
 
 	if d.Id() == "" {
+		var suppressionWindowSize *int = nil
+		if suppression, ok := d.GetOk("suppression_window_size"); ok {
+			suppressionInt := suppression.(int)
+			suppressionWindowSize = &suppressionInt
+		}
+
 		id, err := c.CreateCSEMatchRule(CSEMatchRule{
 			DescriptionExpression: d.Get("description_expression").(string),
 			Enabled:               d.Get("enabled").(bool),
@@ -114,6 +130,7 @@ func resourceSumologicCSEMatchRuleCreate(d *schema.ResourceData, meta interface{
 			Stream:                "record",
 			SummaryExpression:     d.Get("summary_expression").(string),
 			Tags:                  resourceToStringArray(d.Get("tags").([]interface{})),
+			SuppressionWindowSize: suppressionWindowSize,
 		})
 
 		if err != nil {
@@ -145,6 +162,12 @@ func resourceToCSEMatchRule(d *schema.ResourceData) (CSEMatchRule, error) {
 		return CSEMatchRule{}, nil
 	}
 
+	var suppressionWindowSize *int = nil
+	if suppression, ok := d.GetOk("suppression_window_size"); ok {
+		suppressionInt := suppression.(int)
+		suppressionWindowSize = &suppressionInt
+	}
+
 	return CSEMatchRule{
 		ID:                    id,
 		DescriptionExpression: d.Get("description_expression").(string),
@@ -158,5 +181,6 @@ func resourceToCSEMatchRule(d *schema.ResourceData) (CSEMatchRule, error) {
 		Stream:                "record",
 		SummaryExpression:     d.Get("summary_expression").(string),
 		Tags:                  resourceToStringArray(d.Get("tags").([]interface{})),
+		SuppressionWindowSize: suppressionWindowSize,
 	}, nil
 }

--- a/sumologic/resource_sumologic_cse_outlier_rule.go
+++ b/sumologic/resource_sumologic_cse_outlier_rule.go
@@ -1,9 +1,10 @@
 package sumologic
 
 import (
+	"log"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-	"log"
 )
 
 func resourceSumologicCSEOutlierRule() *schema.Resource {
@@ -111,6 +112,12 @@ func resourceSumologicCSEOutlierRule() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"suppression_window_size": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(0, 7*24*60*60*1000),
+				ForceNew:     false,
+			},
 		},
 	}
 }
@@ -149,6 +156,9 @@ func resourceSumologicCSEOutlierRuleRead(d *schema.ResourceData, meta interface{
 	d.Set("summary_expression", CSEOutlierRuleGet.SummaryExpression)
 	d.Set("tags", CSEOutlierRuleGet.Tags)
 	d.Set("window_size", CSEOutlierRuleGet.WindowSizeName)
+	if CSEOutlierRuleGet.SuppressionWindowSize != nil {
+		d.Set("suppression_window_size", CSEOutlierRuleGet.SuppressionWindowSize)
+	}
 
 	return nil
 }
@@ -164,6 +174,12 @@ func resourceSumologicCSEOutlierRuleCreate(d *schema.ResourceData, meta interfac
 	c := meta.(*Client)
 
 	if d.Id() == "" {
+		var suppressionWindowSize *int = nil
+		if suppression, ok := d.GetOk("suppression_window_size"); ok {
+			suppressionInt := suppression.(int)
+			suppressionWindowSize = &suppressionInt
+		}
+
 		id, err := c.CreateCSEOutlierRule(CSEOutlierRule{
 			AggregationFunctions:  resourceToAggregationFunctionsArray(d.Get("aggregation_functions").([]interface{})),
 			BaselineWindowSize:    d.Get("baseline_window_size").(string),
@@ -182,6 +198,7 @@ func resourceSumologicCSEOutlierRuleCreate(d *schema.ResourceData, meta interfac
 			SummaryExpression:     d.Get("summary_expression").(string),
 			Tags:                  resourceToStringArray(d.Get("tags").([]interface{})),
 			WindowSize:            windowSizeField(d.Get("window_size").(string)),
+			SuppressionWindowSize: suppressionWindowSize,
 		})
 
 		if err != nil {
@@ -213,6 +230,12 @@ func resourceToCSEOutlierRule(d *schema.ResourceData) (CSEOutlierRule, error) {
 		return CSEOutlierRule{}, nil
 	}
 
+	var suppressionWindowSize *int = nil
+	if suppression, ok := d.GetOk("suppression_window_size"); ok {
+		suppressionInt := suppression.(int)
+		suppressionWindowSize = &suppressionInt
+	}
+
 	return CSEOutlierRule{
 		ID:                    id,
 		AggregationFunctions:  resourceToAggregationFunctionsArray(d.Get("aggregation_functions").([]interface{})),
@@ -232,5 +255,6 @@ func resourceToCSEOutlierRule(d *schema.ResourceData) (CSEOutlierRule, error) {
 		SummaryExpression:     d.Get("summary_expression").(string),
 		Tags:                  resourceToStringArray(d.Get("tags").([]interface{})),
 		WindowSize:            windowSizeField(d.Get("window_size").(string)),
+		SuppressionWindowSize: suppressionWindowSize,
 	}, nil
 }

--- a/sumologic/resource_sumologic_cse_outlier_rule_test.go
+++ b/sumologic/resource_sumologic_cse_outlier_rule_test.go
@@ -132,7 +132,7 @@ resource "sumologic_cse_outlier_rule" "outlier_rule" {
   summary_expression	= "{{ .SummaryExpression }}"
   tags                  = {{ quoteStringArray .Tags }}
   window_size 		 	= "{{ .WindowSize }}"
-	{{ if ne .SuppressionWindowSize nil }}
+	{{ if .SuppressionWindowSize }}
 	suppression_window_size = {{ .SuppressionWindowSize }}
 	{{ end }}
 }

--- a/sumologic/resource_sumologic_cse_outlier_rule_test.go
+++ b/sumologic/resource_sumologic_cse_outlier_rule_test.go
@@ -24,21 +24,24 @@ func TestAccSumologicCSEOutlierRule_createAndUpdate(t *testing.T) {
 		EntitySelectors: []EntitySelector{
 			{EntityType: "_username", Expression: "user_username"},
 		},
-		FloorValue:          0,
-		DeviationThreshold:  3,
-		GroupByFields:       []string{"user_username"},
-		IsPrototype:         false,
-		MatchExpression:     `objectType="Network"`,
-		Name:                fmt.Sprintf("OutlierRuleTerraformTest %s", uuid.New()),
-		NameExpression:      "OutlierRuleTerraformTest - {{ user_username }}",
-		RetentionWindowSize: "1209600000",
-		Severity:            1,
-		SummaryExpression:   "OutlierRuleTerraformTest - {{ user_username }}",
-		Tags:                []string{"OutlierRuleTerraformTest"},
-		WindowSize:          "T24H",
+		FloorValue:            0,
+		DeviationThreshold:    3,
+		GroupByFields:         []string{"user_username"},
+		IsPrototype:           false,
+		MatchExpression:       `objectType="Network"`,
+		Name:                  fmt.Sprintf("OutlierRuleTerraformTest %s", uuid.New()),
+		NameExpression:        "OutlierRuleTerraformTest - {{ user_username }}",
+		RetentionWindowSize:   "1209600000",
+		Severity:              1,
+		SummaryExpression:     "OutlierRuleTerraformTest - {{ user_username }}",
+		Tags:                  []string{"OutlierRuleTerraformTest"},
+		WindowSize:            "T24H",
+		SuppressionWindowSize: nil,
 	}
 	updatedPayload := payload
 	updatedPayload.Enabled = false
+	suppressionWindow := 25 * 60 * 60 * 1000
+	updatedPayload.SuppressionWindowSize = &suppressionWindow
 
 	var result CSEOutlierRule
 
@@ -129,6 +132,9 @@ resource "sumologic_cse_outlier_rule" "outlier_rule" {
   summary_expression	= "{{ .SummaryExpression }}"
   tags                  = {{ quoteStringArray .Tags }}
   window_size 		 	= "{{ .WindowSize }}"
+	{{ if ne .SuppressionWindowSize nil }}
+	suppression_window_size = {{ .SuppressionWindowSize }}
+	{{ end }}
 }
 `))
 	var buffer bytes.Buffer
@@ -181,6 +187,7 @@ func testCheckOutlierRuleValues(t *testing.T, expected *CSEOutlierRule, actual *
 		assert.Equal(t, expected.SummaryExpression, actual.SummaryExpression)
 		assert.Equal(t, expected.Tags, actual.Tags)
 		assert.Equal(t, expected.WindowSize, windowSizeField(actual.WindowSizeName))
+		assert.Equal(t, expected.SuppressionWindowSize, actual.SuppressionWindowSize)
 
 		return nil
 	}

--- a/sumologic/resource_sumologic_cse_threshold_rule_test.go
+++ b/sumologic/resource_sumologic_cse_threshold_rule_test.go
@@ -197,7 +197,7 @@ func testCreateCSEThresholdRuleConfig(t *testing.T, payload *CSEThresholdRule) s
 			{{ if eq .WindowSize "CUSTOM" }}
 			window_size_millis = "{{ .WindowSizeMilliseconds }}"
 			{{ end }}
-			{{ if ne .SuppressionWindowSize nil }}
+			{{ if .SuppressionWindowSize }}
 			suppression_window_size = {{ .SuppressionWindowSize }}
 			{{ end }}
 		}

--- a/sumologic/sumologic_cse_aggregation_rule.go
+++ b/sumologic/sumologic_cse_aggregation_rule.go
@@ -98,4 +98,5 @@ type CSEAggregationRule struct {
 	WindowSize             windowSizeField       `json:"windowSize,omitempty"`
 	WindowSizeName         string                `json:"windowSizeName,omitempty"`
 	WindowSizeMilliseconds string                `json:"windowSizeMilliseconds,omitempty"`
+	SuppressionWindowSize  *int                  `json:"suppressionWindowSize,omitempty"`
 }

--- a/sumologic/sumologic_cse_chain_rule.go
+++ b/sumologic/sumologic_cse_chain_rule.go
@@ -94,4 +94,5 @@ type CSEChainRule struct {
 	WindowSize             windowSizeField      `json:"windowSize,omitempty"`
 	WindowSizeName         string               `json:"windowSizeName,omitempty"`
 	WindowSizeMilliseconds string               `json:"windowSizeMilliseconds,omitempty"`
+	SuppressionWindowSize  *int                 `json:"suppressionWindowSize,omitempty"`
 }

--- a/sumologic/sumologic_cse_first_seen_rule.go
+++ b/sumologic/sumologic_cse_first_seen_rule.go
@@ -91,4 +91,5 @@ type CSEFirstSeenRule struct {
 	Tags                  []string         `json:"tags"`
 	ValueFields           []string         `json:"valueFields"`
 	Version               int              `json:"version"`
+	SuppressionWindowSize *int             `json:"suppressionWindowSize,omitempty"`
 }

--- a/sumologic/sumologic_cse_match_rule.go
+++ b/sumologic/sumologic_cse_match_rule.go
@@ -99,4 +99,5 @@ type CSEMatchRule struct {
 	Stream                string           `json:"stream"`
 	SummaryExpression     string           `json:"summaryExpression"`
 	Tags                  []string         `json:"tags"`
+	SuppressionWindowSize *int             `json:"suppressionWindowSize,omitempty"`
 }

--- a/sumologic/sumologic_cse_outlier_rule.go
+++ b/sumologic/sumologic_cse_outlier_rule.go
@@ -93,4 +93,5 @@ type CSEOutlierRule struct {
 	Tags                  []string              `json:"tags"`
 	WindowSize            windowSizeField       `json:"windowSize,omitempty"`
 	WindowSizeName        string                `json:"windowSizeName,omitempty"`
+	SuppressionWindowSize *int                  `json:"suppressionWindowSize,omitempty"`
 }

--- a/sumologic/sumologic_cse_threshold_rule.go
+++ b/sumologic/sumologic_cse_threshold_rule.go
@@ -92,4 +92,5 @@ type CSEThresholdRule struct {
 	WindowSize             windowSizeField  `json:"windowSize,omitempty"`
 	WindowSizeName         string           `json:"windowSizeName,omitempty"`
 	WindowSizeMilliseconds string           `json:"windowSizeMilliseconds,omitempty"`
+	SuppressionWindowSize  *int             `json:"suppressionWindowSize,omitempty"`
 }

--- a/website/docs/r/cse_aggregation_rule.html.markdown
+++ b/website/docs/r/cse_aggregation_rule.html.markdown
@@ -36,6 +36,7 @@ resource "sumologic_cse_aggregation_rule" "aggregation_rule" {
   tags = ["_mitreAttackTactic:TA0009"]
   trigger_expression = "distinct_eventid_count > 5"
   window_size = "T30M"
+  suppression_window_size = 2100000
 }
 ```
 
@@ -71,6 +72,7 @@ The following arguments are supported:
 - `trigger_expression` - (Required) The expression to determine whether a Signal should be created based on the aggregation results
 - `window_size` - (Required) How long of a window to aggregate records for. Current acceptable values are T05M, T10M, T30M, T60M, T24H, T12H, T05D or CUSTOM
   + `window_size_millis` - (Optional) Used only when `window_size` is set to CUSTOM. Window size in milliseconds ranging from 1 minute to 5 days ("60000" to "432000000").
+- `suppression_window_size` - (Optional) For how long to suppress Signal generation, in milliseconds. Must be greater than `window_size` and less than the global limit of 7 days.
 
 The following attributes are exported:
 

--- a/website/docs/r/cse_chain_rule.html.markdown
+++ b/website/docs/r/cse_chain_rule.html.markdown
@@ -33,6 +33,7 @@ resource "sumologic_cse_chain_rule" "chain_rule" {
   summary_expression = "Signal summary"
   tags = ["_mitreAttackTactic:TA0009"]
   window_size = "T30M"
+  suppression_window_size = 2100000
 }
 ```
 
@@ -57,6 +58,7 @@ The following arguments are supported:
 - `tags` - (Required) The tags of the generated Signals
 - `window_size` - (Required) How long of a window to aggregate records for. Current acceptable values are T05M, T10M, T30M, T60M, T24H, T12H, T05D or CUSTOM
   + `window_size_millis` - (Optional) Used only when `window_size` is set to CUSTOM. Window size in milliseconds ranging from 1 minute to 5 days ("60000" to "432000000").
+- `suppression_window_size` - (Optional) For how long to suppress Signal generation, in milliseconds. Must be greater than `window_size` and less than the global limit of 7 days.
 
 The following attributes are exported:
 

--- a/website/docs/r/cse_first_seen_rule.html.markdown
+++ b/website/docs/r/cse_first_seen_rule.html.markdown
@@ -34,6 +34,7 @@ resource "sumologic_cse_first_seen_rule" "first_seen_rule" {
   retention_window_size = "86400000"
   severity              = 1
   value_fields          = ["dstDevice_hostname"]
+  suppression_window_size = 2100000
 }
 ```
 
@@ -42,7 +43,7 @@ resource "sumologic_cse_first_seen_rule" "first_seen_rule" {
 The following arguments are supported:
 
 - `baseline_type` - (Required) The baseline type. Current acceptable values are GLOBAL or PER_ENTITY
-- `baseline_window_size` - (Required) The baseline window size in milliseconds 
+- `baseline_window_size` - (Required) The baseline window size in milliseconds
 - `category` - (Optional) The category
 - `description_expression` - (Required) The description of the generated Signals
 - `enabled` - (Required) Whether the rule should generate Signals
@@ -52,13 +53,14 @@ The following arguments are supported:
 - `filter_expression` - (Required) The expression for which records to match on
 - `group_by_fields` - (Optional) A list of fields to group records by
 - `is_prototype` - (Optional) Whether the generated Signals should be prototype Signals
-- `name` - (Required) The name of the Rule 
+- `name` - (Required) The name of the Rule
 - `name_expression` - (Required) The name of the generated Signals
 - `retention_window_size` - (Required) The retention window size in milliseconds
 - `severity` - (Required) The severity of the generated Signals
 - `summary_expression` - (Optional) The summary of the generated Signals
 - `tags` - (Optional) The tags of the generated Signals
 - `value_fields` - (Required) The value fields
+- `suppression_window_size` - (Optional) For how long to suppress Signal generation, in milliseconds. Must be greater than 0 and less than the global limit of 7 days.
 
 The following attributes are exported:
 

--- a/website/docs/r/cse_match_rule.html.markdown
+++ b/website/docs/r/cse_match_rule.html.markdown
@@ -27,6 +27,7 @@ resource "sumologic_cse_match_rule" "match_rule" {
   }
   summary_expression = "Signal summary"
   tags = ["_mitreAttackTactic:TA0009"]
+  suppression_window_size = 2100000
 }
 ```
 
@@ -53,6 +54,7 @@ The following arguments are supported:
     - `to` - (Required) The severity value to map to
 - `summary_expression` - (Optional) The summary of the generated Signals
 - `tags` - (Required) The tags of the generated Signals
+- `suppression_window_size` - (Optional) For how long to suppress Signal generation, in milliseconds. Must be greater than 0 and less than the global limit of 7 days.
 
 The following attributes are exported:
 

--- a/website/docs/r/cse_outlier_rule.html.markdown
+++ b/website/docs/r/cse_outlier_rule.html.markdown
@@ -34,6 +34,7 @@ resource "sumologic_cse_first_seen_rule" "first_seen_rule" {
   severity               = 1
   summary_expression     = "Spike in Login Failures - {{ user_username }}"
   window_size            = "T24H"
+  suppression_window_size = 90000000
 }
 ```
 ## Argument Reference
@@ -62,6 +63,7 @@ The following arguments are supported:
 - `summary_expression` - (Optional) The summary of the generated Signals
 - `tags` - (Optional) The tags of the generated Signals
 - `window_size` - (Required) The window size. Current acceptable values are T60M (1 hr) or  T24H (1 day)
+- `suppression_window_size` - (Optional) For how long to suppress Signal generation, in milliseconds. Must be greater than `window_size` and less than the global limit of 7 days.
 
 The following attributes are exported:
 

--- a/website/docs/r/cse_threshold_rule.html.markdown
+++ b/website/docs/r/cse_threshold_rule.html.markdown
@@ -28,6 +28,7 @@ resource "sumologic_cse_threshold_rule" "threshold_rule" {
   summary_expression = "Signal summary"
   tags = ["_mitreAttackTactic:TA0009"]
   window_size = "T30M"
+  suppression_window_size = 2100000
 }
 ```
 
@@ -52,6 +53,7 @@ The following arguments are supported:
 - `tags` - (Required) The tags of the generated Signals
 - `window_size` - (Required) How long of a window to aggregate records for. Current acceptable values are T05M, T10M, T30M, T60M, T24H, T12H, T05D or CUSTOM
   + `window_size_millis` - (Optional) Used only when `window_size` is set to CUSTOM. Window size in milliseconds ranging from 1 minute to 5 days ("60000" to "432000000").
+- `suppression_window_size` - (Optional) For how long to suppress Signal generation, in milliseconds. Must be greater than `window_size` and less than the global limit of 7 days.
 
 The following attributes are exported:
 


### PR DESCRIPTION
Support for optional int parameter in each rule that determines the signal suppression window size with basic validation (value between 0-7d).

TBD if we should pursue more sophisticated validation that compares the value to rule's window size.