### PR TITLE
Fix analytics_tier case sensitivity in resource_sumologic_partition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 3.0.0 (Unreleased)
 DEPRECATIONS:
 * resource_sumologic_ingest_budget : Deprecated in favour of `resource_sumologic_ingest_budget_v2`.
+
+## 2.31.5 (Unreleased)
 BUG FIXES:
 * fix analytics_tier case sensitivity in resource_sumologic_partition (GH-692)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 3.0.0 (Unreleased)
 DEPRECATIONS:
 * resource_sumologic_ingest_budget : Deprecated in favour of `resource_sumologic_ingest_budget_v2`.
+BUG FIXES:
+* fix analytics_tier case sensitivity in resource_sumologic_partition
 
 ## 2.31.4 (September 19, 2024)
 * **New Resource:** sumologic_data_forwarding_destination (GH-678)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 DEPRECATIONS:
 * resource_sumologic_ingest_budget : Deprecated in favour of `resource_sumologic_ingest_budget_v2`.
 BUG FIXES:
-* fix analytics_tier case sensitivity in resource_sumologic_partition
+* fix analytics_tier case sensitivity in resource_sumologic_partition (GH-692)
 
 ## 2.31.4 (September 19, 2024)
 * **New Resource:** sumologic_data_forwarding_destination (GH-678)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ ENHANCEMENTS:
 * Add IsIncludedInDefaultSearch field to partition resource (GH-674)
 
 BUG FIXES:
-* Fix cse_log_mappings resource conversion affecting import  (GH-675)
+* Fix cse_log_mappings resource conversion affecting import (GH-675)
 
 ## 2.31.1 (July 2, 2024)
 BUG FIXES:

--- a/sumologic/resource_sumologic_partition.go
+++ b/sumologic/resource_sumologic_partition.go
@@ -33,6 +33,12 @@ func resourceSumologicPartition() *schema.Resource {
 			"analytics_tier": {
 				Type:     schema.TypeString,
 				Optional: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if strings.ToLower(old) == strings.ToLower(new) {
+						return true
+					}
+					return false
+				},
 			},
 			"retention_period": {
 				Type:         schema.TypeInt,

--- a/sumologic/resource_sumologic_partition.go
+++ b/sumologic/resource_sumologic_partition.go
@@ -2,6 +2,7 @@ package sumologic
 
 import (
 	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -142,7 +143,7 @@ func resourceSumologicPartitionUpdate(d *schema.ResourceData, meta interface{}) 
 
 func resourceToPartition(d *schema.ResourceData) Partition {
 
-	analyticsTier := d.Get("analytics_tier").(string)
+	analyticsTier := strings.ToLower(d.Get("analytics_tier").(string))
 	isIncludedInDefaultSearch := d.Get("is_included_in_default_search").(bool)
 
 	var isIncludedInDefaultSearchPtr *bool


### PR DESCRIPTION
For flex tier, non-lowercase string was causing issue in setting the `isIncludedInDefaultSearch` . Fixed that now.
Also added a diff suppress function for analytics tier to prevent diffs due to case insensitivity.