### PR TITLE
Remove regex check in name field in log search resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 DEPRECATIONS:
 * resource_sumologic_ingest_budget : Deprecated in favour of `resource_sumologic_ingest_budget_v2`.
 
+## 2.31.5 (Unreleased)
+BUG FIXES:
+* Remove regex match in resource_sumologic_log_search (GH-693) 
+
 ## 2.31.4 (September 19, 2024)
 * **New Resource:** sumologic_data_forwarding_destination (GH-678)
 * **New Resource:** sumologic_data_forwarding_rule (GH-688)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,12 @@
 DEPRECATIONS:
 * resource_sumologic_ingest_budget : Deprecated in favour of `resource_sumologic_ingest_budget_v2`.
 
-<<<<<<< HEAD
-## 2.31.5 (Unreleased)
-BUG FIXES:
-* Remove regex match in resource_sumologic_log_search (GH-693) 
-=======
 ## 2.31.5
 ENHANCEMENTS:
 * Added *index_id* attribute to sumologic_scheduled_view. (GH-691)
 * Added support for configuring sumologic_data_forwarding_rule for sumologic_scheduled_view. (GH-691)
->>>>>>> master
+BUG FIXES:
+* Remove regex match in resource_sumologic_log_search (GH-693) 
 
 ## 2.31.4 (September 19, 2024)
 * **New Resource:** sumologic_data_forwarding_destination (GH-678)

--- a/sumologic/resource_sumologic_log_search.go
+++ b/sumologic/resource_sumologic_log_search.go
@@ -1,13 +1,17 @@
 package sumologic
 
 import (
+	"fmt"
 	"log"
+	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 func resourceSumologicLogSearch() *schema.Resource {
+
+	nameRegex := `^[a-zA-Z0-9 +%\-@.,_()]+$`
 
 	return &schema.Resource{
 		Create: resourceSumologicLogSearchCreate,
@@ -24,6 +28,7 @@ func resourceSumologicLogSearch() *schema.Resource {
 				Required: true,
 				ValidateFunc: validation.All(
 					validation.StringLenBetween(1, 255),
+					validation.StringMatch(regexp.MustCompile(nameRegex), fmt.Sprintf("Must match regex %s", nameRegex)),
 				),
 			},
 			"description": {

--- a/sumologic/resource_sumologic_log_search.go
+++ b/sumologic/resource_sumologic_log_search.go
@@ -1,17 +1,13 @@
 package sumologic
 
 import (
-	"fmt"
 	"log"
-	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 func resourceSumologicLogSearch() *schema.Resource {
-
-	nameRegex := `^[a-zA-Z0-9 +%\-@.,_()]+$`
 
 	return &schema.Resource{
 		Create: resourceSumologicLogSearchCreate,
@@ -28,7 +24,6 @@ func resourceSumologicLogSearch() *schema.Resource {
 				Required: true,
 				ValidateFunc: validation.All(
 					validation.StringLenBetween(1, 255),
-					validation.StringMatch(regexp.MustCompile(nameRegex), fmt.Sprintf("Must match regex %s", nameRegex)),
 				),
 			},
 			"description": {


### PR DESCRIPTION
The regex in log search name was outdated, we are using a regex allowing names with more broader fields with api. With this change we are removing regex validation in name field in terraform, since we want the api to be the single source of truth. 
The api already has regex pattern checks so the change is safe, now instead of failing at plan generation, terraform will fail at apply stage if name is invalid as per regex. 

Tested the changes by creating resource.