### PR TITLE
Update protobuf to v1.33.0 and fix CVE-2024-24786

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -92,6 +92,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20231002182017-d307bd883b97 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231002182017-d307bd883b97 // indirect
 	google.golang.org/grpc v1.57.1 // indirect
-	google.golang.org/protobuf v1.31.0 // indirect
+	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
Addresses https://pkg.go.dev/vuln/GO-2024-2611 
https://nvd.nist.gov/vuln/detail/CVE-2024-24786