### PR TITLE
CSIEM-2549:fix items hash to exclude computed id, preventing unnecessary plan diffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
-## 3.2.9 (Jun 30, 2026)
+## X.Y.Z (Unreleased)
+* Fixed `sumologic_cse_match_list` producing a non-empty plan on every apply by excluding the computed `id` from the items set
+  hash.
 
+## 3.2.9 (Jun 30, 2026)
 FEATURES:
 * **New Resource:** `sumologic_lambda_invoke_action` - Invoke AWS Lambda functions for enabling S3 logging and auto-enable operations.
 

--- a/sumologic/resource_sumologic_cse_match_list.go
+++ b/sumologic/resource_sumologic_cse_match_list.go
@@ -1,6 +1,7 @@
 package sumologic
 
 import (
+	"bytes"
 	"fmt"
 	"log"
 	"regexp"
@@ -60,6 +61,7 @@ func resourceSumologicCSEMatchList() *schema.Resource {
 			"items": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				Set:      matchListItemHash,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {
@@ -86,6 +88,15 @@ func resourceSumologicCSEMatchList() *schema.Resource {
 			},
 		},
 	}
+}
+
+func matchListItemHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+	buf.WriteString(m["value"].(string))
+	buf.WriteString(m["description"].(string))
+	buf.WriteString(m["expiration"].(string))
+	return schema.HashString(buf.String())
 }
 
 func resourceSumologicCSEMatchListRead(d *schema.ResourceData, meta interface{}) error {

--- a/sumologic/resource_sumologic_cse_match_list.go
+++ b/sumologic/resource_sumologic_cse_match_list.go
@@ -92,7 +92,11 @@ func resourceSumologicCSEMatchList() *schema.Resource {
 
 func matchListItemHash(v interface{}) int {
 	var buf bytes.Buffer
-	m := v.(map[string]interface{})
+	m, ok := v.((map[string]interface{}))
+	if !ok {
+		log.Printf("[WARN] matchListItemHash: unexpected type %T, expected map[string]interface{}", v)
+		return 0
+	}
 	buf.WriteString(m["value"].(string))
 	buf.WriteString(m["description"].(string))
 	buf.WriteString(m["expiration"].(string))

--- a/sumologic/resource_sumologic_cse_match_list_test.go
+++ b/sumologic/resource_sumologic_cse_match_list_test.go
@@ -148,14 +148,14 @@ func TestAccSumologicSCEMatchList_createAddRemoveItems(t *testing.T) {
 	})
 }
 
-func TestAccSumologicCSEMatchList_idempotent(t *testing.T) {
+func TestAccSumologicSCEMatchList_idempotent(t *testing.T) {
 	SkipCseTest(t)
 
 	var matchList CSEMatchListGet
 	resourceName := "sumologic_cse_match_list.match_list"
 
 	// Create values
-	nName := fmt.Sprintf("terraform_TestAccSumologicCSEMatchList_idempotent_%s", uuid.New())
+	nName := fmt.Sprintf("terraform_TestAccSumologicSCEMatchList_idempotent_%s", uuid.New())
 	nDefaultTtl := 10800
 	nDescription := "Match List Description"
 	nTargetColumn := "SrcIp"

--- a/sumologic/resource_sumologic_cse_match_list_test.go
+++ b/sumologic/resource_sumologic_cse_match_list_test.go
@@ -148,6 +148,46 @@ func TestAccSumologicSCEMatchList_createAddRemoveItems(t *testing.T) {
 	})
 }
 
+func TestAccSumologicCSEMatchList_idempotent(t *testing.T) {
+	SkipCseTest(t)
+
+	var matchList CSEMatchListGet
+	resourceName := "sumologic_cse_match_list.match_list"
+
+	// Create values
+	nName := fmt.Sprintf("terraform_TestAccSumologicCSEMatchList_idempotent_%s", uuid.New())
+	nDefaultTtl := 10800
+	nDescription := "Match List Description"
+	nTargetColumn := "SrcIp"
+	liDescription := "Match List Item Description"
+	liExpiration := "2122-02-27T04:00:00"
+	liValue := "value"
+	liCount := 2
+	config := testCreateCSEMatchListConfig(nDefaultTtl, nDescription, nName, nTargetColumn, liDescription, liExpiration, liValue, liCount)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCSEMatchListDestroy,
+		Steps: []resource.TestStep{
+			// Creates a match list with {liCount} total match list items
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckCSEMatchListExists(resourceName, &matchList),
+					testCheckMatchListValues(&matchList, nDefaultTtl, nDescription, nName, nTargetColumn),
+					testCheckMatchListItemsValuesAndCount(resourceName, liDescription, liExpiration, liValue, liCount),
+				),
+			},
+			// plan with same config again - the plan should not have any changes to apply
+			{
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+
+}
+
 func testAccCSEMatchListDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*Client)
 


### PR DESCRIPTION
### Description
Problem:

Every terraform apply on a sumologic_cse_match_list with items produced a non-empty plan — deleting and re-creating all items even when nothing changed. This caused unnecessary API churn on every apply.

Root Cause:
 The items field uses schema.TypeSet, which hashes each element to detect changes. The default hash included the id field (which is Computed — empty in config, populated in state after API response). This hash mismatch made Terraform think every item was different on every plan.

Fix:

 Added a custom Set hash function (matchListItemHash) that hashes only user-meaningful fields: value, description, and expiration - excluding the computed id. This makes config items and their state counterparts hash identically when unchanged, producing an empty plan.

### Check list
* [ X] Describe the changes and their purpose
* [X ] Update HTML docs (if applicable)
    * [preview tool](https://registry.terraform.io/tools/doc-preview)
* [ X] Update [`CHANGELOG.md`](../CHANGELOG.md)
* [ X] Check [`CONTRIBUTING.md`](../CONTRIBUTING.md) for anything forgotten
