### PR TITLE
Add region filter support for Azure Metrics source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ ENHANCEMENTS:
 * Added support for overriding sumo built-in rules
 * Updated Terraform version in GitHub Actions tests to 1.7.5
 
+BUG FIXES:
+* Add region filter support to sumologic_azure_metrics_source
+
 ## 3.1.3 (August 6, 2025)
 
 BUG FIXES:

--- a/sumologic/resource_sumologic_azure_metrics_source_test.go
+++ b/sumologic/resource_sumologic_azure_metrics_source_test.go
@@ -38,6 +38,9 @@ func TestAccSumologicAzureMetricsSource_create(t *testing.T) {
 					resource.TestCheckResourceAttr(azureMetricsResourceName, "category", sCategory),
 					resource.TestCheckResourceAttr(azureMetricsResourceName, "content_type", "AzureMetrics"),
 					resource.TestCheckResourceAttr(azureMetricsResourceName, "path.0.type", "AzureMetricsPath"),
+					resource.TestCheckResourceAttr(azureMetricsResourceName, "path.0.limit_to_regions.0", "eastus2"),
+					resource.TestCheckResourceAttr(azureMetricsResourceName, "path.0.limit_to_regions.1", "westeurope"),
+					resource.TestCheckResourceAttr(azureMetricsResourceName, "path.0.limit_to_namespaces.0", "Microsoft.ClassicStorage/storageAccounts"),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -187,6 +190,7 @@ resource "sumologic_azure_metrics_source" "azure" {
 	path {
 		type = "AzureMetricsPath"
 		environment = "Azure"
+		limit_to_regions = ["eastus2", "westeurope"]
 		limit_to_namespaces = ["Microsoft.ClassicStorage/storageAccounts"]
 		azure_tag_filters {
 			type = "AzureTagFilters"

--- a/sumologic/resource_sumologic_generic_polling_source.go
+++ b/sumologic/resource_sumologic_generic_polling_source.go
@@ -804,6 +804,14 @@ func getPollingPathSettings(d *schema.ResourceData) (PollingPath, error) {
 		case "AzureMetricsPath":
 			pathSettings.Type = "AzureMetricsPath"
 			pathSettings.Environment = path["environment"].(string)
+			rawLimitToRegions := path["limit_to_regions"].([]interface{})
+			LimitToRegions := make([]string, 0, len(rawLimitToRegions))
+			for _, v := range rawLimitToRegions {
+				if v != nil {
+					LimitToRegions = append(LimitToRegions, v.(string))
+				}
+			}
+			pathSettings.LimitToRegions = LimitToRegions
 			rawLimitToNamespaces := path["limit_to_namespaces"].([]interface{})
 			LimitToNamespaces := make([]string, 0, len(rawLimitToNamespaces))
 			for _, v := range rawLimitToNamespaces {


### PR DESCRIPTION
### Description

Adds the `limit_to_regions` config to the path for Azure Metrics sources.
Updates UT to verify the new config.

Docs to be updated when published.

Test result:
```
=== RUN   TestAccSumologicAzureMetricsSource_create
--- PASS: TestAccSumologicAzureMetricsSource_create (6.16s)
PASS
ok  	github.com/SumoLogic/terraform-provider-sumologic/sumologic	6.469s
```
