### PR TITLE
Disallow changing a user's email address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,17 @@
 ## X.Y.Z (Unreleased)
 * Add new change notes here
 
+BUG FIXES:
+* When the email of a sumologic_user is changed, instead of silently doing nothing, an error will be raised to the user
+
+DOCS:
+* Updated content docs to include examples of different alerts
+
 ## 3.0.10 (May 6, 2025)
 
 BUG FIXES:
 * Fix the log mapping resource to no longer error out when empty strings are included in skipped_values
 * Fix the log mapping resource to no longer default to a skipped_index of 0 when no skipped_index is specified
-
-DOCS:
-* Updated content docs to include examples of different alerts
 
 ## 3.0.9 (April 28, 2025)
 

--- a/sumologic/fields_map.go
+++ b/sumologic/fields_map.go
@@ -9,7 +9,7 @@ var FieldsMap = map[string]map[string]string{
 		"transferTo":          "",
 		"updatedFirstName":    "TestUpdated",
 		"updatedLastName":     "UserUpdated",
-		"updatedEmail":        "testterraform@demo.com",
+		"updatedEmail":        "testterraformupdated@demo.com",
 		"updatedIsActive":     "false",
 		"preUpdateTransferTo": "nonExistentTestId",
 	},

--- a/sumologic/resource_sumologic_user.go
+++ b/sumologic/resource_sumologic_user.go
@@ -112,6 +112,10 @@ func resourceSumologicUserCreate(d *schema.ResourceData, meta interface{}) error
 func resourceSumologicUserUpdate(d *schema.ResourceData, meta interface{}) error {
 	c := meta.(*Client)
 
+	if d.HasChange("email") {
+		return fmt.Errorf("a user's email may not be changed")
+	}
+
 	user := resourceToUser(d)
 
 	err := c.UpdateUser(user)

--- a/sumologic/resource_sumologic_user_test.go
+++ b/sumologic/resource_sumologic_user_test.go
@@ -13,6 +13,7 @@ package sumologic
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -149,16 +150,20 @@ func TestAccSumologicUser_update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccSumologicUserUpdate(testUpdatedFirstName, testUpdatedLastName, testUpdatedEmail, testUpdatedIsActive, testTransferTo),
+				Config: testAccSumologicUserUpdate(testUpdatedFirstName, testUpdatedLastName, testEmail, testUpdatedIsActive, testTransferTo),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckUserExists("sumologic_user.test", &user, t),
 					testAccCheckUserAttributes("sumologic_user.test"),
 					resource.TestCheckResourceAttr("sumologic_user.test", "first_name", testUpdatedFirstName),
 					resource.TestCheckResourceAttr("sumologic_user.test", "last_name", testUpdatedLastName),
-					resource.TestCheckResourceAttr("sumologic_user.test", "email", testUpdatedEmail),
+					resource.TestCheckResourceAttr("sumologic_user.test", "email", testEmail),
 					resource.TestCheckResourceAttr("sumologic_user.test", "is_active", strconv.FormatBool(testUpdatedIsActive)),
 					resource.TestCheckResourceAttr("sumologic_user.test", "transfer_to", testTransferTo),
 				),
+			},
+			{
+				Config:      testAccSumologicUserUpdate(testUpdatedFirstName, testUpdatedLastName, testUpdatedEmail, testUpdatedIsActive, testTransferTo),
+				ExpectError: regexp.MustCompile(`a user's email may not be changed`),
 			},
 		},
 	})

--- a/website/docs/r/user.html.markdown
+++ b/website/docs/r/user.html.markdown
@@ -59,4 +59,16 @@ Users can be imported using the user id, e.g.:
 terraform import sumologic_user.user 1234567890
 ```
 
+## Transfered content and email updates
+
+When a user is deleted, all of that user's content is transferred to another user. If `transfer_to` is
+set to another user's ID, then the content will be assigned to that user. If `transfer_to` is empty,
+then it will instead be assigned to the user executing the delete operation.
+
+A user's email address may not be changed. As a workaround, you may:
+
+1. create a new `sumologic_user` with the desired email address
+2. set the `transfer_to` of the existing user to the new user's ID
+3. delete the user with the old email address
+
 [1]: https://help.sumologic.com/Manage/Users-and-Roles/Manage-Users


### PR DESCRIPTION
The API for updating a user does not allow the email address to be modified. If someone tries to modify the email of a sumologic_user, then the provider will silently "pass", without making the desired change.

The new behavior informs the user that the email address may not be changed.

Closes #671

Note that #671 requests `ForceNew: true` for a user's email. I discussed with Kevin, and we agree that recreating a user unintentionally can have adverse consequences, so it's safer to just stop the operation.