### PR TITLE
SUMO-250676: move read to use id to support import of df rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ ENHANCEMENTS:
 * Added enable/disable support to the `sumologic_source_template` resource.
 * Updated endpoint for `sumologic_source_template` resource to use the open API standard.
 * Fix for failing content test case for scheduled searches
+  
+BUG FIXES:
+* Fixes import operation for `sumologic_data_forwarding_rule`
+
+DOCS:
+* Fix import documentation for `sumologic_data_forwarding_rule` to clarify index_id usage in imports.
 
 ## 3.2.2 (January 6, 2026)
 DOCS:

--- a/sumologic/resource_sumologic_data_forwarding_rule.go
+++ b/sumologic/resource_sumologic_data_forwarding_rule.go
@@ -50,7 +50,6 @@ func resourceSumologicDataForwardingRule() *schema.Resource {
 			},
 		},
 	}
-
 }
 
 func resourceSumologicDataForwardingRuleCreate(d *schema.ResourceData, meta interface{}) error {
@@ -85,16 +84,19 @@ func resourceSumologicDataForwardingRuleUpdate(d *schema.ResourceData, meta inte
 
 func resourceSumologicDataForwardingRuleDelete(d *schema.ResourceData, meta interface{}) error {
 	c := meta.(*Client)
-
-	return c.DeleteDataForwardingRule(d.Get("index_id").(string))
+	return c.DeleteDataForwardingRule(d.Id())
 }
+
 
 func resourceSumologicDataForwardingRuleRead(d *schema.ResourceData, meta interface{}) error {
 	c := meta.(*Client)
 
-	indexId := d.Get("index_id").(string)
-	dataForwardingRule, err := c.getDataForwardingRule(indexId)
+	indexId := d.Id()
+	if indexId == "" {
+		return nil
+	}
 
+	dataForwardingRule, err := c.getDataForwardingRule(indexId)
 	if err != nil {
 		return err
 	}
@@ -102,12 +104,11 @@ func resourceSumologicDataForwardingRuleRead(d *schema.ResourceData, meta interf
 	if dataForwardingRule == nil {
 		log.Printf("[WARN] DataForwarding Rule (%s) not found, removing from state", indexId)
 		d.SetId("")
-
 		return nil
 	}
 
 	d.SetId(dataForwardingRule.IndexId)
-	d.Set("index_id", indexId)
+	d.Set("index_id", dataForwardingRule.IndexId)
 	d.Set("destination_id", dataForwardingRule.DestinationId)
 	d.Set("enabled", dataForwardingRule.Enabled)
 	d.Set("file_format", dataForwardingRule.FileFormat)
@@ -116,6 +117,7 @@ func resourceSumologicDataForwardingRuleRead(d *schema.ResourceData, meta interf
 
 	return nil
 }
+
 
 func validatePayloadSchema(val interface{}, key string) (warns []string, errs []error) {
 	allowedValues := map[string]struct{}{

--- a/website/docs/r/data_forwarding_rule.html.markdown
+++ b/website/docs/r/data_forwarding_rule.html.markdown
@@ -67,3 +67,20 @@ The following arguments are supported:
 The following attributes are exported:
 
 - `id` - The Index ID of the data_forwarding_rule
+
+## Import
+
+A `sumologic_data_forwarding_rule` can be imported using the **Index ID** (`index_id`) of the rule.
+
+The Index ID is the unique identifier used by the Sumo Logic API to read a Data Forwarding Rule and
+is also used internally by Terraform as the resource ID.
+
+### Import using Terraform CLI
+
+```terraform
+import {
+  to = sumologic_data_forwarding_rule.example
+  id = "[index id]"
+}
+
+```


### PR DESCRIPTION
### Description

I am doing this as a fix towards broken TF import for resource [data_forwarding_rule](https://registry.terraform.io/providers/SumoLogic/sumologic/3.1.1/docs/resources/data_forwarding_rule)

To understand the fix, we need a bit of context on API design for this resource. This resource is exposed in APIs [here](https://api.au.sumologic.com/docs/#operation/getDataForwardingRule). 
Here is the sample response -  
```
{
  "indexId": "1",
  "destinationId": "1",
  "enabled": true,
  "fileFormat": "{index}_{day}_{hour}_{minute}_{second}",
  "payloadSchema": "builtInFields",
  "format": "csv",
  "createdAt": "2018-10-16T09:10:00.000Z",
  "createdBy": "0000000006743FDD",
  "modifiedAt": "2018-10-16T09:10:00.000Z",
  "modifiedBy": "0000000006743FE8",
  "id": "1",
  "bucket": {}
}
```

The interesting thing here is that despite resource having a unique API/resource identifer (field `id`), the resource is identified via the other unique field in payload (field `indexid`). The REST endpoint like `GET /id` or `DELETE /id` expect `indexId` in path. 
This works atm as DF rules are 1-to-1 mapped because of current business rules, but imho this modelling is confusing. 

On the bug fix, currently import uses `ImportStatePassthrough` which just calls read on the resource based on the `id` passed. This won't work because read currently works by reading `indexId` from resource which will be absent in imports. So, I have updated read to use `id` from state. Currently, we end up calling read on resource like `GET /"empty-string"`.

Given, `indexId` is currently saved in state as resource id this will work for now. 

### Check list
* [x] Describe the changes and their purpose
* [x] Update HTML docs (if applicable)
    * [preview tool](https://registry.terraform.io/tools/doc-preview)
* [x] Update [`CHANGELOG.md`](../CHANGELOG.md)
* [ ] Check [`CONTRIBUTING.md`](../CONTRIBUTING.md) for anything forgotten
