### PR TITLE
stay on pre-2.0 version for now

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,8 @@ jobs:
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: latest
-          args: release --clean
+          version: 1.26.2
+          args: release --rm-dist
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Version `2.0.0` of `goreleaser` was just released, with multiple breaking changes, including:
* The deprecated command-line argument `--rm-dist` (replaced by `--clean`) is no longer accepted.
* Configuration is now required to be version 2; we don't know what changes in the actual configuration this entails.

In light of this, we should stay on the latest 1.x version for now.