### PR TITLE
CSRE-2371: add region field to sumologic_kinesis_log_source authentication schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## X.Y.Z (Unreleased)
-* Add new change notes here
+
+ENHANCEMENTS:
+* Added `region` field to `authentication` block of `sumologic_kinesis_log_source` to support non-standard AWS partitions such as EU Sovereign Cloud (`eusc-de-east-1`).
 
 DOCS:
 * Added documentation for `direction` field in `logs_anomaly_condition` and `metrics_anomaly_condition` for `sumologic_monitor` resource

--- a/sumologic/resource_sumologic_kinesis_log_source.go
+++ b/sumologic/resource_sumologic_kinesis_log_source.go
@@ -58,6 +58,10 @@ func resourceSumologicKinesisLogSource() *schema.Resource {
 					Type:     schema.TypeString,
 					Optional: true,
 				},
+				"region": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
 			},
 		},
 	}

--- a/sumologic/resource_sumologic_kinesis_log_source_test.go
+++ b/sumologic/resource_sumologic_kinesis_log_source_test.go
@@ -178,6 +178,69 @@ resource "sumologic_kinesis_log_source" "kinesisLog" {
 `, cName, cDescription, cCategory, sName, sDescription, sCategory, testAwsRoleArn, testAwsBucket)
 }
 
+func TestAccSumologicKinesisLogSource_s3BucketAuthWithRegion(t *testing.T) {
+	var kinesisLogSource KinesisLogSource
+	var collector Collector
+	cName, cDescription, cCategory := getRandomizedParams()
+	sName, sDescription, sCategory := getRandomizedParams()
+	kinesisLogResourceName := "sumologic_kinesis_log_source.kinesisLog"
+	testAwsID := os.Getenv("SUMOLOGIC_TEST_AWS_ID")
+	testAwsKey := os.Getenv("SUMOLOGIC_TEST_AWS_KEY")
+	testAwsBucket := os.Getenv("SUMOLOGIC_TEST_BUCKET_NAME")
+	testAwsRegion := os.Getenv("SUMOLOGIC_TEST_AWS_REGION")
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKinesisLogSourceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSumologicKinesisLogSourceS3AuthWithRegionConfig(cName, cDescription, cCategory, sName, sDescription, sCategory, testAwsID, testAwsKey, testAwsBucket, testAwsRegion),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKinesisLogSourceExists(kinesisLogResourceName, &kinesisLogSource),
+					testAccCheckKinesisLogSourceValues(&kinesisLogSource, sName, sDescription, sCategory),
+					testAccCheckCollectorExists("sumologic_collector.test", &collector),
+					resource.TestCheckResourceAttrSet(kinesisLogResourceName, "id"),
+					resource.TestCheckResourceAttr(kinesisLogResourceName, "name", sName),
+					resource.TestCheckResourceAttr(kinesisLogResourceName, "content_type", "KinesisLog"),
+					resource.TestCheckResourceAttr(kinesisLogResourceName, "authentication.0.type", "S3BucketAuthentication"),
+					resource.TestCheckResourceAttr(kinesisLogResourceName, "authentication.0.region", testAwsRegion),
+					resource.TestCheckResourceAttr(kinesisLogResourceName, "path.0.type", "KinesisLogPath"),
+				),
+			},
+		},
+	})
+}
+
+func testAccSumologicKinesisLogSourceS3AuthWithRegionConfig(cName, cDescription, cCategory, sName, sDescription, sCategory, awsID, awsKey, awsBucket, awsRegion string) string {
+	return fmt.Sprintf(`
+resource "sumologic_collector" "test" {
+    name        = "%s"
+    description = "%s"
+    category    = "%s"
+}
+
+resource "sumologic_kinesis_log_source" "kinesisLog" {
+    name         = "%s"
+    description  = "%s"
+    category     = "%s"
+    content_type = "KinesisLog"
+    collector_id = "${sumologic_collector.test.id}"
+    authentication {
+        type       = "S3BucketAuthentication"
+        access_key = "%s"
+        secret_key = "%s"
+        region     = "%s"
+    }
+    path {
+        type            = "KinesisLogPath"
+        bucket_name     = "%s"
+        path_expression = "http-endpoint-failed/*"
+        scan_interval   = 30000
+    }
+}
+`, cName, cDescription, cCategory, sName, sDescription, sCategory, awsID, awsKey, awsRegion, awsBucket)
+}
+
 func testAccSumologicKinesisLogSourceNoAuthConfig(cName, cDescription, cCategory, sName, sDescription, sCategory string) string {
 	return fmt.Sprintf(`
 resource "sumologic_collector" "test" {

--- a/website/docs/r/kinesis_log_source.html.markdown
+++ b/website/docs/r/kinesis_log_source.html.markdown
@@ -34,6 +34,28 @@ __IMPORTANT:__ The AWS credentials are stored in plain-text in the state. This i
     }
   }
 
+  # EU Sovereign Cloud example using access key authentication with explicit region
+  resource "sumologic_kinesis_log_source" "kinesis_log_esc" {
+    name         = "Kinesis Log ESC"
+    description  = "Description for Kinesis Log Source in EU Sovereign Cloud"
+    category     = "prod/kinesis/log"
+    content_type = "KinesisLog"
+    collector_id = "${sumologic_collector.collector.id}"
+    authentication {
+      type       = "S3BucketAuthentication"
+      access_key = "someKey"
+      secret_key = "******"
+      region     = "eusc-de-east-1"
+    }
+
+    path {
+      type            = "KinesisLogPath"
+      bucket_name     = "testBucket"
+      path_expression = "http-endpoint-failed/*"
+      scan_interval   = 30000
+    }
+  }
+
   resource "sumologic_kinesis_log_source" "kinesis_log_role_arn" {
     name         = "Kinesis Log"
     description  = "Description for Kinesis Log Source"
@@ -71,6 +93,7 @@ In addition to the common properties, the following arguments are supported:
      + `access_key` - (Required) Your AWS access key if using type `S3BucketAuthentication`
      + `secret_key` - (Required) Your AWS secret key if using type `S3BucketAuthentication`
      + `role_arn` - (Required) Your AWS role ARN if using type `AWSRoleBasedAuthentication`
+     + `region` - (Optional) Your AWS bucket region. Required when using non-standard AWS partitions such as EU Sovereign Cloud (`eusc-de-east-1`).
  - `path` - (Optional) The location of S3 bucket for failed Kinesis log data.
      + `type` - (Required) Must be either `KinesisLogPath` or `NoPathExpression`
      + `bucket_name` - (Optional) The name of the bucket. This is needed if using type `KinesisLogPath`. 


### PR DESCRIPTION
### What

Add `region` field to the `authentication` block schema of `sumologic_kinesis_log_source`.

### Why

The Go implementation in `getKinesisLogAuthentication()` already handles `auth["region"]` for both `S3BucketAuthentication` and `AWSRoleBasedAuthentication`, but the field was missing from the Terraform schema definition. This made it impossible to specify a region via Terraform configuration, causing `KinesisLogPath` S3 authentication to fail for non-standard AWS partitions such as EU Sovereign Cloud (`eusc-de-east-1`).

Without `region`, Sumo Logic defaults to standard AWS S3 endpoints (`s3.amazonaws.com`), which are unreachable from sovereign cloud partitions.

### Changes

- Added `region` (Optional, TypeString) to `authentication` schema in `resource_sumologic_kinesis_log_source.go`
- Added acceptance test `TestAccSumologicKinesisLogSource_s3BucketAuthWithRegion` covering `S3BucketAuthentication` with `region`
- Updated docs with `region` argument reference and EU Sovereign Cloud example
- Updated CHANGELOG

### Testing

- [x] Compiled the code
- [ ] Ran UTs locally
- [ ] Tested on EpD

🤖 Generated with [Claude Code](https://claude.com/claude-code)