### PR TITLE
ignore running test for changes to static content

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,11 +8,13 @@ on:
     paths-ignore:
       - 'README.md'
       - 'CHANGELOG.md'
+      - 'website/**'
   push:
     branches: [ master ]
     paths-ignore:
       - 'README.md'
       - 'CHANGELOG.md'
+      - 'website/**'
   # For systems with an upstream API that could drift unexpectedly (like most SaaS systems, etc.),
   # we recommend testing at a regular interval not necessarily tied to code changes. This will
   # ensure you are alerted to something breaking due to an API change, even if the code did not


### PR DESCRIPTION
We can avoid running TF acceptance tests in case only static contents have been changed. 