### PR TITLE
SUMO-248024: 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 DEPRECATIONS:
 * resource_sumologic_ingest_budget : Deprecated in favour of `resource_sumologic_ingest_budget_v2`.
 
-## 2.31.5 (September 23, 2024)
+## 2.31.5
 ENHANCEMENTS:
 * Added *index_id* attribute to sumologic_scheduled_view. (GH-691)
 * Added support for configuring sumologic_data_forwarding_rule for sumologic_scheduled_view. (GH-691)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 DEPRECATIONS:
 * resource_sumologic_ingest_budget : Deprecated in favour of `resource_sumologic_ingest_budget_v2`.
 
+## 2.31.5 (September 23, 2024)
+ENHANCEMENTS:
+* Added *index_id* attribute to sumologic_scheduled_view. (GH-691)
+* Added support for configuring sumologic_data_forwarding_rule for sumologic_scheduled_view. (GH-691)
+
 ## 2.31.4 (September 19, 2024)
 * **New Resource:** sumologic_data_forwarding_destination (GH-678)
 * **New Resource:** sumologic_data_forwarding_rule (GH-688)

--- a/sumologic/resource_sumologic_data_forwarding_destination.go
+++ b/sumologic/resource_sumologic_data_forwarding_destination.go
@@ -61,7 +61,6 @@ func resourceSumologicDataForwardingDestination() *schema.Resource {
 			"enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  false,
 			},
 			"s3_region": {
 				Type:     schema.TypeString,

--- a/sumologic/resource_sumologic_data_forwarding_rule.go
+++ b/sumologic/resource_sumologic_data_forwarding_rule.go
@@ -33,12 +33,10 @@ func resourceSumologicDataForwardingRule() *schema.Resource {
 			"enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  true,
 			},
 			"file_format": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "{index}_{day}_{hour}_{minute}_{second}",
 			},
 			"payload_schema": {
 				Type:         schema.TypeString,

--- a/sumologic/resource_sumologic_data_forwarding_rule_test.go
+++ b/sumologic/resource_sumologic_data_forwarding_rule_test.go
@@ -60,7 +60,7 @@ func TestAccSumologicDataForwardingRule_basic(t *testing.T) {
 					testAccCheckDataForwardingRuleExists(),
 					resource.TestCheckResourceAttr(dataForwardingRuleResourceName, "index_id", indexId),
 					resource.TestCheckResourceAttr(dataForwardingRuleResourceName, "destination_id", destinationId),
-					resource.TestCheckResourceAttr(dataForwardingRuleResourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(dataForwardingRuleResourceName, "enabled", "false"),
 					resource.TestCheckResourceAttr(dataForwardingRuleResourceName, "file_format", "test/"),
 					resource.TestCheckResourceAttr(dataForwardingRuleResourceName, "payload_schema", "builtInFields"),
 					resource.TestCheckResourceAttr(dataForwardingRuleResourceName, "format", "json"),
@@ -227,7 +227,7 @@ func testAccSumologicDataForwardingRuleUpdateConfig() string {
 		resource "sumologic_data_forwarding_rule" "test" {
 			index_id = "%s"
 			destination_id = "%s"
-			enabled = true
+			enabled = false
 			file_format = "test/"
 			payload_schema = "builtInFields"
 			format = "json"

--- a/sumologic/resource_sumologic_scheduled_view.go
+++ b/sumologic/resource_sumologic_scheduled_view.go
@@ -40,6 +40,7 @@ func resourceSumologicScheduledView() *schema.Resource {
 			"index_id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"retention_period": {
 				Type:         schema.TypeInt,
@@ -80,6 +81,7 @@ func resourceSumologicScheduledViewCreate(d *schema.ResourceData, meta interface
 		}
 
 		d.SetId(createdSview.ID)
+		d.Set("index_id", createdSview.IndexId)
 		d.Set("retention_period", createdSview.RetentionPeriod)
 	}
 

--- a/sumologic/resource_sumologic_scheduled_view.go
+++ b/sumologic/resource_sumologic_scheduled_view.go
@@ -37,6 +37,10 @@ func resourceSumologicScheduledView() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validation.IsRFC3339Time,
 			},
+			"index_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"retention_period": {
 				Type:         schema.TypeInt,
 				Optional:     true,
@@ -99,6 +103,7 @@ func resourceSumologicScheduledViewRead(d *schema.ResourceData, meta interface{}
 		return nil
 	}
 
+	d.Set("index_id", sview.IndexId)
 	d.Set("query", sview.Query)
 	d.Set("index_name", sview.IndexName)
 	d.Set("start_time", sview.StartTime.Format(time.RFC3339))

--- a/sumologic/sumologic_data_forwarding_rule.go
+++ b/sumologic/sumologic_data_forwarding_rule.go
@@ -62,7 +62,7 @@ func (s *Client) DeleteDataForwardingRule(indexId string) error {
 type DataForwardingRule struct {
 	IndexId       string `json:"indexId"`
 	DestinationId string `json:"destinationId"`
-	Enabled       bool   `json:"enabled,omitempty"`
+	Enabled       bool   `json:"enabled"`
 	FileFormat    string `json:"fileFormat,omitempty"`
 	PayloadSchema string `json:"payloadSchema,omitempty"`
 	Format        string `json:"format,omitempty"`

--- a/sumologic/sumologic_scheduled_view.go
+++ b/sumologic/sumologic_scheduled_view.go
@@ -58,6 +58,7 @@ func (s *Client) UpdateScheduledView(sview ScheduledView) error {
 
 type ScheduledView struct {
 	ID                               string    `json:"id,omitempty"`
+	IndexId                          string    `json:"indexId,omitempty"`
 	Query                            string    `json:"query"`
 	IndexName                        string    `json:"indexName"`
 	StartTime                        time.Time `json:"startTime"`

--- a/website/docs/r/data_forwarding_destination.html.markdown
+++ b/website/docs/r/data_forwarding_destination.html.markdown
@@ -20,6 +20,7 @@ resource "sumologic_data_forwarding_destination" "example_data_forwarding_destin
     secret_access_key = "secretAccessKey"
     role_arn = "arn:aws:iam::some-valid-arn"
     encrypted = "false"
+    enabled = "true"
 }
 ```
 ## Argument reference
@@ -35,6 +36,7 @@ The following arguments are supported:
 - `secret_access_key` - (Optional) The AWS Secret Key to access the S3 bucket.
 - `role_arn` - (Optional) The AWS Role ARN to access the S3 bucket.
 - `encrypted` - (Optional) Enable S3 server-side encryption.
+- `enabled` - (Optional) True when the data forwarding destination is enabled. Will be treated as _false_ if left blank.
 
 The following attributes are exported:
 

--- a/website/docs/r/data_forwarding_destination.html.markdown
+++ b/website/docs/r/data_forwarding_destination.html.markdown
@@ -19,8 +19,8 @@ resource "sumologic_data_forwarding_destination" "example_data_forwarding_destin
     access_key_id = "accessKeyId"
     secret_access_key = "secretAccessKey"
     role_arn = "arn:aws:iam::some-valid-arn"
-    encrypted = "false"
-    enabled = "true"
+    encrypted = false
+    enabled = true
 }
 ```
 ## Argument reference

--- a/website/docs/r/data_forwarding_destination.html.markdown
+++ b/website/docs/r/data_forwarding_destination.html.markdown
@@ -12,14 +12,16 @@ Provider to manage [Sumologic Data Forwarding Destination](https://help.sumologi
 ```hcl
 resource "sumologic_data_forwarding_destination" "example_data_forwarding_destination" {
     destination_name = "df-destination"
-    description = ""
+    description = "some description"
     bucket_name = "df-bucket"
-    region = "us-east-1"
-    authentication_mode = "RoleBased"
-    access_key_id = "accessKeyId"
-    secret_access_key = "secretAccessKey"
-    role_arn = "arn:aws:iam::some-valid-arn"
-    encrypted = false
+    s3_region = "us-east-1"
+    authentication {
+      type = "RoleBased"
+      role_arn = "arn:aws:iam::your_arn"
+      # access_key = "your access key"
+      # secret_key = "your secret key"
+    }
+    s3_server_side_encryption = false
     enabled = true
 }
 ```
@@ -30,12 +32,12 @@ The following arguments are supported:
 - `destination_name` - (Required) Name of the S3 data forwarding destination.
 - `description` - (Optional) Description of the S3 data forwarding destination.
 - `bucket_name` - (Required) The name of the Amazon S3 bucket.
-- `region` - (Optional) The region where the S3 bucket is located.
-- `authentication_mode` - (Required) AWS IAM authentication method used for access. Possible values are: 1. `AccessKey` 2. `RoleBased`
-- `access_key_id` - (Optional) The AWS Access ID to access the S3 bucket.
-- `secret_access_key` - (Optional) The AWS Secret Key to access the S3 bucket.
+- `s3_region` - (Optional) The region where the S3 bucket is located.
+- `type` - (Required) AWS IAM authentication method used for access. Possible values are: 1. `AccessKey` 2. `RoleBased`
+- `access_key` - (Optional) The AWS Access ID to access the S3 bucket.
+- `secret_key` - (Optional) The AWS Secret Key to access the S3 bucket.
 - `role_arn` - (Optional) The AWS Role ARN to access the S3 bucket.
-- `encrypted` - (Optional) Enable S3 server-side encryption.
+- `s3_server_side_encryption` - (Optional) Enable S3 server-side encryption.
 - `enabled` - (Optional) True when the data forwarding destination is enabled. Will be treated as _false_ if left blank.
 
 The following attributes are exported:

--- a/website/docs/r/data_forwarding_rule.html.markdown
+++ b/website/docs/r/data_forwarding_rule.html.markdown
@@ -58,7 +58,7 @@ The following arguments are supported:
 - `index_id` - (Required) The *id* of the Partition or *index_id* of the Scheduled View the rule applies to.
 - `destination_id` - (Required) The data forwarding destination id.
 - `enabled` - (Optional) True when the data forwarding rule is enabled. Will be treated as _false_ if left blank.
-- `file_format` - (Optional) Specify the path prefix to a directory in the S3 bucket and how to format the file name.
+- `file_format` - (Optional) Specify the path prefix to a directory in the S3 bucket and how to format the file name. For possible values, kindly refer the point 6 in the [documentation](https://help.sumologic.com/docs/manage/data-forwarding/amazon-s3-bucket/#forward-datato-s3).
 - `payload_schema` - (Optional) Schema for the payload. Default value of the payload schema is _allFields_ for scheduled view, and _builtInFields_ for partition.
   _raw_ payloadSchema should be used in conjunction with _text_ format and vice versa.
 - `format` - (Optional) Format of the payload. Default format will be _csv_. 

--- a/website/docs/r/data_forwarding_rule.html.markdown
+++ b/website/docs/r/data_forwarding_rule.html.markdown
@@ -9,21 +9,53 @@ description: |-
 Provider to manage [Sumologic Data Forwarding Rule](https://help.sumologic.com/docs/manage/data-forwarding/amazon-s3-bucket/#forward-datato-s3)
 
 ## Example Usage
+
+For Partitions
 ```hcl
+resource "sumologic_partition" "test_partition" {
+  name               = "testing_rule_partitions"
+  routing_expression = "_sourcecategory=abc/Terraform"
+  is_compliant       = false
+  retention_period   = 30
+  analytics_tier     = "flex"
+}
+
 resource "sumologic_data_forwarding_rule" "example_data_forwarding_rule" {
-    index_id = "00000000024C6155"
-    destination_id = "00000000000732AA"
-    enabled = "true"
-    file_format = "test/{index}/{day}/{hour}/{minute}"
-    payload_schema = "builtInFields"
-    format = "json"
+  index_id = sumologic_partition.test_partition.id
+  destination_id = "00000000000732AA"
+  enabled = true
+  file_format = "test/{index}/{day}/{hour}/{minute}"
+  payload_schema = "builtInFields"
+  format = "json"
+}
+```
+For Scheduled Views
+```hcl
+resource "sumologic_scheduled_view" "failed_connections" {
+  index_name = "failed_connections"
+  query = "_sourceCategory=fire | count"
+  start_time = "2024-09-01T00:00:00Z"
+  retention_period = 1
+  lifecycle {
+    prevent_destroy = true
+    ignore_changes = [index_id]
+  }
+}
+
+resource "sumologic_data_forwarding_rule" "test_rule_sv" {
+  index_id       = sumologic_scheduled_view.failed_connections.index_id
+  destination_id = sumologic_data_forwarding_destination.test_destination.id
+  enabled        = false
+  file_format    = "test/{index}"
+  payload_schema = "raw"
+  format         = "text"
 }
 ```
 ## Argument reference
 
 The following arguments are supported:
 
-- `index_id` - (Required) The _id_ of the Partition or Scheduled View the rule applies to.
+- `index_id` - (Required) The *id* of the Partition or *index_id* of the Scheduled View the rule applies to.
 - `destination_id` - (Required) The data forwarding destination id.
 - `enabled` - (Optional) True when the data forwarding rule is enabled. Will be treated as _false_ if left blank.
 - `file_format` - (Optional) Specify the path prefix to a directory in the S3 bucket and how to format the file name.
@@ -31,3 +63,7 @@ The following arguments are supported:
   _raw_ payloadSchema should be used in conjunction with _text_ format and vice versa.
 - `format` - (Optional) Format of the payload. Default format will be _csv_. 
   _text_ format should be used in conjunction with _raw_ payloadSchema and vice versa.
+
+The following attributes are exported:
+
+- `id` - The Index ID of the data_forwarding_rule

--- a/website/docs/r/data_forwarding_rule.html.markdown
+++ b/website/docs/r/data_forwarding_rule.html.markdown
@@ -25,7 +25,7 @@ The following arguments are supported:
 
 - `index_id` - (Required) The _id_ of the Partition or Scheduled View the rule applies to.
 - `destination_id` - (Required) The data forwarding destination id.
-- `enabled` - (Required) True when the data forwarding rule is enabled.
+- `enabled` - (Optional) True when the data forwarding rule is enabled. Will be treated as _false_ if left blank.
 - `file_format` - (Optional) Specify the path prefix to a directory in the S3 bucket and how to format the file name.
 - `payload_schema` - (Optional) Schema for the payload. Default value of the payload schema is _allFields_ for scheduled view, and _builtInFields_ for partition.
   _raw_ payloadSchema should be used in conjunction with _text_ format and vice versa.

--- a/website/docs/r/scheduled_view.html.markdown
+++ b/website/docs/r/scheduled_view.html.markdown
@@ -45,7 +45,7 @@ The following arguments are supported:
 The following attributes are exported:
 
 - `id` - The internal ID of the scheduled view.
-- `index_id` - The Index ID of the scheduled view. It never updates at any point of time during resource updates, therefore make sure to ignore this via `ignore_changes = [index_id]`.
+- `index_id` - The Index ID of the scheduled view. It remains unchanged during resource updates, and any manual modifications will be disregarded. While it’s not mandatory, we recommend to ignore this via `ignore_changes = [index_id]`.
 
 ## Import
 Scheduled Views can can be imported using the id. The list of scheduled views and their ids can be obtained using the Sumologic [scheduled views api][2].

--- a/website/docs/r/scheduled_view.html.markdown
+++ b/website/docs/r/scheduled_view.html.markdown
@@ -44,6 +44,7 @@ The following arguments are supported:
 The following attributes are exported:
 
 - `id` - The internal ID of the scheduled view.
+- `index_id` - The Index ID of the scheduled view.
 
 ## Import
 Scheduled Views can can be imported using the id. The list of scheduled views and their ids can be obtained using the Sumologic [scheduled views api][2].

--- a/website/docs/r/scheduled_view.html.markdown
+++ b/website/docs/r/scheduled_view.html.markdown
@@ -23,6 +23,7 @@ QUERY
   retention_period = 365
   lifecycle {
     prevent_destroy = true
+    ignore_changes = [index_id]
   }
 }
 ```
@@ -44,7 +45,7 @@ The following arguments are supported:
 The following attributes are exported:
 
 - `id` - The internal ID of the scheduled view.
-- `index_id` - The Index ID of the scheduled view.
+- `index_id` - The Index ID of the scheduled view. It never updates at any point of time during resource updates, therefore make sure to ignore this via `ignore_changes = [index_id]`.
 
 ## Import
 Scheduled Views can can be imported using the id. The list of scheduled views and their ids can be obtained using the Sumologic [scheduled views api][2].


### PR DESCRIPTION
#### What are we doing?
- Adding `enabled` to the documentation of sumologic_data_forwarding_destination, and adjusted default values.
- Adding `index_id` in sumologic_scheduled_views, and adjusted necessary documentations.

#### Why is this required?
As a part of supporting Data Forwarding Rules creation via TF for Scheduled Views we need `index_id`, because the `id` is coming from the autoview table.

#### Please review commit by commit.

#### Testing
Manual testing has been performed via `main.tf` and we are successfully able to configure a DF Rule for a SV. Attached test results and the test file in the comment.