### PR TITLE
Update CODEOWNERS to include core-platform members

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,10 +2,9 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# @sumovishal, @dagould will be requested for
-# review when someone opens a pull request.
-*       @sumovishal @dagould
+# the repo. Unless a later match takes precedence, they will
+# be requested for review when someone opens a pull request.
+*       @sumovishal @ashpaliwal @adisuj @ErikAtSumo @sjain05
 
 # Code owners for collection sources
 /sumologic/*_source.go        @maimaisie @vsinghal13

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,7 @@
 /sumologic/*_source_test.go   @maimaisie @vsinghal13
 /sumologic/*_ingest_budget*   @maimaisie @vsinghal13
 /sumologic/*_collector*       @maimaisie @vsinghal13
-/sumologic/*_cse*             @josh-williams @pmontiel-sumo
+/sumologic/*_cse*             @pmontiel-sumo
 /website/docs/r/collector*    @maimaisie @vsinghal13
 /website/docs/r/ingest_*      @maimaisie @vsinghal13
 /website/docs/r/*_source*     @maimaisie @vsinghal13


### PR DESCRIPTION
In recent months, the core platform team has added some new members, and we have increased capacity to help maintain the terraform provider. This PR adds Ashish and myself as code owners, and sets us to the default reviewers to reduce the review burden of Vishal.