### PR TITLE
Increase acceptance tests timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
     name: Matrix Test
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
@@ -77,7 +77,7 @@ jobs:
         go mod download
 
     - name: TF acceptance tests
-      timeout-minutes: 55
+      timeout-minutes: 90
       env:
         TF_ACC: "1"
         TF_ACC_TERRAFORM_VERSION: ${{ matrix.terraform }}


### PR DESCRIPTION
Most of the recent acceptance tests have failed because of getting timed out instead of a test failure