### PR TITLE
SUMO-287425: Disable source template before deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## X.Y.Z (Unreleased)
 
+BUG FIXES:
+* Fixed `sumologic_source_template` deletion failing with "Enabled source template cannot be deleted" by disabling the template before issuing the delete call.
+
 DOCS:
 * Fixed documentation for `sumologic_s3_archive_source` to clarify it creates a source for ingesting from an S3 archive bucket (not an Archive Destination). Added a note pointing to the Archive Management UI for creating archive destinations. Fixed incorrect `content_type` value in example usage (`AwsS3Bucket` → `AwsS3ArchiveBucket`).
 

--- a/sumologic/resource_sumologic_source_template.go
+++ b/sumologic/resource_sumologic_source_template.go
@@ -204,6 +204,14 @@ func resourceSumologicSourceTemplateUpdate(d *schema.ResourceData, meta interfac
 func resourceSumologicSourceTemplateDelete(d *schema.ResourceData, meta interface{}) error {
 	c := meta.(*Client)
 
+	sourceTemplate := resourceToSourceTemplate(d)
+	disabled := false
+	sourceTemplate.IsEnabled = &disabled
+	err := c.UpdateSourceTemplate(sourceTemplate)
+	if err != nil {
+		return err
+	}
+
 	return c.DeleteSourceTemplate(d.Id())
 }
 


### PR DESCRIPTION
### Description

The backend recently introduced deletion protection for enabled source templates (feature flag: `ot.source.template.deletion.protection.enabled`). This causes the API to reject `DELETE` calls on source templates that are still enabled, returning:

```
"Enabled source template cannot be deleted. Please disable the template before deleting."
```

This PR updates `resourceSumologicSourceTemplateDelete` to disable the source template (set `isEnabled=false` via `UpdateSourceTemplate`) before calling `DeleteSourceTemplate`. This ensures Terraform can cleanly destroy source template resources without manual intervention.

**Root cause:** [Sanyaku/sumologic#151046](https://github.com/Sanyaku/sumologic/pull/151046)

### Check list
* [x] Describe the changes and their purpose
* [ ] Update HTML docs (if applicable)
    * [preview tool](https://registry.terraform.io/tools/doc-preview)
* [x] Update [`CHANGELOG.md`](../CHANGELOG.md)
* [ ] Check [`CONTRIBUTING.md`](../CONTRIBUTING.md) for anything forgotten