### PR TITLE
Removed extra empty line causing gofmt error

### DIFF
--- a/sumologic/resource_sumologic_partition.go
+++ b/sumologic/resource_sumologic_partition.go
@@ -207,4 +207,3 @@ func areAnalyticsTierEqual(a, b *string) bool {
 
 	return strings.EqualFold(coerceToStr(a), coerceToStr(b))
 }
-


### PR DESCRIPTION
Before `on master`:
```
$ make
==> Checking that code complies with gofmt requirements...
gofmt needs running on the following files:
./sumologic/resource_sumologic_partition.go
You can use the command: `make fmt` to reformat code.
make: *** [fmtcheck] Error 1
```

After `on aj/fix-make-build`:
```
$ make                          
==> Checking that code complies with gofmt requirements...
go install

$ echo $?
0
```