### PR TITLE
INVS-2397-cse-log-mapping-import-fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2.31.2 (Unreleased)
-
+BUG FIXES:
+* Fix cse_log_mappings resource conversion affecting import  (GH-675)
 
 ## 2.31.1 (July 2, 2024)
 BUG FIXES:

--- a/sumologic/resource_sumologic_cse_log_mapping_test.go
+++ b/sumologic/resource_sumologic_cse_log_mapping_test.go
@@ -34,7 +34,7 @@ func TestAccSumologicSCELogMapping_create(t *testing.T) {
 		AlternateValues:  []string{"altValue"},
 		TimeZone:         "UTC",
 		SplitDelimiter:   ",",
-		SplitIndex:       "0",
+		SplitIndex:       "1",
 		FieldJoin:        []string{"and"},
 		JoinDelimiter:    "",
 		FormatParameters: []string{"param"},
@@ -245,6 +245,9 @@ func testCheckLogMappingValues(logMapping *CSELogMapping, lmName string, lmRecor
 		if logMapping.SkippedValues[0] != lmSkippedValues {
 			return fmt.Errorf("bad skippedValues, expected \"%s\", got: %#v", lmSkippedValues, logMapping.SkippedValues[0])
 		}
+
+		lookup := logMapping.Fields[0].LookUp
+
 		if logMapping.Fields[0].Name != lmField.Name ||
 			logMapping.Fields[0].Value != lmField.Value ||
 			logMapping.Fields[0].ValueType != lmField.ValueType ||
@@ -258,7 +261,7 @@ func testCheckLogMappingValues(logMapping *CSELogMapping, lmName string, lmRecor
 			logMapping.Fields[0].SplitIndex != lmField.SplitIndex ||
 			logMapping.Fields[0].FieldJoin[0] != lmField.FieldJoin[0] ||
 			logMapping.Fields[0].JoinDelimiter != lmField.JoinDelimiter ||
-			logMapping.Fields[0].LookUp[0].Key != lmLookUp.Key || logMapping.Fields[0].LookUp[0].Value != lmLookUp.Value {
+			(*lookup)[0].Key != lmLookUp.Key || (*lookup)[0].Value != lmLookUp.Value {
 
 			return fmt.Errorf("bad field, expected \"%#v\", got: %#v", lmField, logMapping.Fields[0])
 		}

--- a/sumologic/sumologic_cse_log_mapping.go
+++ b/sumologic/sumologic_cse_log_mapping.go
@@ -89,21 +89,21 @@ type CSELogMapping struct {
 }
 
 type CSELogMappingField struct {
-	Name             string                `json:"name"`
-	Value            string                `json:"value"`
-	ValueType        string                `json:"valueType"`
-	SkippedValues    []string              `json:"skippedValues"`
-	DefaultValue     string                `json:"defaultValue"`
-	Format           string                `json:"format"`
-	CaseInsensitive  bool                  `json:"caseInsensitive"`
-	AlternateValues  []string              `json:"alternateValues"`
-	TimeZone         string                `json:"timeZone"`
-	SplitDelimiter   string                `json:"splitDelimiter"`
-	SplitIndex       string                `json:"splitIndex"`
-	FieldJoin        []string              `json:"fieldJoin"`
-	JoinDelimiter    string                `json:"joinDelimiter"`
-	FormatParameters []string              `json:"formatParameters"`
-	LookUp           []CSELogMappingLookUp `json:"lookup"`
+	Name             string                 `json:"name"`
+	Value            string                 `json:"value,omitempty"`
+	ValueType        string                 `json:"valueType,omitempty"`
+	SkippedValues    []string               `json:"skippedValues,omitempty"`
+	DefaultValue     string                 `json:"defaultValue,omitempty"`
+	Format           string                 `json:"format,omitempty"`
+	CaseInsensitive  bool                   `json:"caseInsensitive,omitempty"`
+	AlternateValues  []string               `json:"alternateValues,omitempty"`
+	TimeZone         string                 `json:"timeZone,omitempty"`
+	SplitDelimiter   string                 `json:"splitDelimiter,omitempty"`
+	SplitIndex       string                 `json:"splitIndex,omitempty"`
+	FieldJoin        []string               `json:"fieldJoin,omitempty"`
+	JoinDelimiter    string                 `json:"joinDelimiter,omitempty"`
+	FormatParameters []string               `json:"formatParameters,omitempty"`
+	LookUp           *[]CSELogMappingLookUp `json:"lookup,omitempty"`
 }
 
 type CSELogMappingLookUp struct {


### PR DESCRIPTION
Addresses: https://sumologic.atlassian.net/browse/INVS-2397
slack conv: https://sumologic.slack.com/archives/CAU3N0Y92/p1721397319790159


when using `terraform plan -generate-config-out="main.tf"`  produced cse_log_mappings resources are missing required field `fields`

was able to reproduce in local test:
```
╷
│ Error: Insufficient fields blocks
│ 
│   on generated_resources.tf line 1:
│   (source code not available)
│ 
│ At least 1 "fields" blocks are required.
╵
```

was a little hard to find the root cause since there was no error or exception in log.

TLDR: 
there is a discrepancy in field `splitIndex` type definition between API(`string`) and resource in terraform provider(`int`), so `setFields` function in `resource_sumologic_cse_log_mappings.go` was silently failing for log mappings having splitIndex as null ( was expecting there a more evident error ¯\_(ツ)_/¯ )

while tackling this, spot also couple discrepancies on "required" fields in `sumologic_cse_log_mapping.go` vs CSE API (https://api.sumologic.com/docs/sec/#operation/GetLogMapping), so also taking care of them.


