### PR TITLE
Define possible values for `value_type` in `field` schema

### DIFF
--- a/website/docs/r/cse_log_mapping.html.markdown
+++ b/website/docs/r/cse_log_mapping.html.markdown
@@ -63,7 +63,7 @@ The following arguments are supported:
 
 ### Schema for `field`
 - `name` - (Required) Name of the field.
-- `value` - (Optional) Value of the field. 
+- `value` - (Optional) Value of the field.
 - `value_type` - (Optional) The value type. Possible values: null (for standard mapping), constant, sumofield (for extracted mapping), format, join (for joined mapping), lookup, split, time
 - `skipped_values` - (Optional) List of skipped values.
 - `default_value` - (Optional) Default value of the field.


### PR DESCRIPTION
Resolves #788 

This field should be well defined with possible values given that some of the value names are not intuitive.