### PR TITLE
DET-727: Added Rule tuning expression IDs field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ FEATURES:
 * **Updated sumologic_monitor resource:** Added support for automated playbooks in monitors
 * **New Data Source:** sumologic_monitor_folder
 
+## 3.1.3 (July 24, 2025)
+
+ENHANCEMENTS:
+* Added optional tuning_expression_ids for all types of rule resources
+
 ## 3.1.2 (July 23, 2025)
 
 BUG FIXES:

--- a/sumologic/resource_sumologic_cse_aggregation_rule.go
+++ b/sumologic/resource_sumologic_cse_aggregation_rule.go
@@ -111,6 +111,7 @@ func resourceSumologicCSEAggregationRule() *schema.Resource {
 				ValidateFunc: validation.IntBetween(0, 7*24*60*60*1000),
 				ForceNew:     false,
 			},
+			"tuning_expression_ids": getTuningExpressionIDsSchema(),
 		},
 	}
 }
@@ -154,6 +155,7 @@ func resourceSumologicCSEAggregationRuleRead(d *schema.ResourceData, meta interf
 	if CSEAggregationRuleGet.SuppressionWindowSize != nil {
 		d.Set("suppression_window_size", CSEAggregationRuleGet.SuppressionWindowSize)
 	}
+	d.Set("tuning_expression_ids", CSEAggregationRuleGet.TuningExpressionIDs)
 	return nil
 }
 
@@ -194,6 +196,7 @@ func resourceSumologicCSEAggregationRuleCreate(d *schema.ResourceData, meta inte
 			WindowSize:             windowSizeField(d.Get("window_size").(string)),
 			WindowSizeMilliseconds: d.Get("window_size_millis").(string),
 			SuppressionWindowSize:  suppressionWindowSize,
+			TuningExpressionIDs:    resourceToStringArray(d.Get("tuning_expression_ids").([]interface{})),
 		})
 
 		if err != nil {
@@ -280,5 +283,6 @@ func resourceToCSEAggregationRule(d *schema.ResourceData) (CSEAggregationRule, e
 		WindowSize:             windowSizeField(d.Get("window_size").(string)),
 		WindowSizeMilliseconds: d.Get("window_size_millis").(string),
 		SuppressionWindowSize:  suppressionWindowSize,
+		TuningExpressionIDs:    resourceToStringArray(d.Get("tuning_expression_ids").([]interface{})),
 	}, nil
 }

--- a/sumologic/resource_sumologic_cse_chain_rule.go
+++ b/sumologic/resource_sumologic_cse_chain_rule.go
@@ -95,6 +95,7 @@ func resourceSumologicCSEChainRule() *schema.Resource {
 				ValidateFunc: validation.IntBetween(0, 7*24*60*60*1000),
 				ForceNew:     false,
 			},
+			"tuning_expression_ids": getTuningExpressionIDsSchema(),
 		},
 	}
 }
@@ -134,7 +135,7 @@ func resourceSumologicCSEChainRuleRead(d *schema.ResourceData, meta interface{})
 	if CSEChainRuleGet.SuppressionWindowSize != nil {
 		d.Set("suppression_window_size", CSEChainRuleGet.SuppressionWindowSize)
 	}
-
+	d.Set("tuning_expression_ids", CSEChainRuleGet.TuningExpressionIDs)
 	return nil
 }
 
@@ -172,6 +173,7 @@ func resourceSumologicCSEChainRuleCreate(d *schema.ResourceData, meta interface{
 			WindowSize:             windowSizeField(d.Get("window_size").(string)),
 			WindowSizeMilliseconds: d.Get("window_size_millis").(string),
 			SuppressionWindowSize:  suppressionWindowSize,
+			TuningExpressionIDs:    resourceToStringArray(d.Get("tuning_expression_ids").([]interface{})),
 		})
 
 		if err != nil {
@@ -252,5 +254,6 @@ func resourceToCSEChainRule(d *schema.ResourceData) (CSEChainRule, error) {
 		WindowSize:             windowSizeField(d.Get("window_size").(string)),
 		WindowSizeMilliseconds: d.Get("window_size_millis").(string),
 		SuppressionWindowSize:  suppressionWindowSize,
+		TuningExpressionIDs:    resourceToStringArray(d.Get("tuning_expression_ids").([]interface{})),
 	}, nil
 }

--- a/sumologic/resource_sumologic_cse_first_seen_rule.go
+++ b/sumologic/resource_sumologic_cse_first_seen_rule.go
@@ -93,6 +93,7 @@ func resourceSumologicCSEFirstSeenRule() *schema.Resource {
 				ValidateFunc: validation.IntBetween(0, 7*24*60*60*1000),
 				ForceNew:     false,
 			},
+			"tuning_expression_ids": getTuningExpressionIDsSchema(),
 		},
 	}
 }
@@ -132,7 +133,7 @@ func resourceSumologicCSEFirstSeenRuleRead(d *schema.ResourceData, meta interfac
 	if CSEFirstSeenRuleGet.SuppressionWindowSize != nil {
 		d.Set("suppression_window_size", CSEFirstSeenRuleGet.SuppressionWindowSize)
 	}
-
+	d.Set("tuning_expression_ids", CSEFirstSeenRuleGet.TuningExpressionIDs)
 	return nil
 }
 
@@ -171,6 +172,7 @@ func resourceSumologicCSEFirstSeenRuleCreate(d *schema.ResourceData, meta interf
 			ValueFields:           resourceToStringArray(d.Get("value_fields").([]interface{})),
 			Version:               1,
 			SuppressionWindowSize: suppressionWindowSize,
+			TuningExpressionIDs:   resourceToStringArray(d.Get("tuning_expression_ids").([]interface{})),
 		})
 
 		if err != nil {
@@ -227,5 +229,6 @@ func resourceToCSEFirstSeenRule(d *schema.ResourceData) (CSEFirstSeenRule, error
 		ValueFields:           resourceToStringArray(d.Get("value_fields").([]interface{})),
 		Version:               1,
 		SuppressionWindowSize: suppressionWindowSize,
+		TuningExpressionIDs:   resourceToStringArray(d.Get("tuning_expression_ids").([]interface{})),
 	}, nil
 }

--- a/sumologic/resource_sumologic_cse_match_rule.go
+++ b/sumologic/resource_sumologic_cse_match_rule.go
@@ -62,6 +62,7 @@ func resourceSumologicCSEMatchRule() *schema.Resource {
 				ValidateFunc: validation.IntBetween(0, 7*24*60*60*1000),
 				ForceNew:     false,
 			},
+			"tuning_expression_ids": getTuningExpressionIDsSchema(),
 		},
 	}
 }
@@ -97,6 +98,7 @@ func resourceSumologicCSEMatchRuleRead(d *schema.ResourceData, meta interface{})
 	if CSEMatchRuleGet.SuppressionWindowSize != nil {
 		d.Set("suppression_window_size", CSEMatchRuleGet.SuppressionWindowSize)
 	}
+	d.Set("tuning_expression_ids", CSEMatchRuleGet.TuningExpressionIDs)
 
 	return nil
 }
@@ -131,6 +133,7 @@ func resourceSumologicCSEMatchRuleCreate(d *schema.ResourceData, meta interface{
 			SummaryExpression:     d.Get("summary_expression").(string),
 			Tags:                  resourceToStringArray(d.Get("tags").([]interface{})),
 			SuppressionWindowSize: suppressionWindowSize,
+			TuningExpressionIDs:   resourceToStringArray(d.Get("tuning_expression_ids").([]interface{})),
 		})
 
 		if err != nil {
@@ -182,5 +185,6 @@ func resourceToCSEMatchRule(d *schema.ResourceData) (CSEMatchRule, error) {
 		SummaryExpression:     d.Get("summary_expression").(string),
 		Tags:                  resourceToStringArray(d.Get("tags").([]interface{})),
 		SuppressionWindowSize: suppressionWindowSize,
+		TuningExpressionIDs:   resourceToStringArray(d.Get("tuning_expression_ids").([]interface{})),
 	}, nil
 }

--- a/sumologic/resource_sumologic_cse_outlier_rule.go
+++ b/sumologic/resource_sumologic_cse_outlier_rule.go
@@ -118,6 +118,7 @@ func resourceSumologicCSEOutlierRule() *schema.Resource {
 				ValidateFunc: validation.IntBetween(0, 7*24*60*60*1000),
 				ForceNew:     false,
 			},
+			"tuning_expression_ids": getTuningExpressionIDsSchema(),
 		},
 	}
 }
@@ -159,7 +160,7 @@ func resourceSumologicCSEOutlierRuleRead(d *schema.ResourceData, meta interface{
 	if CSEOutlierRuleGet.SuppressionWindowSize != nil {
 		d.Set("suppression_window_size", CSEOutlierRuleGet.SuppressionWindowSize)
 	}
-
+	d.Set("tuning_expression_ids", CSEOutlierRuleGet.TuningExpressionIDs)
 	return nil
 }
 
@@ -199,6 +200,7 @@ func resourceSumologicCSEOutlierRuleCreate(d *schema.ResourceData, meta interfac
 			Tags:                  resourceToStringArray(d.Get("tags").([]interface{})),
 			WindowSize:            windowSizeField(d.Get("window_size").(string)),
 			SuppressionWindowSize: suppressionWindowSize,
+			TuningExpressionIDs:   resourceToStringArray(d.Get("tuning_expression_ids").([]interface{})),
 		})
 
 		if err != nil {
@@ -256,5 +258,6 @@ func resourceToCSEOutlierRule(d *schema.ResourceData) (CSEOutlierRule, error) {
 		Tags:                  resourceToStringArray(d.Get("tags").([]interface{})),
 		WindowSize:            windowSizeField(d.Get("window_size").(string)),
 		SuppressionWindowSize: suppressionWindowSize,
+		TuningExpressionIDs:   resourceToStringArray(d.Get("tuning_expression_ids").([]interface{})),
 	}, nil
 }

--- a/sumologic/resource_sumologic_cse_threshold_rule.go
+++ b/sumologic/resource_sumologic_cse_threshold_rule.go
@@ -91,6 +91,7 @@ func resourceSumologicCSEThresholdRule() *schema.Resource {
 				ValidateFunc: validation.IntBetween(0, 7*24*60*60*1000),
 				ForceNew:     false,
 			},
+			"tuning_expression_ids": getTuningExpressionIDsSchema(),
 		},
 	}
 }
@@ -132,6 +133,7 @@ func resourceSumologicCSEThresholdRuleRead(d *schema.ResourceData, meta interfac
 	if CSEThresholdRuleGet.SuppressionWindowSize != nil {
 		d.Set("suppression_window_size", CSEThresholdRuleGet.SuppressionWindowSize)
 	}
+	d.Set("tuning_expression_ids", CSEThresholdRuleGet.TuningExpressionIDs)
 	return nil
 }
 
@@ -172,6 +174,7 @@ func resourceSumologicCSEThresholdRuleCreate(d *schema.ResourceData, meta interf
 			WindowSize:             windowSizeField(d.Get("window_size").(string)),
 			WindowSizeMilliseconds: d.Get("window_size_millis").(string),
 			SuppressionWindowSize:  suppressionWindowSize,
+			TuningExpressionIDs:    resourceToStringArray(d.Get("tuning_expression_ids").([]interface{})),
 		})
 
 		if err != nil {
@@ -229,5 +232,6 @@ func resourceToCSEThresholdRule(d *schema.ResourceData) (CSEThresholdRule, error
 		WindowSize:             windowSizeField(d.Get("window_size").(string)),
 		WindowSizeMilliseconds: d.Get("window_size_millis").(string),
 		SuppressionWindowSize:  suppressionWindowSize,
+		TuningExpressionIDs:    resourceToStringArray(d.Get("tuning_expression_ids").([]interface{})),
 	}, nil
 }

--- a/sumologic/sumologic_cse_rule_common.go
+++ b/sumologic/sumologic_cse_rule_common.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func getEntitySelectorsSchema() *schema.Schema {
@@ -167,4 +168,36 @@ func (r *windowSizeField) UnmarshalJSON(data []byte) error {
 	cleanedData := strings.Trim(string(data), `"`)
 	*r = windowSizeField(cleanedData)
 	return nil
+}
+
+type TuningExpression struct {
+	ID          string `json:"id,omitempty"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Expression  string `json:"expression"`
+	Enabled     bool   `json:"enabled"`
+	IsGlobal    bool   `json:"isGlobal"`
+}
+
+// getTuningExpressionSchema returns the schema for a tuning expression.
+func getTuningExpressionIDsSchema() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		Elem: &schema.Schema{
+			Type:         schema.TypeString,
+			ValidateFunc: validation.StringIsNotEmpty,
+		},
+	}
+}
+
+// getTuningExpressionIDs converts a list of tuning expressions to a list of their IDs.
+func getTuningExpressionIDs(tuningExpressions []TuningExpression) []string {
+	var result []string
+
+	for _, tuningExpression := range tuningExpressions {
+		result = append(result, tuningExpression.ID)
+	}
+
+	return result
 }


### PR DESCRIPTION
DET-727: Added support for rule tuning expression ids for all rule types

Tested changes manually. 

- Rule creation with tuning_expression_ids field:

Rule body:

    description_expression = "TEST - description expression"
    enabled                = true
    expression             = "objectType = \"Network\""
    is_prototype           = false
    name                   = "DET-727 test"
    name_expression        = "TEST - name expression"
    tags                   = []
    tuning_expression_ids  = [
        "TUNING-EXPRESSION-44", "TUNING-EXPRESSION-117"
    ]
    entity_selectors {
        entity_type = "_ip"
        expression  = "srcDevice_ip"
    }
    severity_mapping {
        default = 5
        type    = "constant"
    }

<img width="669" height="743" alt="Screenshot 2025-07-24 at 11 03 07 AM" src="https://github.com/user-attachments/assets/f02b6cac-48d6-4b26-b92f-9f46f484887c" />




- Rule update without tuning_expression_ids field:

Rule body:

    description_expression = "TEST - description expression"
    enabled                = true
    expression             = "objectType = \"Network\""
    is_prototype           = false
    name                   = "DET-727 test"
    name_expression        = "TEST - name expression"
    tags                   = []
    entity_selectors {
        entity_type = "_ip"
        expression  = "srcDevice_ip"
    }
    severity_mapping {
        default = 5
        type    = "constant"
    }
    
<img width="1140" height="685" alt="Screenshot 2025-07-24 at 11 12 10 AM" src="https://github.com/user-attachments/assets/be0f1d37-a13f-43f9-97de-89cf2f931d60" />




- Rule update with single id in tuning_expression_ids field:

Rule body:

    description_expression = "TEST - description expression"
    enabled                = true
    expression             = "objectType = \"Network\""
    is_prototype           = false
    name                   = "DET-7272"
    name_expression        = "TEST - name expression"
    tags                   = []
    tuning_expression_ids  = ["TUNING-EXPRESSION-44"]
    entity_selectors {
        entity_type = "_ip"
        expression  = "srcDevice_ip"
    }
    severity_mapping {
        default = 5
        type    = "constant"
    }

<img width="627" height="607" alt="Screenshot 2025-07-24 at 11 17 45 AM" src="https://github.com/user-attachments/assets/9d4c985d-c72e-4b48-9d45-f9f7ed8e9a1d" />
