### PR TITLE
feat(password_policy): add disallow_weak_passwords to password policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## X.Y.Z (Unreleased)
 * Add new change notes here
 
+ENHANCEMENTS:
+* Added `disallow_weak_passwords` field to `sumologic_password_policy` resource to support the Disallow Weak Passwords setting introduced in the Sumo Logic password policy API.
+
 DOCS:
 * Added documentation for `direction` field in `logs_anomaly_condition` and `metrics_anomaly_condition` for `sumologic_monitor` resource
 

--- a/sumologic/resource_sumologic_password_policy.go
+++ b/sumologic/resource_sumologic_password_policy.go
@@ -18,6 +18,7 @@ var DefaultPasswordPolicy = PasswordPolicy{
 	AccountLockoutDurationInMins:   30,
 	RequireMfa:                     false,
 	RememberMfa:                    true,
+	DisallowWeakPasswords:          false,
 }
 
 func resourceSumologicPasswordPolicy() *schema.Resource {
@@ -93,6 +94,11 @@ func resourceSumologicPasswordPolicy() *schema.Resource {
 				Optional: true,
 				Default:  DefaultPasswordPolicy.RememberMfa,
 			},
+			"disallow_weak_passwords": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  DefaultPasswordPolicy.DisallowWeakPasswords,
+			},
 		},
 	}
 }
@@ -153,6 +159,7 @@ func resourceToPasswordPolicy(d *schema.ResourceData) PasswordPolicy {
 		AccountLockoutDurationInMins:   d.Get("account_lockout_duration_in_mins").(int),
 		RequireMfa:                     d.Get("require_mfa").(bool),
 		RememberMfa:                    d.Get("remember_mfa").(bool),
+		DisallowWeakPasswords:          d.Get("disallow_weak_passwords").(bool),
 	}
 }
 
@@ -170,4 +177,5 @@ func setPasswordPolicyResource(d *schema.ResourceData, passwordPolicy *PasswordP
 	d.Set("account_lockout_duration_in_mins", passwordPolicy.AccountLockoutDurationInMins)
 	d.Set("require_mfa", passwordPolicy.RequireMfa)
 	d.Set("remember_mfa", passwordPolicy.RememberMfa)
+	d.Set("disallow_weak_passwords", passwordPolicy.DisallowWeakPasswords)
 }

--- a/sumologic/resource_sumologic_password_policy_test.go
+++ b/sumologic/resource_sumologic_password_policy_test.go
@@ -24,6 +24,7 @@ func TestAccPasswordPolicy_create(t *testing.T) {
 		AccountLockoutDurationInMins:   30,
 		RequireMfa:                     false,
 		RememberMfa:                    false,
+		DisallowWeakPasswords:          true,
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -57,6 +58,7 @@ func TestAccPasswordPolicy_update(t *testing.T) {
 		AccountLockoutDurationInMins:   30,
 		RequireMfa:                     false,
 		RememberMfa:                    false,
+		DisallowWeakPasswords:          false,
 	}
 
 	updatedPasswordPolicy := PasswordPolicy{
@@ -73,6 +75,7 @@ func TestAccPasswordPolicy_update(t *testing.T) {
 		AccountLockoutDurationInMins:   31,
 		RequireMfa:                     true,
 		RememberMfa:                    true,
+		DisallowWeakPasswords:          true,
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -146,6 +149,7 @@ func testPasswordPolicyCheckResourceAttr(resourceName string, passwordPolicy *Pa
 			resource.TestCheckResourceAttr(resourceName, "account_lockout_duration_in_mins", strconv.Itoa(passwordPolicy.AccountLockoutDurationInMins)),
 			resource.TestCheckResourceAttr(resourceName, "require_mfa", strconv.FormatBool(passwordPolicy.RequireMfa)),
 			resource.TestCheckResourceAttr(resourceName, "remember_mfa", strconv.FormatBool(passwordPolicy.RememberMfa)),
+			resource.TestCheckResourceAttr(resourceName, "disallow_weak_passwords", strconv.FormatBool(passwordPolicy.DisallowWeakPasswords)),
 		)
 		return f(s)
 	}
@@ -167,6 +171,7 @@ resource "sumologic_password_policy" "%s" {
 	account_lockout_duration_in_mins = %d
 	require_mfa = %t
 	remember_mfa = %t
+	disallow_weak_passwords = %t
 }`, label,
 		passwordPolicy.MinLength,
 		passwordPolicy.MaxLength,
@@ -180,5 +185,6 @@ resource "sumologic_password_policy" "%s" {
 		passwordPolicy.FailedLoginResetDurationInMins,
 		passwordPolicy.AccountLockoutDurationInMins,
 		passwordPolicy.RequireMfa,
-		passwordPolicy.RememberMfa)
+		passwordPolicy.RememberMfa,
+		passwordPolicy.DisallowWeakPasswords)
 }

--- a/sumologic/sumologic_password_policy.go
+++ b/sumologic/sumologic_password_policy.go
@@ -66,4 +66,5 @@ type PasswordPolicy struct {
 	AccountLockoutDurationInMins   int  `json:"accountLockoutDurationInMins"`
 	RequireMfa                     bool `json:"requireMfa"`
 	RememberMfa                    bool `json:"rememberMfa"`
+	DisallowWeakPasswords          bool `json:"disallowWeakPasswords"`
 }

--- a/website/docs/r/password_policy.html.markdown
+++ b/website/docs/r/password_policy.html.markdown
@@ -26,6 +26,7 @@ resource "sumologic_password_policy" "examplePasswordPolicy" {
   account_lockout_duration_in_mins = 30
   require_mfa = false
   remember_mfa = true
+  disallow_weak_passwords = false
 }
 ```
 
@@ -46,5 +47,6 @@ The following arguments are supported:
 - `account_lockout_duration_in_mins` - (Optional) The duration of time in minutes that a locked-out account remained locked before getting unlocked automatically. Defaults to 30.
 - `require_mfa` - (Optional) If MFA should be required to log in. Defaults to false.
 - `remember_mfa` - (Optional) If MFA should be remembered on the browser. Defaults to true.
+- `disallow_weak_passwords` - (Optional) If weak passwords should be disallowed. When enabled, Sumo Logic will reject passwords that are commonly used, obtained from previous breaches, dictionary words, repetitive or sequential characters, or context-specific words such as the service name or username. Defaults to false.
 
 [1]: https://help.sumologic.com/Manage/Security/Set-the-Password-Policy


### PR DESCRIPTION


### Description

  Adds support for the `disallow_weak_passwords` field introduced in the Sumo Logic
  password policy API. When enabled, Sumo Logic rejects passwords that are
  commonly used, obtained from previous breaches, dictionary words, repetitive/sequential
  characters, or context-specific words.

### Changes
  - Added `DisallowWeakPasswords` to the `PasswordPolicy` struct (`disallowWeakPasswords` JSON field)
  - Added `disallow_weak_passwords` boolean schema attribute (optional, default `false`)
  - Wired into `resourceToPasswordPolicy` and `setPasswordPolicyResource`
  - Updated acceptance tests and example docs


### Check list
* [x] Describe the changes and their purpose
* [x] Update HTML docs (if applicable)
    * [preview tool](https://registry.terraform.io/tools/doc-preview)
* [x] Update [`CHANGELOG.md`](../CHANGELOG.md)
* [x] Check [`CONTRIBUTING.md`](../CONTRIBUTING.md) for anything forgotten
