### PR TITLE
Replace default codeowners with @SumoLogic/tf-platform-team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence, they will
 # be requested for review when someone opens a pull request.
-*       @sumovishal @ashpaliwal @adisuj @ErikAtSumo @sjain05
+*       @SumoLogic/tf-platform-team
 
 # Code owners for collection sources
 /sumologic/*_source.go        @maimaisie @vsinghal13


### PR DESCRIPTION
GitHub is adding all five owners to each PR as Reviewers. I created a team @SumoLogic/tf-platform-team with these five members, to reduce the clutter in the list of Reviewers and the CODEOWNERS file.