### PR TITLE
unmarshal computed property `field_names` on `field_extraction_rule`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## X.Y.Z (Unreleased)
-* Add new change notes here
+* return computed `field_names` property for resource `field_extraction_rule`
 
 FEATURES:
 * **Updated sumologic_monitor resource:** Added support for automated playbooks in monitors

--- a/sumologic/fields_map.go
+++ b/sumologic/fields_map.go
@@ -30,10 +30,12 @@ var FieldsMap = map[string]map[string]string{
 		"scope":                  "_sourceHost=127.0.0.1",
 		"parseExpression":        "csv _raw extract 1 as f1",
 		"enabled":                "true",
+		"fieldNames":             "f1",
 		"updatedName":            "TestTestTestTerraformFERUpdated",
 		"updatedScope":           "_sourceHost=127.0.0.1",
 		"updatedParseExpression": "csv _raw extract 1 as f1",
 		"updatedEnabled":         "true",
+		"updatedFieldNames":      "f1",
 	},
 
 	"IngestBudget": map[string]string{

--- a/sumologic/resource_sumologic_extraction_rule.go
+++ b/sumologic/resource_sumologic_extraction_rule.go
@@ -53,6 +53,11 @@ func resourceSumologicFieldExtractionRule() *schema.Resource {
 				Type:     schema.TypeBool,
 				Required: true,
 			},
+			"field_names": {
+				Computed: true,
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }
@@ -77,6 +82,7 @@ func resourceSumologicFieldExtractionRuleRead(d *schema.ResourceData, meta inter
 	d.Set("scope", fieldextractionrule.Scope)
 	d.Set("parse_expression", fieldextractionrule.ParseExpression)
 	d.Set("enabled", fieldextractionrule.Enabled)
+	d.Set("field_names", fieldextractionrule.FieldNames)
 
 	return nil
 }
@@ -125,5 +131,6 @@ func resourceToFieldExtractionRule(d *schema.ResourceData) FieldExtractionRule {
 		Scope:           d.Get("scope").(string),
 		ParseExpression: d.Get("parse_expression").(string),
 		Enabled:         d.Get("enabled").(bool),
+		FieldNames:      resourceToStringArray(d.Get("field_names").([]interface{})),
 	}
 }

--- a/sumologic/resource_sumologic_extraction_rule_test.go
+++ b/sumologic/resource_sumologic_extraction_rule_test.go
@@ -52,6 +52,7 @@ func TestAccSumologicFieldExtractionRule_create(t *testing.T) {
 	testScope := FieldsMap["FieldExtractionRule"]["scope"]
 	testParseExpression := FieldsMap["FieldExtractionRule"]["parseExpression"]
 	testEnabled, _ := strconv.ParseBool(FieldsMap["FieldExtractionRule"]["enabled"])
+	testFieldName := FieldsMap["FieldExtractionRule"]["fieldNames"]
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -66,6 +67,7 @@ func TestAccSumologicFieldExtractionRule_create(t *testing.T) {
 					resource.TestCheckResourceAttr("sumologic_field_extraction_rule.test", "scope", testScope),
 					resource.TestCheckResourceAttr("sumologic_field_extraction_rule.test", "parse_expression", testParseExpression),
 					resource.TestCheckResourceAttr("sumologic_field_extraction_rule.test", "enabled", strconv.FormatBool(testEnabled)),
+					resource.TestCheckTypeSetElemAttr("sumologic_field_extraction_rule.test", "field_names.*", testFieldName),
 				),
 			},
 		},
@@ -120,11 +122,13 @@ func TestAccSumologicFieldExtractionRule_update(t *testing.T) {
 	testScope := FieldsMap["FieldExtractionRule"]["scope"]
 	testParseExpression := FieldsMap["FieldExtractionRule"]["parseExpression"]
 	testEnabled, _ := strconv.ParseBool(FieldsMap["FieldExtractionRule"]["enabled"])
+	testFieldName := FieldsMap["FieldExtractionRule"]["fieldNames"]
 
 	testUpdatedName := FieldsMap["FieldExtractionRule"]["updatedName"] + randomSuffix
 	testUpdatedScope := FieldsMap["FieldExtractionRule"]["updatedScope"]
 	testUpdatedParseExpression := FieldsMap["FieldExtractionRule"]["updatedParseExpression"]
 	testUpdatedEnabled, _ := strconv.ParseBool(FieldsMap["FieldExtractionRule"]["updatedEnabled"])
+	testUpdatedFieldName := FieldsMap["FieldExtractionRule"]["updatedFieldNames"]
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -140,6 +144,7 @@ func TestAccSumologicFieldExtractionRule_update(t *testing.T) {
 					resource.TestCheckResourceAttr("sumologic_field_extraction_rule.test", "scope", testScope),
 					resource.TestCheckResourceAttr("sumologic_field_extraction_rule.test", "parse_expression", testParseExpression),
 					resource.TestCheckResourceAttr("sumologic_field_extraction_rule.test", "enabled", strconv.FormatBool(testEnabled)),
+					resource.TestCheckTypeSetElemAttr("sumologic_field_extraction_rule.test", "field_names.*", testFieldName),
 				),
 			},
 			{
@@ -151,6 +156,7 @@ func TestAccSumologicFieldExtractionRule_update(t *testing.T) {
 					resource.TestCheckResourceAttr("sumologic_field_extraction_rule.test", "scope", testUpdatedScope),
 					resource.TestCheckResourceAttr("sumologic_field_extraction_rule.test", "parse_expression", testUpdatedParseExpression),
 					resource.TestCheckResourceAttr("sumologic_field_extraction_rule.test", "enabled", strconv.FormatBool(testUpdatedEnabled)),
+					resource.TestCheckTypeSetElemAttr("sumologic_field_extraction_rule.test", "field_names.*", testUpdatedFieldName),
 				),
 			},
 		},
@@ -197,6 +203,7 @@ func testAccCheckFieldExtractionRuleAttributes(name string) resource.TestCheckFu
 			resource.TestCheckResourceAttrSet(name, "scope"),
 			resource.TestCheckResourceAttrSet(name, "parse_expression"),
 			resource.TestCheckResourceAttrSet(name, "enabled"),
+			resource.TestCheckResourceAttrSet(name, "field_names.#"),
 		)
 		return f(s)
 	}

--- a/sumologic/sumologic_extraction_rule.go
+++ b/sumologic/sumologic_extraction_rule.go
@@ -55,8 +55,9 @@ func (s *Client) GetFieldExtractionRule(id string) (*FieldExtractionRule, error)
 
 func (s *Client) UpdateFieldExtractionRule(fieldExtractionRule FieldExtractionRule) error {
 	url := fmt.Sprintf("v1/extractionRules/%s", fieldExtractionRule.ID)
-
+	var empty_fields []string
 	fieldExtractionRule.ID = ""
+	fieldExtractionRule.FieldNames = empty_fields
 
 	_, err := s.Put(url, fieldExtractionRule)
 	return err
@@ -73,4 +74,6 @@ type FieldExtractionRule struct {
 	ParseExpression string `json:"parseExpression"`
 	// Is the field extraction rule enabled.
 	Enabled bool `json:"enabled"`
+	// Field names extracted by the rule
+	FieldNames []string `json:"fieldNames,omitempty"`
 }

--- a/website/docs/r/field_extraction_rule.html.markdown
+++ b/website/docs/r/field_extraction_rule.html.markdown
@@ -32,6 +32,8 @@ The following arguments are supported:
 The following attributes are exported:
 
 - `id` - Unique identifier for the field extraction rule.
+- `field_names` - (computed after creation) identifiers projected from the field extraction rule. 
+                  
 
 ## Import
 Extraction Rules can be imported using the extraction rule id, e.g.:


### PR DESCRIPTION
The REST API documentation indicates that the list of identifiers projected from the parse
expression configured in the `field_extraction_rule` resource. The json data for
`fieldNames` will contain an array of strings for each named field projection. 

we added `FieldNames` to the the terraform schema as `field_names`, 
extended the client, updated the acc tests, and updated docs