### PR TITLE
CSIEM-2572: fix TestAccSumologicCSEOutlierRule_Override and TestAccSumologicSourceTemplate_* tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## X.Y.Z (Unreleased)
 
+BUG FIXES:
+* Fixed `sumologic_source_template` deletion failing with "Enabled source template cannot be deleted" by disabling the template before issuing the delete call.
+
 DOCS:
 * Fixed documentation for `sumologic_s3_archive_source` to clarify it creates a source for ingesting from an S3 archive bucket (not an Archive Destination). Added a note pointing to the Archive Management UI for creating archive destinations. Fixed incorrect `content_type` value in example usage (`AwsS3Bucket` → `AwsS3ArchiveBucket`).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 ## X.Y.Z (Unreleased)
 
+ENHANCEMENTS:
+* Adjusts fields in `resource_sumologic_cse_aggregation_rule` and `resource_sumologic_cse_outlier_rule` that aren't sent as part of the override payload to be Optional & Computed. This allows the override config
+
 BUG FIXES:
 * Fixed `sumologic_source_template` deletion failing with "Enabled source template cannot be deleted" by disabling the template before issuing the delete call.
-* Fixed `TestAccSumologicCSEOutlierRule_Override` that broke after an internal update to the match expression of the built-in rule it tests.
+* Fixed `TestAccSumologicCSEOutlierRule_Override` that broke after an internal update to the match expression of the built-in rule it tests. The fix adjusts non-overrideable fields in `resource_sumologic_cse_aggregation_rule` and `resource_sumologic_cse_outlier_rule` to be Optional & Computed, which allows those fields to be read from the API instead of asserting a hardcoded value. Any internal updates made to the built-in-rule's non-overrideable fields should no longer break this test, and users won't see a perpetual plan diff when Sumo internally changes a non-overridable field.
 
 DOCS:
 * Fixed documentation for `sumologic_s3_archive_source` to clarify it creates a source for ingesting from an S3 archive bucket (not an Archive Destination). Added a note pointing to the Archive Management UI for creating archive destinations. Fixed incorrect `content_type` value in example usage (`AwsS3Bucket` → `AwsS3ArchiveBucket`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 ## X.Y.Z (Unreleased)
 
-ENHANCEMENTS:
-* Adjusts fields in `resource_sumologic_cse_aggregation_rule` and `resource_sumologic_cse_outlier_rule` that aren't sent as part of the override payload to be Optional & Computed. This allows the override config
-
 BUG FIXES:
 * Fixed `sumologic_source_template` deletion failing with "Enabled source template cannot be deleted" by disabling the template before issuing the delete call.
 * Fixed `TestAccSumologicCSEOutlierRule_Override` that broke after an internal update to the match expression of the built-in rule it tests. The fix adjusts non-overrideable fields in `resource_sumologic_cse_aggregation_rule` and `resource_sumologic_cse_outlier_rule` to be Optional & Computed, which allows those fields to be read from the API instead of asserting a hardcoded value. Any internal updates made to the built-in-rule's non-overrideable fields should no longer break this test, and users won't see a perpetual plan diff when Sumo internally changes a non-overridable field.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,10 @@
 
 BUG FIXES:
 * Fixed `sumologic_source_template` deletion failing with "Enabled source template cannot be deleted" by disabling the template before issuing the delete call.
+* Fixed `TestAccSumologicCSEOutlierRule_Override` that broke after an internal update to the match expression of the built-in rule it tests.
 
 DOCS:
 * Fixed documentation for `sumologic_s3_archive_source` to clarify it creates a source for ingesting from an S3 archive bucket (not an Archive Destination). Added a note pointing to the Archive Management UI for creating archive destinations. Fixed incorrect `content_type` value in example usage (`AwsS3Bucket` → `AwsS3ArchiveBucket`).
-
-BUG FIXES:
-* Fixed `TestAccSumologicCSEOutlierRule_Override` that broke after an internal update to the match expression of the built-in rule it tests.
 
 ## 3.2.8 (May 11, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 DOCS:
 * Fixed documentation for `sumologic_s3_archive_source` to clarify it creates a source for ingesting from an S3 archive bucket (not an Archive Destination). Added a note pointing to the Archive Management UI for creating archive destinations. Fixed incorrect `content_type` value in example usage (`AwsS3Bucket` → `AwsS3ArchiveBucket`).
 
+BUG FIXES:
+* Fixed `TestAccSumologicCSEOutlierRule_Override` that broke after an internal update to the match expression of the built-in rule it tests.
+
 ## 3.2.8 (May 11, 2026)
 
 ENHANCEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 BUG FIXES:
 * Fixed `sumologic_source_template` deletion failing with "Enabled source template cannot be deleted" by disabling the template before issuing the delete call.
-* Fixed `TestAccSumologicCSEOutlierRule_Override` that broke after an internal update to the match expression of the built-in rule it tests. The fix adjusts non-overrideable fields in `resource_sumologic_cse_aggregation_rule` and `resource_sumologic_cse_outlier_rule` to be Optional & Computed, which allows those fields to be read from the API instead of asserting a hardcoded value. Any internal updates made to the built-in-rule's non-overrideable fields should no longer break this test, and users won't see a perpetual plan diff when Sumo internally changes a non-overridable field.
+* Fixes `resource_sumologic_cse_aggregation_rule` and `resource_sumologic_cse_outlier_rule` so that they don't see a perpetual plan diff when Sumo internally updates a non-overridable field. The fix adjusts non-overrideable fields to be Optional & Computed, which allows those fields to be read from the API during an override instead of asserting a hardcoded value. Logic has been added to ensure these fields are still required during a create.
 
 DOCS:
 * Fixed documentation for `sumologic_s3_archive_source` to clarify it creates a source for ingesting from an S3 archive bucket (not an Archive Destination). Added a note pointing to the Archive Management UI for creating archive destinations. Fixed incorrect `content_type` value in example usage (`AwsS3Bucket` → `AwsS3ArchiveBucket`).

--- a/sumologic/resource_sumologic_cse_aggregation_rule.go
+++ b/sumologic/resource_sumologic_cse_aggregation_rule.go
@@ -1,6 +1,8 @@
 package sumologic
 
 import (
+	"context"
+	"fmt"
 	"log"
 	"strings"
 
@@ -16,6 +18,17 @@ func resourceSumologicCSEAggregationRule() *schema.Resource {
 		Update: resourceSumologicCSEAggregationRuleUpdate,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
+		},
+		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+			if d.Id() != "" {
+				return nil
+			}
+			for _, field := range []string{"aggregation_functions", "enabled", "match_expression", "trigger_expression"} {
+				if _, ok := d.GetOk(field); !ok {
+					return fmt.Errorf("%q is required when creating a new aggregation rule", field)
+				}
+			}
+			return nil
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/sumologic/resource_sumologic_cse_aggregation_rule.go
+++ b/sumologic/resource_sumologic_cse_aggregation_rule.go
@@ -21,7 +21,8 @@ func resourceSumologicCSEAggregationRule() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"aggregation_functions": {
 				Type:     schema.TypeList,
-				Required: true,
+				Optional: true,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
@@ -48,7 +49,8 @@ func resourceSumologicCSEAggregationRule() *schema.Resource {
 			},
 			"enabled": {
 				Type:     schema.TypeBool,
-				Required: true,
+				Optional: true,
+				Computed: true,
 			},
 			"entity_selectors": getEntitySelectorsSchema(),
 			"group_by_entity": {
@@ -70,7 +72,8 @@ func resourceSumologicCSEAggregationRule() *schema.Resource {
 			},
 			"match_expression": {
 				Type:             schema.TypeString,
-				Required:         true,
+				Optional:         true,
+				Computed:         true,
 				DiffSuppressFunc: suppressSpaceDiff,
 			},
 			"name": {
@@ -96,7 +99,8 @@ func resourceSumologicCSEAggregationRule() *schema.Resource {
 			},
 			"trigger_expression": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				Computed: true,
 			},
 			"window_size": {
 				Type:     schema.TypeString,

--- a/sumologic/resource_sumologic_cse_aggregation_rule_test.go
+++ b/sumologic/resource_sumologic_cse_aggregation_rule_test.go
@@ -231,14 +231,9 @@ func testOverrideCSEAggregationRuleConfig(descriptionExpression string) string {
 	return fmt.Sprintf(`
 resource "sumologic_cse_aggregation_rule" "sumo_aggregation_rule_test" {
     description_expression = "%s"
-    enabled                = true
     group_by_entity        = true
     group_by_fields        = []
     is_prototype           = true
-    match_expression       = <<-EOT
-        metadata_vendor = "Okta"
-        and metadata_deviceEventId = "user.authentication.sso"
-    EOT
     name                   = "Okta - Session Anomaly (Multiple User Agents)"
     name_expression        = "Okta - Session Anomaly (Multiple User Agents) for user: {{user_username}}"
     summary_expression     = "{{user_username}} has utilized a number of distinct User Agents which has crossed the threshold (4) value within a 30-minute time period to perform Okta authentication."
@@ -246,16 +241,7 @@ resource "sumologic_cse_aggregation_rule" "sumo_aggregation_rule_test" {
         "_mitreAttackTactic:TA0001",
         "_mitreAttackTechnique:T1078.004",
     ]
-    trigger_expression     = "distinct_userAgents > 4"
     window_size            = "T30M"
-
-    aggregation_functions {
-        arguments = [
-            "fields[\"client.userAgent.rawUserAgent\"]",
-        ]
-        function  = "count_distinct"
-        name      = "distinct_userAgents"
-    }
 
     entity_selectors {
         entity_type = "_username"

--- a/sumologic/resource_sumologic_cse_outlier_rule.go
+++ b/sumologic/resource_sumologic_cse_outlier_rule.go
@@ -1,6 +1,8 @@
 package sumologic
 
 import (
+	"context"
+	"fmt"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -15,6 +17,17 @@ func resourceSumologicCSEOutlierRule() *schema.Resource {
 		Update: resourceSumologicCSEOutlierRuleUpdate,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
+		},
+		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+			if d.Id() != "" {
+				return nil
+			}
+			for _, field := range []string{"aggregation_functions", "enabled", "match_expression"} {
+				if _, ok := d.GetOk(field); !ok {
+					return fmt.Errorf("%q is required when creating a new outlier rule", field)
+				}
+			}
+			return nil
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/sumologic/resource_sumologic_cse_outlier_rule.go
+++ b/sumologic/resource_sumologic_cse_outlier_rule.go
@@ -20,7 +20,8 @@ func resourceSumologicCSEOutlierRule() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"aggregation_functions": {
 				Type:     schema.TypeList,
-				Required: true,
+				Optional: true,
+				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -57,7 +58,8 @@ func resourceSumologicCSEOutlierRule() *schema.Resource {
 			},
 			"enabled": {
 				Type:     schema.TypeBool,
-				Required: true,
+				Optional: true,
+				Computed: true,
 			},
 			"entity_selectors": getEntitySelectorsSchema(),
 			"floor_value": {
@@ -78,7 +80,8 @@ func resourceSumologicCSEOutlierRule() *schema.Resource {
 			},
 			"match_expression": {
 				Type:             schema.TypeString,
-				Required:         true,
+				Optional:         true,
+				Computed:         true,
 				DiffSuppressFunc: suppressSpaceDiff,
 			},
 			"name": {

--- a/sumologic/resource_sumologic_cse_outlier_rule_test.go
+++ b/sumologic/resource_sumologic_cse_outlier_rule_test.go
@@ -207,23 +207,11 @@ resource "sumologic_cse_outlier_rule" "sumo_outlier_rule_test" {
     baseline_window_size   = "432000000"
     description_expression = "%s"
     deviation_threshold    = 2
-    enabled                = true
     floor_value            = 1
     group_by_fields        = [
         "user_username",
     ]
     is_prototype           = true
-    match_expression       = <<-EOT
-        metadata_vendor = 'Microsoft'
-        AND metadata_product = 'Windows'
-        AND metadata_deviceEventId = 'Security-4672'
-        AND NOT lower(user_username) = 'system'
-        AND NOT lower(user_username) RLIKE '(\$$)'
-        AND NOT lower(user_username) RLIKE '(dwm\-)'
-        AND NOT lower(user_username) RLIKE '(local service|network service)'
-        AND NOT lower(user_username) RLIKE '(iusr)'
-        AND NOT lower(user_username) LIKE '%%svc%%'
-    EOT
     name                   = "Spike in Windows Administrative Privileges Granted for User"
     name_expression        = "Spike in Windows Administrative Privileges Granted for User: {{user_username}}"
     retention_window_size  = "7776000000"
@@ -234,14 +222,6 @@ resource "sumologic_cse_outlier_rule" "sumo_outlier_rule_test" {
         "_mitreAttackTechnique:T1078.002",
     ]
     window_size            = "T60M"
-
-    aggregation_functions {
-        arguments = [
-            "device_hostname",
-        ]
-        function  = "count_distinct"
-        name      = "current"
-    }
 
     entity_selectors {
         entity_type = "_username"

--- a/sumologic/resource_sumologic_cse_outlier_rule_test.go
+++ b/sumologic/resource_sumologic_cse_outlier_rule_test.go
@@ -217,13 +217,12 @@ resource "sumologic_cse_outlier_rule" "sumo_outlier_rule_test" {
         metadata_vendor = 'Microsoft'
         AND metadata_product = 'Windows'
         AND metadata_deviceEventId = 'Security-4672'
-        AND NOT user_username = 'system'
-        AND NOT user_username RLIKE '(\$$)'
-        AND NOT user_username RLIKE '(dwm\-)'
-        AND NOT user_username RLIKE '(local service|network service)'
-        AND NOT user_username RLIKE '(iusr)'AND NOT (
-            LOWER(user_username) LIKE '%%svc%%'
-        )
+        AND NOT lower(user_username) = 'system'
+        AND NOT lower(user_username) RLIKE '(\$$)'
+        AND NOT lower(user_username) RLIKE '(dwm\-)'
+        AND NOT lower(user_username) RLIKE '(local service|network service)'
+        AND NOT lower(user_username) RLIKE '(iusr)'
+        AND NOT lower(user_username) LIKE '%%svc%%'
     EOT
     name                   = "Spike in Windows Administrative Privileges Granted for User"
     name_expression        = "Spike in Windows Administrative Privileges Granted for User: {{user_username}}"

--- a/sumologic/resource_sumologic_source_template.go
+++ b/sumologic/resource_sumologic_source_template.go
@@ -204,6 +204,14 @@ func resourceSumologicSourceTemplateUpdate(d *schema.ResourceData, meta interfac
 func resourceSumologicSourceTemplateDelete(d *schema.ResourceData, meta interface{}) error {
 	c := meta.(*Client)
 
+	sourceTemplate := resourceToSourceTemplate(d)
+	disabled := false
+	sourceTemplate.IsEnabled = &disabled
+	err := c.UpdateSourceTemplate(sourceTemplate)
+	if err != nil {
+		return err
+	}
+
 	return c.DeleteSourceTemplate(d.Id())
 }
 


### PR DESCRIPTION
### Description

Fixed `TestAccSumologicCSEOutlierRule_Override` that broke after an internal update to the match expression of the built-in rule it tests. The fix adjusts non-overrideable fields in `resource_sumologic_cse_aggregation_rule` and `resource_sumologic_cse_outlier_rule` to be Optional & Computed, which allows those fields to be read from the API instead of asserting a hardcoded value. Any internal updates made to the built-in-rule's non-overrideable fields should no longer break this test, and users won't see a perpetual plan diff when Sumo internally changes a non-overridable field.

Because all fixes preventing CI tests from passing need to be on one PR to get a passing build, this also pulls in the fix from https://github.com/SumoLogic/terraform-provider-sumologic/pull/873. 

### Check list
* [X] Describe the changes and their purpose
* [ ] Update HTML docs (if applicable)
    * [preview tool](https://registry.terraform.io/tools/doc-preview)
* [X] Update [`CHANGELOG.md`](../CHANGELOG.md)
* [X] Check [`CONTRIBUTING.md`](../CONTRIBUTING.md) for anything forgotten
