### PR TITLE
Add .terraform-registry file to verify ownership of SumoLogic namespace -- Required by HashiCorp to process ownership transfer of the SumoLogic namespace on the Terraform Public Registry

### DIFF
--- a/.terraform-registry
+++ b/.terraform-registry
@@ -1,0 +1,3 @@
+Request: Transfer ownership of the SumoLogic namespace to our HCP Terraform organization. We have lost track of the original account that created this namespace and need to reclaim it to continue publishing and maintaining our provider and modules.
+Registry Link: https://registry.terraform.io/namespaces/SumoLogic
+Request by: md.azhar@sumologic.com


### PR DESCRIPTION
### Description

We have lost track of the original account that created the SumoLogic namespace ([registry.terraform.io/namespaces/SumoLogic](http://registry.terraform.io/namespaces/SumoLogic)) and currently have no administrative access to manage it. HashiCorp's Terraform Registry Support team requires this file to be present on the default branch as proof of repository ownership before they can process our namespace ownership transfer request.
This is a non-functional change, it does not affect the provider code, builds, or releases.
https://github.com/hashicorp/terraform-registry-support/issues/new?template=02_change_artifact_ownership.yml
