### PR TITLE
SUMO-252740 Add method to update status of fields resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## X.Y.Z (Unreleased)
 * Add new change notes here
+* Add support for update method to change state of the fields resource
 
 ## 3.0.0 (December 09, 2024)
 **REMOVALS:**

--- a/sumologic/resource_sumologic_field.go
+++ b/sumologic/resource_sumologic_field.go
@@ -137,10 +137,6 @@ func resourceSumologicFieldUpdate(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	if f.FieldName != name || f.DataType != tpe {
-		return errors.New("Only state field is updatable")
-	}
-
 	if state == "Enabled" {
 		err := c.EnableField(id)
 		if err != nil {

--- a/sumologic/resource_sumologic_field.go
+++ b/sumologic/resource_sumologic_field.go
@@ -122,7 +122,6 @@ func resourceSumologicFieldUpdate(d *schema.ResourceData, meta interface{}) erro
 
 	id := d.Get("field_id").(string)
 	name := d.Get("field_name").(string)
-	tpe := d.Get("data_type").(string)
 	state := d.Get("state").(string)
 	if id == "" {
 		newId, err := c.FindFieldId(name)
@@ -131,7 +130,7 @@ func resourceSumologicFieldUpdate(d *schema.ResourceData, meta interface{}) erro
 		}
 		id = newId
 	}
-	f, err := c.GetField(id)
+	_, err := c.GetField(id)
 
 	if err != nil {
 		return err

--- a/sumologic/resource_sumologic_field.go
+++ b/sumologic/resource_sumologic_field.go
@@ -10,9 +10,8 @@ func resourceSumologicField() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceSumologicFieldCreate,
 		Read:   resourceSumologicFieldRead,
-		Update: resourceSumologicFieldUpdate 
+		Update: resourceSumologicFieldUpdate,
 		Delete: resourceSumologicFieldDelete,
-		Update: 
 		Importer: &schema.ResourceImporter{
 			State: resourceSumologicFieldImport,
 		},
@@ -132,7 +131,7 @@ func resourceSumologicFieldUpdate(d *schema.ResourceData, meta interface{}) erro
 		}
 		id = newId
 	}
-	f,err := c.GetField(id)
+	f, err := c.GetField(id)
 
 	if err != nil {
 		return err
@@ -140,11 +139,11 @@ func resourceSumologicFieldUpdate(d *schema.ResourceData, meta interface{}) erro
 
 	if f.FieldName != name && f.DataType != tpe {
 		return errors.New("Only state field is updatable")
-	} 
+	}
 
-	if f.status === "Enabled" {
+	if f.status == "Enabled" {
 		return c.EnableField(id)
-	} else if  f.status === "Disabled" {
+	} else if f.status == "Disabled" {
 		return c.DisableField(id)
 	} else {
 		return errors.New("Invalid value of state field. Only Enabled or Disabled values are accepted")

--- a/sumologic/resource_sumologic_field.go
+++ b/sumologic/resource_sumologic_field.go
@@ -149,7 +149,7 @@ func resourceSumologicFieldUpdate(d *schema.ResourceData, meta interface{}) erro
 		return errors.New("Invalid value of state field. Only Enabled or Disabled values are accepted")
 	}
 
-	resourceSumologicFieldRead(c, meta)
+	return resourceSumologicFieldRead(d, meta)
 
 }
 

--- a/sumologic/resource_sumologic_field.go
+++ b/sumologic/resource_sumologic_field.go
@@ -123,7 +123,7 @@ func resourceSumologicFieldUpdate(d *schema.ResourceData, meta interface{}) erro
 	id := d.Get("field_id").(string)
 	name := d.Get("field_name").(string)
 	tpe := d.Get("data_type").(string)
-	status := d.Get("state").(string)
+	state := d.Get("state").(string)
 	if id == "" {
 		newId, err := c.FindFieldId(name)
 		if err != nil {
@@ -141,13 +141,16 @@ func resourceSumologicFieldUpdate(d *schema.ResourceData, meta interface{}) erro
 		return errors.New("Only state field is updatable")
 	}
 
-	if status == "Enabled" {
+	if state == "Enabled" {
 		return c.EnableField(id)
-	} else if status == "Disabled" {
+	} else if state == "Disabled" {
 		return c.DisableField(id)
 	} else {
 		return errors.New("Invalid value of state field. Only Enabled or Disabled values are accepted")
 	}
+
+	resourceSumologicFieldRead(c, meta)
+
 }
 
 func resourceToField(d *schema.ResourceData) Field {

--- a/sumologic/resource_sumologic_field.go
+++ b/sumologic/resource_sumologic_field.go
@@ -1,8 +1,8 @@
 package sumologic
 
 import (
-	"fmt"
 	"errors"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
@@ -40,7 +40,6 @@ func resourceSumologicField() *schema.Resource {
 			"state": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 			},
 		},
 	}

--- a/sumologic/resource_sumologic_field.go
+++ b/sumologic/resource_sumologic_field.go
@@ -2,6 +2,7 @@ package sumologic
 
 import (
 	"fmt"
+	"errors"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
@@ -141,9 +142,9 @@ func resourceSumologicFieldUpdate(d *schema.ResourceData, meta interface{}) erro
 		return errors.New("Only state field is updatable")
 	}
 
-	if f.status == "Enabled" {
+	if status == "Enabled" {
 		return c.EnableField(id)
-	} else if f.status == "Disabled" {
+	} else if status == "Disabled" {
 		return c.DisableField(id)
 	} else {
 		return errors.New("Invalid value of state field. Only Enabled or Disabled values are accepted")

--- a/sumologic/resource_sumologic_field.go
+++ b/sumologic/resource_sumologic_field.go
@@ -142,15 +142,15 @@ func resourceSumologicFieldUpdate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	if state == "Enabled" {
-		 err := c.EnableField(id)
-		 if(err != nil) {
-		 	return err
-		 }
+		err := c.EnableField(id)
+		if err != nil {
+			return err
+		}
 	} else if state == "Disabled" {
-		 err := c.DisableField(id)
-		 if(err != nil) {
-		 	return err
-		 }
+		err := c.DisableField(id)
+		if err != nil {
+			return err
+		}
 	} else {
 		return errors.New("Invalid value of state field. Only Enabled or Disabled values are accepted")
 	}

--- a/sumologic/resource_sumologic_field.go
+++ b/sumologic/resource_sumologic_field.go
@@ -10,7 +10,9 @@ func resourceSumologicField() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceSumologicFieldCreate,
 		Read:   resourceSumologicFieldRead,
+		Update: resourceSumologicFieldUpdate 
 		Delete: resourceSumologicFieldDelete,
+		Update: 
 		Importer: &schema.ResourceImporter{
 			State: resourceSumologicFieldImport,
 		},
@@ -114,6 +116,39 @@ func resourceSumologicFieldImport(d *schema.ResourceData, meta interface{}) ([]*
 	}
 
 	return []*schema.ResourceData{d}, nil
+}
+
+func resourceSumologicFieldUpdate(d *schema.ResourceData, meta interface{}) error {
+	c := meta.(*Client)
+
+	id := d.Get("field_id").(string)
+	name := d.Get("field_name").(string)
+	tpe := d.Get("data_type").(string)
+	status := d.Get("state").(string)
+	if id == "" {
+		newId, err := c.FindFieldId(name)
+		if err != nil {
+			return err
+		}
+		id = newId
+	}
+	f,err := c.GetField(id)
+
+	if err != nil {
+		return err
+	}
+
+	if f.FieldName != name && f.DataType != tpe {
+		return errors.New("Only state field is updatable")
+	} 
+
+	if f.status === "Enabled" {
+		return c.EnableField(id)
+	} else if  f.status === "Disabled" {
+		return c.DisableField(id)
+	} else {
+		return errors.New("Invalid value of state field. Only Enabled or Disabled values are accepted")
+	}
 }
 
 func resourceToField(d *schema.ResourceData) Field {

--- a/sumologic/resource_sumologic_field.go
+++ b/sumologic/resource_sumologic_field.go
@@ -137,14 +137,20 @@ func resourceSumologicFieldUpdate(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	if f.FieldName != name && f.DataType != tpe {
+	if f.FieldName != name || f.DataType != tpe {
 		return errors.New("Only state field is updatable")
 	}
 
 	if state == "Enabled" {
-		return c.EnableField(id)
+		 err := c.EnableField(id)
+		 if(err != nil) {
+		 	return err
+		 }
 	} else if state == "Disabled" {
-		return c.DisableField(id)
+		 err := c.DisableField(id)
+		 if(err != nil) {
+		 	return err
+		 }
 	} else {
 		return errors.New("Invalid value of state field. Only Enabled or Disabled values are accepted")
 	}

--- a/sumologic/resource_sumologic_field_test.go
+++ b/sumologic/resource_sumologic_field_test.go
@@ -128,6 +128,12 @@ func TestAccSumologicFieldUpdate_OnlyStateFieldIsUpdatable(t *testing.T) {
 						field_name = "%s"
 						data_type  = "%s"
 						state      = "%s"
+
+						lifecycle {
+    						ignore_changes = [
+    							data_type 
+    						]
+  						}
 					}
 				`, testFieldName, updatedDataType, testState),
 				ExpectError: regexp.MustCompile("Only state field is updatable"),

--- a/sumologic/resource_sumologic_field_test.go
+++ b/sumologic/resource_sumologic_field_test.go
@@ -56,6 +56,42 @@ func TestAccSumologicField_create(t *testing.T) {
 	})
 }
 
+
+func TestAccSumologicField_update(t *testing.T) {
+	var field Field
+	testFieldName := "fields_provider_test"
+	testDataType := "String"
+	testState := "Enabled"
+	updatedState := "Disabled"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckFieldDestroy(field),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSumologicField(testFieldName, testDataType, testState),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFieldExists("sumologic_field.test", &field, t),
+					testAccCheckFieldAttributes("sumologic_field.test"),
+					resource.TestCheckResourceAttr("sumologic_field.test", "field_name", testFieldName),
+					resource.TestCheckResourceAttr("sumologic_field.test", "data_type", testDataType),
+					resource.TestCheckResourceAttr("sumologic_field.test", "state", testState),
+				),
+			},
+			{
+				Config: testAccSumologicFieldUpdate(testFieldName, testDataType, updatedState),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFieldExists("sumologic_field.test", &field, t),
+					testAccCheckFieldAttributes("sumologic_field.test"),
+					resource.TestCheckResourceAttr("sumologic_field.test", "field_name", testFieldName),
+					resource.TestCheckResourceAttr("sumologic_field.test", "data_type", testDataType),
+					resource.TestCheckResourceAttr("sumologic_field.test", "state", updatedState),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckFieldDestroy(field Field) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testAccProvider.Meta().(*Client)
@@ -107,6 +143,16 @@ resource "sumologic_field" "foo" {
 }
 
 func testAccSumologicField(fieldName string, dataType string, state string) string {
+	return fmt.Sprintf(`
+resource "sumologic_field" "test" {
+    field_name = "%s"
+    data_type = "%s"
+    state = "%s"
+}
+`, fieldName, dataType, state)
+}
+
+func testAccSumologicFieldUpdate(fieldName string, dataType string, state string) string {
 	return fmt.Sprintf(`
 resource "sumologic_field" "test" {
     field_name = "%s"

--- a/sumologic/resource_sumologic_field_test.go
+++ b/sumologic/resource_sumologic_field_test.go
@@ -92,53 +92,6 @@ func TestAccSumologicField_update(t *testing.T) {
 	})
 }
 
-func TestAccSumologicField_OnlyStateFieldIsUpdatable(t *testing.T) {
-
-	var field Field
-
-	resourceName := "sumologic_field.test"
-	testFieldName := "fields_provider_test"
-	testDataType := "String"
-	testState := "Enabled"
-	updatedDataType := "int"
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckFieldDestroy(field),
-		Steps: []resource.TestStep{
-			{
-				Config: fmt.Sprintf(`
-					resource "sumologic_field" "test" {
-						field_name = "%s"
-						data_type  = "%s"
-						state      = "%s"
-					}
-				`, testFieldName, testDataType, testState),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "field_name", testFieldName),
-					resource.TestCheckResourceAttr(resourceName, "data_type", testDataType),
-					resource.TestCheckResourceAttr(resourceName, "state", testState),
-				),
-			},
-
-			{
-				Config: fmt.Sprintf(`
-					resource "sumologic_field" "test" {
-						field_name = "%s"
-						data_type  = "%s"
-						state      = "%s"
-					}
-				`, testFieldName, updatedDataType, testState),
-				ExpectError: regexp.MustCompile("Only state field is updatable"),
-				Check: resource.ComposeTestCheckFunc(
-                    resource.TestCheckResourceAttr(resourceName, "data_type", testDataType),
-                ),
-			},
-		},
-	})
-}
-
 func testAccCheckFieldDestroy(field Field) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testAccProvider.Meta().(*Client)

--- a/sumologic/resource_sumologic_field_test.go
+++ b/sumologic/resource_sumologic_field_test.go
@@ -56,7 +56,6 @@ func TestAccSumologicField_create(t *testing.T) {
 	})
 }
 
-
 func TestAccSumologicField_update(t *testing.T) {
 	var field Field
 	testFieldName := "fields_provider_test"

--- a/sumologic/resource_sumologic_field_test.go
+++ b/sumologic/resource_sumologic_field_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"regexp"
 )
 
 func TestAccSumologicField_basic(t *testing.T) {

--- a/sumologic/resource_sumologic_field_test.go
+++ b/sumologic/resource_sumologic_field_test.go
@@ -92,7 +92,7 @@ func TestAccSumologicField_update(t *testing.T) {
 	})
 }
 
-func TestAccSumologicFieldUpdate_OnlyStateFieldIsUpdatable(t *testing.T) {
+func TestAccSumologicField_OnlyStateFieldIsUpdatable(t *testing.T) {
 
 	var field Field
 

--- a/sumologic/resource_sumologic_field_test.go
+++ b/sumologic/resource_sumologic_field_test.go
@@ -128,14 +128,9 @@ func TestAccSumologicFieldUpdate_OnlyStateFieldIsUpdatable(t *testing.T) {
 						field_name = "%s"
 						data_type  = "%s"
 						state      = "%s"
-
-						lifecycle {
-    						ignore_changes = [
-    							data_type 
-    						]
-  						}
 					}
 				`, testFieldName, updatedDataType, testState),
+				PlanOnly:    true,
 				ExpectError: regexp.MustCompile("Only state field is updatable"),
 			},
 		},

--- a/sumologic/resource_sumologic_field_test.go
+++ b/sumologic/resource_sumologic_field_test.go
@@ -130,8 +130,10 @@ func TestAccSumologicFieldUpdate_OnlyStateFieldIsUpdatable(t *testing.T) {
 						state      = "%s"
 					}
 				`, testFieldName, updatedDataType, testState),
-				PlanOnly:    true,
 				ExpectError: regexp.MustCompile("Only state field is updatable"),
+				Check: resource.ComposeTestCheckFunc(
+                    resource.TestCheckResourceAttr(resourceName, "data_type", testDataType),
+                ),
 			},
 		},
 	})

--- a/sumologic/sumologic_field.go
+++ b/sumologic/sumologic_field.go
@@ -95,28 +95,19 @@ func (s *Client) FindFieldId(name string) (string, error) {
 }
 
 func (s *Client) DisableField(id string) error {
-	urlWithoutParams := "v1/fields/%s/disable"
-	sprintfArgs := []interface{}{}
-	sprintfArgs = append(sprintfArgs, id)
-
-	urlWithParams := fmt.Sprintf(urlWithoutParams, sprintfArgs...)
+	urlWithParams := fmt.Sprintf("v1/fields/%s/disable", id)
 
 	_, err := s.Delete(urlWithParams)
-
 	return err
 }
 
 func (s *Client) EnableField(id string) error {
-	urlWithoutParams := "v1/fields/%s/enable"
-	sprintfArgs := []interface{}{}
-	sprintfArgs = append(sprintfArgs, id)
-
-	urlWithParams := fmt.Sprintf(urlWithoutParams, sprintfArgs...)
+	urlWithParams := fmt.Sprintf("v1/fields/%s/enable", id)
 
 	_, err := s.Put(urlWithParams, nil)
-
 	return err
 }
+
 
 type Field struct {
 	FieldId   string `json:"fieldId"`

--- a/sumologic/sumologic_field.go
+++ b/sumologic/sumologic_field.go
@@ -94,6 +94,32 @@ func (s *Client) FindFieldId(name string) (string, error) {
 	return "", fmt.Errorf("Field \"%s\" not found", name)
 }
 
+func (s *Client) DisableField(id string) error {
+	url:= "v1/fields/%s/disable"
+	sprintfArgs := []interface{}{}
+	sprintfArgs = append(sprintfArgs, id)
+
+	urlWithParams := fmt.Sprintf(urlWithoutParams, sprintfArgs...)
+
+	_, err := s.Delete(urlWithParams)
+
+	return err
+}
+
+func (s *Client) EnableField(id string) error {
+	url:= "v1/fields/%s/enable"
+	sprintfArgs := []interface{}{}
+	sprintfArgs = append(sprintfArgs, id)
+
+	urlWithParams := fmt.Sprintf(urlWithoutParams, sprintfArgs...)
+
+	_, err := s.Put(urlWithParams)
+
+	return err
+}
+
+
+
 type Field struct {
 	FieldId   string `json:"fieldId"`
 	DataType  string `json:"dataType"`

--- a/sumologic/sumologic_field.go
+++ b/sumologic/sumologic_field.go
@@ -95,7 +95,7 @@ func (s *Client) FindFieldId(name string) (string, error) {
 }
 
 func (s *Client) DisableField(id string) error {
-	url:= "v1/fields/%s/disable"
+	url := "v1/fields/%s/disable"
 	sprintfArgs := []interface{}{}
 	sprintfArgs = append(sprintfArgs, id)
 
@@ -107,7 +107,7 @@ func (s *Client) DisableField(id string) error {
 }
 
 func (s *Client) EnableField(id string) error {
-	url:= "v1/fields/%s/enable"
+	url := "v1/fields/%s/enable"
 	sprintfArgs := []interface{}{}
 	sprintfArgs = append(sprintfArgs, id)
 
@@ -117,8 +117,6 @@ func (s *Client) EnableField(id string) error {
 
 	return err
 }
-
-
 
 type Field struct {
 	FieldId   string `json:"fieldId"`

--- a/sumologic/sumologic_field.go
+++ b/sumologic/sumologic_field.go
@@ -108,7 +108,6 @@ func (s *Client) EnableField(id string) error {
 	return err
 }
 
-
 type Field struct {
 	FieldId   string `json:"fieldId"`
 	DataType  string `json:"dataType"`

--- a/sumologic/sumologic_field.go
+++ b/sumologic/sumologic_field.go
@@ -95,7 +95,7 @@ func (s *Client) FindFieldId(name string) (string, error) {
 }
 
 func (s *Client) DisableField(id string) error {
-	url := "v1/fields/%s/disable"
+	urlWithoutParams := "v1/fields/%s/disable"
 	sprintfArgs := []interface{}{}
 	sprintfArgs = append(sprintfArgs, id)
 
@@ -107,13 +107,13 @@ func (s *Client) DisableField(id string) error {
 }
 
 func (s *Client) EnableField(id string) error {
-	url := "v1/fields/%s/enable"
+	urlWithoutParams := "v1/fields/%s/enable"
 	sprintfArgs := []interface{}{}
 	sprintfArgs = append(sprintfArgs, id)
 
 	urlWithParams := fmt.Sprintf(urlWithoutParams, sprintfArgs...)
 
-	_, err := s.Put(urlWithParams)
+	_, err := s.Put(urlWithParams, nil)
 
 	return err
 }


### PR DESCRIPTION
In the APIs exposed by Sumologic fields, we have two APIs /enable and /disable to enable or disable the state of the fields.  So, in this PR, we have build a method to update only the state of the field. Other variables are still not updatable. 

Wrote test for update and tested it via acceptance tests. 