### PR TITLE
Feat: Add timezone support for scheduled view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## X.Y.Z (Unreleased)
 * Add new change notes here
 
+ENHANCEMENTS:
+* Add timezone support for scheduled_view
+
 BUG FIXES:
 * Corrected capabilities documentation for role_v2
 

--- a/sumologic/resource_sumologic_scheduled_view.go
+++ b/sumologic/resource_sumologic_scheduled_view.go
@@ -70,7 +70,7 @@ func resourceSumologicScheduledView() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
-				Description: "Time zone for ingesting data in scheduled view. Follow the format in the IANA Time Zone Database.",
+				Description: "Time zone for ingesting data in scheduled view. Follow the format in the [IANA Time Zone Database](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List).",
 			},
 		},
 	}

--- a/sumologic/resource_sumologic_scheduled_view.go
+++ b/sumologic/resource_sumologic_scheduled_view.go
@@ -66,6 +66,12 @@ func resourceSumologicScheduledView() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+			"time_zone": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "Time zone for ingesting data in scheduled view. Follow the format in the IANA Time Zone Database.",
+			},
 		},
 	}
 }
@@ -74,6 +80,12 @@ func resourceSumologicScheduledViewCreate(d *schema.ResourceData, meta interface
 	c := meta.(*Client)
 	if d.Id() == "" {
 		sview := resourceToScheduledView(d)
+
+		// add timeZone if specified
+		if v, ok := d.GetOk("time_zone"); ok {
+			sview.TimeZone = v.(string)
+		}
+
 		createdSview, err := c.CreateScheduledView(sview)
 
 		if err != nil {
@@ -112,6 +124,7 @@ func resourceSumologicScheduledViewRead(d *schema.ResourceData, meta interface{}
 	d.Set("retention_period", sview.RetentionPeriod)
 	d.Set("data_forwarding_id", sview.DataForwardingId)
 	d.Set("parsing_mode", sview.ParsingMode)
+	d.Set("time_zone", sview.TimeZone)
 
 	return nil
 }
@@ -121,6 +134,10 @@ func resourceSumologicScheduledViewDelete(d *schema.ResourceData, meta interface
 }
 func resourceSumologicScheduledViewUpdate(d *schema.ResourceData, meta interface{}) error {
 	sview := resourceToScheduledView(d)
+
+	if d.HasChange("time_zone") {
+		sview.TimeZone = d.Get("time_zone").(string)
+	}
 
 	c := meta.(*Client)
 	err := c.UpdateScheduledView(sview)

--- a/sumologic/resource_sumologic_scheduled_view_test.go
+++ b/sumologic/resource_sumologic_scheduled_view_test.go
@@ -1,0 +1,155 @@
+package sumologic
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// TestAccSumologicScheduledView_basic tests the creation and basic reading of a scheduled view.
+func TestAccSumologicScheduledView_basic(t *testing.T) {
+	resourceName := "sumologic_scheduled_view.test_scheduled_view"
+	name := acctest.RandomWithPrefix("tf-test-scheduled-view-")
+	nameNoTimeZone := acctest.RandomWithPrefix("tf-test-scheduled-view-no-tz")
+	initialQuery := "_sourceCategory=terraform/test/scheduledview/basic | count by _source"
+	initialTimeZone := "America/Los_Angeles"
+	initialRetention := 30 // days
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSumologicScheduledViewDestroy,
+		Steps: []resource.TestStep{
+			// Test 1: Create a scheduled view with all initial fields, including time_zone.
+			{
+				Config: testAccSumologicScheduledViewConfig_Create(
+					name,
+					initialQuery,
+					initialTimeZone,
+					initialRetention,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "index_name", name),
+					resource.TestCheckResourceAttr(resourceName, "query", initialQuery),
+					resource.TestCheckResourceAttr(resourceName, "time_zone", initialTimeZone),
+					resource.TestCheckResourceAttr(resourceName, "retention_period", fmt.Sprintf("%d", initialRetention)),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+				),
+			},
+			// Test 2: Update only time_zone and retention_period.
+			// Other fields (name, query, index_alias) should remain unchanged.
+			{
+				Config: testAccSumologicScheduledViewConfig_Update(
+					name,            // Keep original name
+					initialQuery,    // Keep original query
+					"Europe/Berlin", // NEW time_zone
+					60,              // NEW retention_period
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "index_name", name),
+					resource.TestCheckResourceAttr(resourceName, "query", initialQuery), // Verify query is unchanged
+					resource.TestCheckResourceAttr(resourceName, "time_zone", "Europe/Berlin"),
+					resource.TestCheckResourceAttr(resourceName, "retention_period", "60"),
+				),
+			},
+			// Test 3: Create a scheduled view WITHOUT time_zone initially (check default behavior)
+			{
+				Config: testAccSumologicScheduledViewConfig_CreateNoTimeZone(
+					nameNoTimeZone,
+					initialQuery,
+					initialRetention,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "index_name", nameNoTimeZone),
+					resource.TestCheckResourceAttr(resourceName, "query", initialQuery),
+					resource.TestCheckResourceAttr(resourceName, "retention_period", fmt.Sprintf("%d", initialRetention)),
+					// defaults to "UTC" if time_zone not provided
+					resource.TestCheckResourceAttr(resourceName, "time_zone", "UTC"),
+				),
+			},
+			// Test 4: For the no-time-zone scheduled view, now set the time_zone and update retention.
+			{
+				Config: testAccSumologicScheduledViewConfig_Update(
+					nameNoTimeZone, // Keep original name
+					initialQuery,   // Keep original query
+					"Asia/Kolkata", // NEW time_zone
+					90,             // NEW retention_period
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "index_name", nameNoTimeZone),
+					resource.TestCheckResourceAttr(resourceName, "query", initialQuery), // Verify query is unchanged
+					resource.TestCheckResourceAttr(resourceName, "time_zone", "Asia/Kolkata"),
+					resource.TestCheckResourceAttr(resourceName, "retention_period", "90"),
+				),
+			},
+		},
+	})
+}
+
+// testAccCheckSumologicScheduledViewDestroy verifies that the scheduled view is deleted upon destroy.
+func testAccCheckSumologicScheduledViewDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "sumologic_scheduled_view" {
+			continue
+		}
+		fmt.Printf("DEBUG: Checking for id: %s", rs.Primary.ID)
+		sv, err := client.GetScheduledView(rs.Primary.ID)
+		if sv != nil {
+			return fmt.Errorf("scheduled view (%s) still exists", rs.Primary.ID)
+		}
+
+		if err != nil && !regexp.MustCompile(`not found|404|view:scheduled_view_not_found`).MatchString(err.Error()) {
+			return fmt.Errorf("error checking scheduled view %s: %s", rs.Primary.ID, err)
+		}
+	}
+
+	return nil
+}
+
+// testAccSumologicScheduledViewConfig_Create generates the HCL for initial creation.
+func testAccSumologicScheduledViewConfig_Create(name, query, timeZone string, retention int) string {
+	return fmt.Sprintf(`
+resource "sumologic_scheduled_view" "test_scheduled_view" {
+  index_name               = "%s"
+  query                    = "%s"
+  start_time               = "2024-01-01T00:00:00Z"
+  retention_period         = %d
+  time_zone                = "%s"
+}
+`, name, query, retention, timeZone)
+}
+
+// testAccSumologicScheduledViewConfig_CreateNoTimeZone generates HCL for creation without time_zone.
+func testAccSumologicScheduledViewConfig_CreateNoTimeZone(name, query string, retention int) string {
+	return fmt.Sprintf(`
+resource "sumologic_scheduled_view" "test_scheduled_view" {
+  index_name               = "%s"
+  query                    = "%s"
+  start_time               = "2024-01-01T00:00:00Z"
+  retention_period         = %d
+  # time_zone intentionally omitted to test default behavior
+}
+`, name, query, retention)
+}
+
+// testAccSumologicScheduledViewConfig_Update generates HCL for updating specific fields.
+// It assumes that 'name', 'query', and 'indexAlias' are part of the resource config
+// but are NOT changed in the update scenario (they are just passed through from initial state).
+func testAccSumologicScheduledViewConfig_Update(name, query, newTimeZone string, newRetention int) string {
+	return fmt.Sprintf(`
+resource "sumologic_scheduled_view" "test_scheduled_view" {
+  index_name                           = "%s"
+  query                                = "%s"
+  start_time                           = "2024-01-01T00:00:00Z" # Keep start_time consistent
+  retention_period                     = %d # Updated retention_period
+  reduce_retention_period_immediately  = false
+  time_zone                            = "%s" # Updated time_zone
+}
+`, name, query, newRetention, newTimeZone)
+}

--- a/sumologic/sumologic_scheduled_view.go
+++ b/sumologic/sumologic_scheduled_view.go
@@ -66,4 +66,5 @@ type ScheduledView struct {
 	DataForwardingId                 string    `json:"dataForwardingId"`
 	ParsingMode                      string    `json:"parsingMode"`
 	ReduceRetentionPeriodImmediately bool      `json:"reduceRetentionPeriodImmediately"`
+	TimeZone                         string    `json:"timeZone,omitempty"`
 }

--- a/website/docs/r/scheduled_view.html.markdown
+++ b/website/docs/r/scheduled_view.html.markdown
@@ -25,6 +25,7 @@ QUERY
     prevent_destroy = true
     ignore_changes = [index_id]
   }
+  time_zone = "America/Los_Angeles"
 }
 ```
 
@@ -41,6 +42,7 @@ The following arguments are supported:
 - `data_forwarding_id` - (Optional) An optional ID of a data forwarding configuration to be used by the scheduled view.
 - `parsing_mode` - (Optional, Forces new resource) Default to `Manual`. Define the parsing mode to scan the JSON format log messages. Possible values are: `AutoParse` - In AutoParse mode, the system automatically figures out fields to parse based on the search query. `Manual` - While in the Manual mode, no fields are parsed out automatically. For more information see Dynamic Parsing.
 - `reduce_retention_period_immediately` - (Optional) This is required on update if the newly specified retention period is less than the existing retention period. In such a situation, a value of true says that data between the existing retention period and the new retention period should be deleted immediately; if false, such data will be deleted after seven days. This property is optional and ignored if the specified retentionPeriod is greater than or equal to the current retention period.
+- `time_zone` - (Optional) Time zone for ingesting data in scheduled view. Follow the format in the [IANA Time Zone Database][3].
 
 The following attributes are exported:
 
@@ -56,3 +58,4 @@ terraform import sumologic_scheduled_view.failed_connections 1234567890
 
 [1]: https://help.sumologic.com/Manage/Scheduled-Views
 [2]: https://api.sumologic.com/docs/#operation/listScheduledViews
+[3]: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List


### PR DESCRIPTION
Added support for timezone in scheduled view, now user's can specify the timezone while creating scheduled view, and update it as well.
Wrote acceptance tests for scheduled views 

Testing performed : Tested locally on environment, ran acceptance tests locally