### PR TITLE
Fix the use_versioned_api noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## X.Y.Z (Unreleased)
 * Add new change notes here
 
+BUG FIXES:
+* Polling source paths without `use_versioned_api` will not show an incorrect diff in the `terraform plan`
+
 ## 3.0.4 (February 4, 2025)
 BUG FIXES:
 * Fixed issue with release artifacts

--- a/sumologic/resource_sumologic_azure_event_hub_log_source_test.go
+++ b/sumologic/resource_sumologic_azure_event_hub_log_source_test.go
@@ -41,7 +41,6 @@ func TestAccSumologicAzureEventHubLogSource_create(t *testing.T) {
 					resource.TestCheckResourceAttr(azureEventHubLogResourceName, "content_type", "AzureEventHubLog"),
 					resource.TestCheckResourceAttr(azureEventHubLogResourceName, "path.0.type", "AzureEventHubPath"),
 				),
-				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -75,7 +74,6 @@ func TestAccSumologicAzureEventHubLogSource_update(t *testing.T) {
 					resource.TestCheckResourceAttr(azureEventHubLogResourceName, "content_type", "AzureEventHubLog"),
 					resource.TestCheckResourceAttr(azureEventHubLogResourceName, "path.0.type", "AzureEventHubPath"),
 				),
-				ExpectNonEmptyPlan: true,
 			},
 			{
 				Config: testAccSumologicAzureEventHubLogSourceConfig(cName, cDescription, cCategory, sNameUpdated, sDescriptionUpdated, sCategoryUpdated, testSASKeyName, testSASKey, testNamespace, testEventHub, testConsumerGroup, testRegion),
@@ -89,7 +87,6 @@ func TestAccSumologicAzureEventHubLogSource_update(t *testing.T) {
 					resource.TestCheckResourceAttr(azureEventHubLogResourceName, "content_type", "AzureEventHubLog"),
 					resource.TestCheckResourceAttr(azureEventHubLogResourceName, "path.0.type", "AzureEventHubPath"),
 				),
-				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/sumologic/resource_sumologic_cloudwatch_source_test.go
+++ b/sumologic/resource_sumologic_cloudwatch_source_test.go
@@ -36,7 +36,6 @@ func TestAccSumologicCloudWatchSource_create(t *testing.T) {
 					resource.TestCheckResourceAttr(cloudWatchResourceName, "content_type", "AwsCloudWatch"),
 					resource.TestCheckResourceAttr(cloudWatchResourceName, "path.0.type", "CloudWatchPath"),
 				),
-				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -65,7 +64,6 @@ func TestAccSumologicCloudWatchSource_update(t *testing.T) {
 					resource.TestCheckResourceAttr(cloudWatchResourceName, "content_type", "AwsCloudWatch"),
 					resource.TestCheckResourceAttr(cloudWatchResourceName, "path.0.type", "CloudWatchPath"),
 				),
-				ExpectNonEmptyPlan: true,
 			},
 			{
 				Config: testAccSumologicCloudWatchSourceConfig(cName, cDescription, cCategory, sNameUpdated, sDescriptionUpdated, sCategoryUpdated, testAwsRoleArn),
@@ -79,7 +77,6 @@ func TestAccSumologicCloudWatchSource_update(t *testing.T) {
 					resource.TestCheckResourceAttr(cloudWatchResourceName, "content_type", "AwsCloudWatch"),
 					resource.TestCheckResourceAttr(cloudWatchResourceName, "path.0.type", "CloudWatchPath"),
 				),
-				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/sumologic/resource_sumologic_gcp_metrics_source_test.go
+++ b/sumologic/resource_sumologic_gcp_metrics_source_test.go
@@ -47,7 +47,6 @@ func TestAccSumologicGcpMetricsSource_create(t *testing.T) {
 						resource.TestCheckResourceAttr(GcpMetricsResourceName, "path.0.custom_services.1.prefixes.0", customServicePrefix),
 						resource.TestCheckResourceAttr(GcpMetricsResourceName, "path.0.custom_services.1.prefixes.1", "compute.googleapis.com/guest/"),
 					),
-					ExpectNonEmptyPlan: true,
 				},
 			},
 		})
@@ -81,7 +80,6 @@ func TestAccSumologicGcpMetricsSource_update(t *testing.T) {
 						resource.TestCheckResourceAttr(GcpMetricsResourceName, "path.0.type", "GcpMetricsPath"),
 						resource.TestCheckResourceAttr(GcpMetricsResourceName, "path.0.custom_services.1.prefixes.0", customServicePrefix),
 					),
-					ExpectNonEmptyPlan: true,
 				},
 				{
 					Config: testAccSumologicGcpMetricsSourceConfig(t, cName, cDescription, cCategory, sNameUpdated, sDescriptionUpdated, sCategoryUpdated, updatedCustomServicePrefix),
@@ -96,7 +94,6 @@ func TestAccSumologicGcpMetricsSource_update(t *testing.T) {
 						resource.TestCheckResourceAttr(GcpMetricsResourceName, "path.0.type", "GcpMetricsPath"),
 						resource.TestCheckResourceAttr(GcpMetricsResourceName, "path.0.custom_services.1.prefixes.0", updatedCustomServicePrefix),
 					),
-					ExpectNonEmptyPlan: true,
 				},
 			},
 		})

--- a/sumologic/resource_sumologic_generic_polling_source.go
+++ b/sumologic/resource_sumologic_generic_polling_source.go
@@ -150,7 +150,7 @@ func resourceSumologicGenericPollingSource() *schema.Resource {
 				"use_versioned_api": {
 					Type:     schema.TypeBool,
 					Optional: true,
-					Default:  true,
+					Default:  nil,
 				},
 				"path_expression": {
 					Type:     schema.TypeString,
@@ -749,10 +749,14 @@ func getPollingPathSettings(d *schema.ResourceData) (PollingPath, error) {
 			pathSettings.Type = "S3BucketPathExpression"
 			pathSettings.BucketName = path["bucket_name"].(string)
 			pathSettings.PathExpression = path["path_expression"].(string)
-			if path["use_versioned_api"] != nil {
+
+			if isFieldSet(d, "path.0.use_versioned_api") {
 				val := path["use_versioned_api"].(bool)
 				pathSettings.UseVersionedApi = &val
+			} else {
+				pathSettings.UseVersionedApi = nil
 			}
+
 			pathSettings.SnsTopicOrSubscriptionArn = getPollingSnsTopicOrSubscriptionArn(d)
 		case "CloudWatchPath", "AwsInventoryPath":
 			pathSettings.Type = pathType
@@ -817,4 +821,9 @@ func getPollingPathSettings(d *schema.ResourceData) (PollingPath, error) {
 	}
 
 	return pathSettings, nil
+}
+
+func isFieldSet(d *schema.ResourceData, key string) bool {
+	_, ok := d.GetOkExists(key)
+	return ok
 }


### PR DESCRIPTION
For polling sources that do not use an S3 bucket, the `use_versioned_api` path setting means nothing. Unfortunately, they still generate some noise in the `terraform plan` output, because terraform thinks the missing values ought to be set to something.

By setting the use_versioned_api default value to `nil`, terraform is able to distinguish between the case of "use_versioned_api is false" and "use_versioned_api is not set at all". This should remove the noise.

Several acceptance tests were configured to tolerate this noise with `ExpectNonEmptyPlan: true`. That tolerance is also removed in this PR.

Manual tests:

- create a sumologic_aws_xray_source
   - in .tf, path has no use_versioned_api
   - before: created resource has use_versioned_api = false
   - after: created resource has no use_versioned_api
- create a sumologic_cloudtrail_source
   - in .tf, path has no use_versioned_api
   - before: created resource has use_versioned_api = false
   - after: created resource has no use_versioned_api
- sumologic_cloudtrail_source
   - in .tf, path has use_versioned_api = false
   - before: created resource has use_versioned_api = false
   - after: created resource has use_versioned_api = false