### PR TITLE
Matrix test step should be a noop when only doc change is pushed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@
 # you can turn it on using a cron schedule for regular testing.
 #
 name: Tests
+permissions:
+  contents: read
 on:
   pull_request:
     branches: [ master ]
@@ -127,7 +129,7 @@ jobs:
       run: |
         go test -timeout 0 -v -cover ./sumologic/
   # skip acceptance tests
-  noop:
+  skip:
     if: needs.should_test.outputs.run_tests != 'true'
     needs: should_test
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,23 @@ on:
 concurrency: "TfAccTests"
 
 jobs:
+  should_test:
+    runs-on: ubuntu-latest
+    outputs:
+      run_tests: ${{ steps.filter.outputs.run_tests }}
+    steps:
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            run_tests:
+              - '!CHANGELOG.md'
+              - '!README.md'
+              - '!website/**'
   # ensure the code builds...
   build:
+    if: needs.should_test.outputs.run_tests == 'true'
+    needs: should_test
     name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -53,8 +68,9 @@ jobs:
         go build -v .
   # run acceptance tests in a matrix with Terraform core versions
   test:
-    name: Matrix Test
+    if: needs.should_test.outputs.run_tests == 'true'
     needs: build
+    name: Matrix Test
     runs-on: ubuntu-latest
     timeout-minutes: 90
     strategy:
@@ -110,3 +126,10 @@ jobs:
       # disable go test timeout. We rely on GitHub action timeout.
       run: |
         go test -timeout 0 -v -cover ./sumologic/
+  # skip acceptance tests
+  noop:
+    if: needs.should_test.outputs.run_tests != 'true'
+    needs: should_test
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Skipping tests because only docs or website files changed."


### PR DESCRIPTION
matrix test step is a required step in branch protection rules to merge the pr

when docs changes are there, this step is skipped/not triggered hence the pr builder infinitely waits for the status to be reported.

In this PR i make this step a noop so that its status is always reported
After this change:
1. matrix test will run when required
2. matrix test will be a noop when not required

<img width="1136" alt="Screenshot 2025-05-09 at 10 32 02 AM" src="https://github.com/user-attachments/assets/e0e8ce38-aed4-43b0-b44b-a54663630709" />
