### PR TITLE
add omitempty tag to ViewFilter in ViewFilterDefinition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## X.Y.Z (Unreleased)
-* Add new change notes here
+## 3.1.8 (Unreleased)
+BUG FIXES:
+* Fixed validation error when updating roles with selection_type="Deny" 
 
 ## 3.1.7 (October 31, 2025)
 

--- a/sumologic/sumologic_role_v2.go
+++ b/sumologic/sumologic_role_v2.go
@@ -95,5 +95,5 @@ type RoleV2 struct {
 
 type ViewFilterDefinition struct {
 	ViewName   string `json:"viewName"`
-	ViewFilter string `json:"viewFilter"`
+	ViewFilter string `json:"viewFilter,omitempty"`
 }


### PR DESCRIPTION
### Description

Fix: Add omitempty tag to ViewFilter
Problem: Creating Sumo Logic roles with selection_type = "Deny" fails
with "view_filter_should_be_null" error when view_filter is not specified.

Cause: Unset view_filter fields were serialized as empty strings ("")
instead of being omitted from JSON, causing backend validation to fail.

Fix: Added omitempty JSON tag to ViewFilterDefinition.ViewFilter
field. Empty values are now omitted from the JSON payload.

Result: Users can now create and update Deny roles without validation errors.

### Check list
* [x] Describe the changes and their purpose
* [ ] Update HTML docs (if applicable)
    * [preview tool](https://registry.terraform.io/tools/doc-preview)
* [x] Update [`CHANGELOG.md`](../CHANGELOG.md)
* [ ] Check [`CONTRIBUTING.md`](../CONTRIBUTING.md) for anything forgotten
