### PR TITLE
Add IsIncludedInDefaultSearch field to partition resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.31.2 (Unreleased)
-
+ENHANCEMENTS:
+* Add IsIncludedInDefaultSearch field to partition resource (GH-674)
 
 ## 2.31.1 (July 2, 2024)
 BUG FIXES:

--- a/sumologic/resource_sumologic_cse_match_rule_test.go
+++ b/sumologic/resource_sumologic_cse_match_rule_test.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
@@ -19,7 +20,7 @@ func TestAccSumologicCSEMatchRule_createAndUpdate(t *testing.T) {
 	entitySelectorExpression := "srcDevice_ip"
 	expression := "foo = bar"
 	isPrototype := false
-	name := "Test Match Rule"
+	name := acctest.RandomWithPrefix("Test Match Rule")
 	nameExpression := "Signal Name"
 	severityMappingType := "constant"
 	severityMappingDefault := 5
@@ -27,7 +28,7 @@ func TestAccSumologicCSEMatchRule_createAndUpdate(t *testing.T) {
 	tag := "foo"
 	suppressionWindowSize := 24 * 60 * 60 * 1000
 
-	nameUpdated := "Updated Match Rule"
+	nameUpdated := acctest.RandomWithPrefix("Updated Match Rule")
 	tagUpdated := "bar"
 	suppressionWindowSizeUpdated := 25 * 60 * 60 * 1000
 
@@ -83,7 +84,7 @@ func TestAccSumologicCSEMatchRule_failSuppressionValidation(t *testing.T) {
 	entitySelectorExpression := "srcDevice_ip"
 	expression := "foo = bar"
 	isPrototype := false
-	name := "Test Match Rule"
+	name := acctest.RandomWithPrefix("Test Match Rule")
 	nameExpression := "Signal Name"
 	severityMappingType := "constant"
 	severityMappingDefault := 5

--- a/sumologic/resource_sumologic_cse_network_block_test.go
+++ b/sumologic/resource_sumologic_cse_network_block_test.go
@@ -2,6 +2,8 @@ package sumologic
 
 import (
 	"fmt"
+	"math/rand"
+	"net"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -12,7 +14,7 @@ func TestAccSumologicSCENetworkBlock_create(t *testing.T) {
 	SkipCseTest(t)
 
 	var networkBlock CSENetworkBlock
-	nAddressBlock := "10.0.1.0/26"
+	nAddressBlock := generateRandomCIDRBlock()
 	nLabel := "network block test"
 	nInternal := true
 	nSuppressesSignals := false
@@ -111,4 +113,13 @@ func testCheckNetworkBlockValues(networkBlock *CSENetworkBlock, nAddressBlock st
 		}
 		return nil
 	}
+}
+
+func generateRandomCIDRBlock() string {
+	ip := make(net.IP, 4)
+	for i := 0; i < 4; i++ {
+		ip[i] = byte(rand.Intn(256))
+	}
+
+	return ip.String() + "/26"
 }

--- a/sumologic/resource_sumologic_cse_network_block_test.go
+++ b/sumologic/resource_sumologic_cse_network_block_test.go
@@ -117,9 +117,10 @@ func testCheckNetworkBlockValues(networkBlock *CSENetworkBlock, nAddressBlock st
 
 func generateRandomCIDRBlock() string {
 	ip := make(net.IP, 4)
-	for i := 0; i < 4; i++ {
+	for i := 0; i < 3; i++ {
 		ip[i] = byte(rand.Intn(256))
 	}
+	ip[3] = 0
 
 	return ip.String() + "/26"
 }

--- a/sumologic/resource_sumologic_cse_rule_tuning_expression_test.go
+++ b/sumologic/resource_sumologic_cse_rule_tuning_expression_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/stretchr/testify/assert"
@@ -14,7 +15,7 @@ func TestAccSumologicSCERuleTuningExpression_create(t *testing.T) {
 	SkipCseTest(t)
 
 	var ruleTuningExpression CSERuleTuningExpression
-	nName := "New Rule Tuning Name"
+	nName := acctest.RandomWithPrefix("New Rule Tuning Name")
 	nDescription := "New Rule Tuning Description"
 	nExpression := "expression"
 	nEnabled := true

--- a/sumologic/resource_sumologic_extraction_rule_test.go
+++ b/sumologic/resource_sumologic_extraction_rule_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestAccSumologicFieldExtractionRule_basic(t *testing.T) {
 	var fieldextractionrule FieldExtractionRule
-	testName := FieldsMap["FieldExtractionRule"]["name"+acctest.RandString(8)]
+	testName := FieldsMap["FieldExtractionRule"]["name"] + acctest.RandString(8)
 	testScope := FieldsMap["FieldExtractionRule"]["scope"]
 	testParseExpression := FieldsMap["FieldExtractionRule"]["parseExpression"]
 	testEnabled, _ := strconv.ParseBool(FieldsMap["FieldExtractionRule"]["enabled"])
@@ -48,7 +48,7 @@ func TestAccSumologicFieldExtractionRule_basic(t *testing.T) {
 
 func TestAccSumologicFieldExtractionRule_create(t *testing.T) {
 	var fieldextractionrule FieldExtractionRule
-	testName := FieldsMap["FieldExtractionRule"]["name"+acctest.RandString(8)]
+	testName := FieldsMap["FieldExtractionRule"]["name"] + acctest.RandString(8)
 	testScope := FieldsMap["FieldExtractionRule"]["scope"]
 	testParseExpression := FieldsMap["FieldExtractionRule"]["parseExpression"]
 	testEnabled, _ := strconv.ParseBool(FieldsMap["FieldExtractionRule"]["enabled"])
@@ -116,12 +116,12 @@ func testAccCheckFieldExtractionRuleExists(name string, fieldextractionrule *Fie
 func TestAccSumologicFieldExtractionRule_update(t *testing.T) {
 	var fieldextractionrule FieldExtractionRule
 	randomSuffix := acctest.RandString(8)
-	testName := FieldsMap["FieldExtractionRule"]["name"+randomSuffix]
+	testName := FieldsMap["FieldExtractionRule"]["name"] + randomSuffix
 	testScope := FieldsMap["FieldExtractionRule"]["scope"]
 	testParseExpression := FieldsMap["FieldExtractionRule"]["parseExpression"]
 	testEnabled, _ := strconv.ParseBool(FieldsMap["FieldExtractionRule"]["enabled"])
 
-	testUpdatedName := FieldsMap["FieldExtractionRule"]["updatedName"+randomSuffix]
+	testUpdatedName := FieldsMap["FieldExtractionRule"]["updatedName"] + randomSuffix
 	testUpdatedScope := FieldsMap["FieldExtractionRule"]["updatedScope"]
 	testUpdatedParseExpression := FieldsMap["FieldExtractionRule"]["updatedParseExpression"]
 	testUpdatedEnabled, _ := strconv.ParseBool(FieldsMap["FieldExtractionRule"]["updatedEnabled"])

--- a/sumologic/resource_sumologic_extraction_rule_test.go
+++ b/sumologic/resource_sumologic_extraction_rule_test.go
@@ -17,13 +17,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 func TestAccSumologicFieldExtractionRule_basic(t *testing.T) {
 	var fieldextractionrule FieldExtractionRule
-	testName := FieldsMap["FieldExtractionRule"]["name"]
+	testName := FieldsMap["FieldExtractionRule"]["name"+acctest.RandString(8)]
 	testScope := FieldsMap["FieldExtractionRule"]["scope"]
 	testParseExpression := FieldsMap["FieldExtractionRule"]["parseExpression"]
 	testEnabled, _ := strconv.ParseBool(FieldsMap["FieldExtractionRule"]["enabled"])
@@ -47,7 +48,7 @@ func TestAccSumologicFieldExtractionRule_basic(t *testing.T) {
 
 func TestAccSumologicFieldExtractionRule_create(t *testing.T) {
 	var fieldextractionrule FieldExtractionRule
-	testName := FieldsMap["FieldExtractionRule"]["name"]
+	testName := FieldsMap["FieldExtractionRule"]["name"+acctest.RandString(8)]
 	testScope := FieldsMap["FieldExtractionRule"]["scope"]
 	testParseExpression := FieldsMap["FieldExtractionRule"]["parseExpression"]
 	testEnabled, _ := strconv.ParseBool(FieldsMap["FieldExtractionRule"]["enabled"])
@@ -114,12 +115,13 @@ func testAccCheckFieldExtractionRuleExists(name string, fieldextractionrule *Fie
 
 func TestAccSumologicFieldExtractionRule_update(t *testing.T) {
 	var fieldextractionrule FieldExtractionRule
-	testName := FieldsMap["FieldExtractionRule"]["name"]
+	randomSuffix := acctest.RandString(8)
+	testName := FieldsMap["FieldExtractionRule"]["name"+randomSuffix]
 	testScope := FieldsMap["FieldExtractionRule"]["scope"]
 	testParseExpression := FieldsMap["FieldExtractionRule"]["parseExpression"]
 	testEnabled, _ := strconv.ParseBool(FieldsMap["FieldExtractionRule"]["enabled"])
 
-	testUpdatedName := FieldsMap["FieldExtractionRule"]["updatedName"]
+	testUpdatedName := FieldsMap["FieldExtractionRule"]["updatedName"+randomSuffix]
 	testUpdatedScope := FieldsMap["FieldExtractionRule"]["updatedScope"]
 	testUpdatedParseExpression := FieldsMap["FieldExtractionRule"]["updatedParseExpression"]
 	testUpdatedEnabled, _ := strconv.ParseBool(FieldsMap["FieldExtractionRule"]["updatedEnabled"])

--- a/sumologic/resource_sumologic_partition.go
+++ b/sumologic/resource_sumologic_partition.go
@@ -118,7 +118,7 @@ func resourceSumologicPartitionRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("is_active", spartition.IsActive)
 	d.Set("total_bytes", spartition.TotalBytes)
 	d.Set("index_type", spartition.IndexType)
-	d.Set("is_included_in_default_search", *spartition.IsIncludedInDefaultSearch)
+	d.Set("is_included_in_default_search", spartition.IsIncludedInDefaultSearch)
 
 	return nil
 }

--- a/sumologic/resource_sumologic_partition.go
+++ b/sumologic/resource_sumologic_partition.go
@@ -42,7 +42,7 @@ func resourceSumologicPartition() *schema.Resource {
 					return new == "-1" && old != ""
 				},
 			},
-			"is_compliant": {
+			"is_compliantt": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
@@ -71,6 +71,7 @@ func resourceSumologicPartition() *schema.Resource {
 				Type:        schema.TypeBool,
 				Description: "Indicates whether the partition is included in the default search scope. Configuring this property is exclusively permitted for flex partitions.",
 				Optional:    true,
+				Default:     true,
 			},
 		},
 	}
@@ -113,7 +114,7 @@ func resourceSumologicPartitionRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("name", spartition.Name)
 	d.Set("analytics_tier", spartition.AnalyticsTier)
 	d.Set("retention_period", spartition.RetentionPeriod)
-	d.Set("is_compliant", spartition.IsCompliant)
+	d.Set("is_compliantt", spartition.IsCompliant)
 	d.Set("data_forwarding_id", spartition.DataForwardingId)
 	d.Set("is_active", spartition.IsActive)
 	d.Set("total_bytes", spartition.TotalBytes)
@@ -146,7 +147,7 @@ func resourceToPartition(d *schema.ResourceData) Partition {
 		RoutingExpression:                d.Get("routing_expression").(string),
 		AnalyticsTier:                    d.Get("analytics_tier").(string),
 		RetentionPeriod:                  d.Get("retention_period").(int),
-		IsCompliant:                      d.Get("is_compliant").(bool),
+		IsCompliant:                      d.Get("is_compliantt").(bool),
 		DataForwardingId:                 d.Get("data_forwarding_id").(string),
 		IsActive:                         d.Get("is_active").(bool),
 		TotalBytes:                       d.Get("total_bytes").(int),

--- a/sumologic/resource_sumologic_partition.go
+++ b/sumologic/resource_sumologic_partition.go
@@ -71,6 +71,7 @@ func resourceSumologicPartition() *schema.Resource {
 				Type:        schema.TypeBool,
 				Description: "Indicates whether the partition is included in the default search scope. Configuring this property is exclusively permitted for flex partitions.",
 				Optional:    true,
+				Default:     true,
 			},
 		},
 	}

--- a/sumologic/resource_sumologic_partition.go
+++ b/sumologic/resource_sumologic_partition.go
@@ -67,6 +67,11 @@ func resourceSumologicPartition() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+			"is_included_in_default_search": {
+				Type:        schema.TypeBool,
+				Description: "Indicates whether the partition is included in the default search scope. Configuring this property is exclusively permitted for flex partitions.",
+				Optional:    true,
+			},
 		},
 	}
 }
@@ -113,6 +118,7 @@ func resourceSumologicPartitionRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("is_active", spartition.IsActive)
 	d.Set("total_bytes", spartition.TotalBytes)
 	d.Set("index_type", spartition.IndexType)
+	d.Set("is_included_in_default_search", spartition.IsIncludedInDefaultSearch)
 
 	return nil
 }
@@ -146,5 +152,6 @@ func resourceToPartition(d *schema.ResourceData) Partition {
 		TotalBytes:                       d.Get("total_bytes").(int),
 		IndexType:                        d.Get("index_type").(string),
 		ReduceRetentionPeriodImmediately: d.Get("reduce_retention_period_immediately").(bool),
+		IsIncludedInDefaultSearch:        d.Get("is_included_in_default_search").(bool),
 	}
 }

--- a/sumologic/sumologic_partition.go
+++ b/sumologic/sumologic_partition.go
@@ -26,7 +26,7 @@ func (s *Client) GetPartition(id string) (*Partition, error) {
 	err = json.Unmarshal(data, &spartition)
 	if err != nil {
 		return nil, err
-	} else if spartition.IsActive == false {
+	} else if !spartition.IsActive {
 		return nil, nil
 	}
 
@@ -75,5 +75,5 @@ type Partition struct {
 	TotalBytes                       int    `json:"totalBytes"`
 	IndexType                        string `json:"indexType"`
 	ReduceRetentionPeriodImmediately bool   `json:"reduceRetentionPeriodImmediately,omitempty"`
-	IsIncludedInDefaultSearch        bool   `json:"isIncludedInDefaultSearch"`
+	IsIncludedInDefaultSearch        *bool  `json:"isIncludedInDefaultSearch,omitempty"`
 }

--- a/sumologic/sumologic_partition.go
+++ b/sumologic/sumologic_partition.go
@@ -75,4 +75,5 @@ type Partition struct {
 	TotalBytes                       int    `json:"totalBytes"`
 	IndexType                        string `json:"indexType"`
 	ReduceRetentionPeriodImmediately bool   `json:"reduceRetentionPeriodImmediately,omitempty"`
+	IsIncludedInDefaultSearch        bool   `json:"isIncludedInDefaultSearch"`
 }

--- a/website/docs/r/partition.html.markdown
+++ b/website/docs/r/partition.html.markdown
@@ -15,6 +15,7 @@ resource "sumologic_partition" "examplePartition" {
   routing_expression = "_sourcecategory=*/Terraform"
   analytics_tier = "continuous"
   is_compliant = false
+  is_included_in_default_search = true
   lifecycle {
     prevent_destroy = true
   }
@@ -27,10 +28,11 @@ The following arguments are supported:
 
 - `name` - (Required, Forces new resource) The name of the partition.
 - `routing_expression` - (Required) The query that defines the data to be included in the partition.
-- `analytics_tier` - (Optional) The cloud flex analytics tier for your data; only relevant if your account has basic analytics enabled. If no value is supplied, partition will be created in continuous tier. Other possible values are : "frequent" and "infrequent".
+- `analytics_tier` - (Optional) The cloud flex analytics tier for your data; only relevant if your account has basic analytics enabled. If no value is supplied, partition will be created in continuous tier. Other possible values are : "frequent" and "infrequent". For flex partition, you can leave it empty or send flex.
 - `retention_period` - (Optional) The number of days to retain data in the partition, or -1 to use the default value for your account. Only relevant if your account has variable retention enabled.
 - `is_compliant` - (Optional) Whether the partition is compliant or not. Mark a partition as compliant if it contains data used for compliance or audit purpose. Retention for a compliant partition can only be increased and cannot be reduced after the partition is marked compliant. A partition once marked compliant, cannot be marked non-compliant later.
 - `reduce_retention_period_immediately` - (Optional) This is required on update if the newly specified retention period is less than the existing retention period. In such a situation, a value of true says that data between the existing retention period and the new retention period should be deleted immediately; if false, such data will be deleted after seven days. This property is optional and ignored if the specified retentionPeriod is greater than or equal to the current retention period.
+- `is_included_in_default_search` - Indicates whether the partition is included in the default search scope. When executing a query such as "error | count," certain partitions are automatically part of the search scope. However, for specific partitions, the user must explicitly mention the partition using the _index term, as in "_index=webApp error | count". This property governs the default inclusion of the partition in the search scope. Configuring this property is exclusively permitted for flex partitions.
 
 ## Attributes reference
 


### PR DESCRIPTION
For flex partitions, there is an option to included the partition in default search or not. Added support for this option in partition resource. 

Also added randomness in names of some tests which were failing.