### PR TITLE
CSIEM-2549: use bulk delete API for match list items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ENHANCEMENTS:
 * Added `collapsible_panel` support to `sumologic_dashboard` resource, allowing panels to be grouped into collapsible sections with configurable `collapsed` state and `collapsible_panel_child_keys`.
-* `sumologic_cse_match_list`: use bulk delete API for match list tems instead of individual deletes, batching in groups of 1000.
+* `sumologic_cse_match_list`: use bulk delete API for match list items instead of individual deletes, batching in groups of 1000.
 
 DOCS:
 * Added documentation for `collapsible_panel` block in `sumologic_dashboard` resource, including argument descriptions and example usage.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ENHANCEMENTS:
 * Added `collapsible_panel` support to `sumologic_dashboard` resource, allowing panels to be grouped into collapsible sections with configurable `collapsed` state and `collapsible_panel_child_keys`.
+* `sumologic_cse_match_list`: use bulk delete API for match list tems instead of individual deletes, batching in groups of 1000.
 
 DOCS:
 * Added documentation for `collapsible_panel` block in `sumologic_dashboard` resource, including argument descriptions and example usage.

--- a/sumologic/resource_sumologic_cse_match_list.go
+++ b/sumologic/resource_sumologic_cse_match_list.go
@@ -322,12 +322,10 @@ func resourceSumologicCSEMatchListUpdate(d *schema.ResourceData, meta interface{
 	log.Printf("[DEBUG] Match List update items - to add: %d, to update: %d, to delete: %d", len(addItems), len(updateItems), len(deleteItemIds))
 
 	// Delete old items
-	for _, oldItem := range cseMatchListItemsAll.CSEMatchListItemsAllGetObjects {
-		if contains(deleteItemIds, oldItem.ID) {
-			err = c.DeleteCSEMatchListItem(oldItem.ID)
-			if err != nil {
-				return fmt.Errorf("[ERROR] An error occurred while deleting match list item with id %s, err: %v", oldItem.ID, err)
-			}
+	if len(deleteItemIds) > 0 {
+		err = c.DeleteCSEMatchListItems(deleteItemIds)
+		if err != nil {
+			return fmt.Errorf("[ERROR] An error occurred while deleting match list item with ids %v, err: %v", deleteItemIds, err)
 		}
 	}
 

--- a/sumologic/resource_sumologic_cse_match_list_test.go
+++ b/sumologic/resource_sumologic_cse_match_list_test.go
@@ -201,7 +201,7 @@ func TestSumologicSCEMatchListBulkDeleteSuccess(t *testing.T) {
 	client := newTestClient(response)
 	err := client.SendBulkDeleteCSEMatchListItemsRequest([]string{"id1", "id2"})
 	if err != nil {
-		t.Fatalf("Expected bulk delete to succeed, received: %s", err)
+		t.Fatalf("Expected bulk delete to succeed, received: %v", err)
 	}
 }
 
@@ -215,7 +215,7 @@ func TestSumologicSCEMatchListBulkDeletePartialSuccess(t *testing.T) {
 	client := newTestClient(response)
 	err := client.SendBulkDeleteCSEMatchListItemsRequest([]string{"id1", "id2"})
 	if err == nil {
-		t.Error("Expected bulk delete to fail for id1, but it was successful")
+		t.Fatal("Expected bulk delete to fail for id1, but it was successful")
 	}
 	if !strings.Contains(err.Error(), "id1") {
 		t.Errorf("Expected error to contain 'id1', got: %s", err.Error())

--- a/sumologic/resource_sumologic_cse_match_list_test.go
+++ b/sumologic/resource_sumologic_cse_match_list_test.go
@@ -1,8 +1,11 @@
 package sumologic
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"log"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -186,6 +189,37 @@ func TestAccSumologicSCEMatchList_idempotent(t *testing.T) {
 		},
 	})
 
+}
+
+func TestSumologicSCEMatchListBulkDeleteSuccess(t *testing.T) {
+	responseBody := []byte(`{"data": {"errorResults": []}}`)
+	response := &http.Response{
+		Status:     http.StatusText(200),
+		StatusCode: 200,
+		Body:       io.NopCloser(bytes.NewReader(responseBody)),
+	}
+	client := newTestClient(response)
+	err := client.SendBulkDeleteCSEMatchListItemsRequest([]string{"id1", "id2"})
+	if err != nil {
+		t.Fatalf("Expected bulk delete to succeed, received: %s", err)
+	}
+}
+
+func TestSumologicSCEMatchListBulkDeletePartialSuccess(t *testing.T) {
+	responseBody := []byte(`{"data": {"errorResults": ["id1"]}}`)
+	response := &http.Response{
+		Status:     http.StatusText(200),
+		StatusCode: 200,
+		Body:       io.NopCloser(bytes.NewReader(responseBody)),
+	}
+	client := newTestClient(response)
+	err := client.SendBulkDeleteCSEMatchListItemsRequest([]string{"id1", "id2"})
+	if err == nil {
+		t.Error("Expected bulk delete to fail for id1, but it was successful")
+	}
+	if !strings.Contains(err.Error(), "id1") {
+		t.Errorf("Expected error to contain 'id1', got: %s", err.Error())
+	}
 }
 
 func testAccCSEMatchListDestroy(s *terraform.State) error {

--- a/sumologic/sumologic_cse_match_list_item.go
+++ b/sumologic/sumologic_cse_match_list_item.go
@@ -117,6 +117,31 @@ func (s *Client) DeleteCSEMatchListItem(id string) error {
 	return err
 }
 
+func (s *Client) SendBulkDeleteCSEMatchListItemsRequest(ids []string) error {
+	request := CSEMatchListBulkDeleteRequestPost{
+		IDs: ids,
+	}
+
+	var response CSEMatchListBulkDeleteResponse
+
+	responseBody, err := s.Post("sec/v1/match-list-items/bulk-delete", request)
+	if err != nil {
+		return err
+	}
+
+	err = json.Unmarshal(responseBody, &response)
+
+	if err != nil {
+		return err
+	}
+
+	if len(response.Data.ErrorResults) > 0 {
+		return fmt.Errorf("failed to delete match list items: %v", response.Data.ErrorResults)
+	}
+
+	return nil
+}
+
 func (s *Client) SendCreateCSEMatchListItemsRequest(cseMatchListItemPost []CSEMatchListItemPost, matchListID string) error {
 	request := CSEMatchListItemRequestPost{
 		CSEMatchListItemPost: cseMatchListItemPost,
@@ -136,6 +161,23 @@ func (s *Client) SendCreateCSEMatchListItemsRequest(cseMatchListItemPost []CSEMa
 	}
 
 	return nil
+}
+
+func (s *Client) DeleteCSEMatchListItems(ids []string) error {
+	var start = 0
+	var end = 1000
+
+	//If there are more than 1000 items, batch delete
+	for end < len(ids) {
+		err := s.SendBulkDeleteCSEMatchListItemsRequest(ids[start:end])
+		if err != nil {
+			return err
+		}
+		start += 1000
+		end += 1000
+	}
+
+	return s.SendBulkDeleteCSEMatchListItemsRequest(ids[start:])
 }
 
 func (s *Client) CreateCSEMatchListItems(cseMatchListItemPost []CSEMatchListItemPost, matchListID string) error {
@@ -176,12 +218,22 @@ type CSEMatchListItemRequestPost struct {
 	CSEMatchListItemPost []CSEMatchListItemPost `json:"items"`
 }
 
+type CSEMatchListBulkDeleteRequestPost struct {
+	IDs []string `json:"ids"`
+}
+
 type CSEMatchListItemRequestUpdate struct {
 	CSEMatchListItemUpdate CSEMatchListItemUpdate `json:"fields"`
 }
 
 type CSEMatchListItemResponse struct {
 	CSEMatchListItemGet CSEMatchListItemGet `json:"data"`
+}
+
+type CSEMatchListBulkDeleteResponse struct {
+	Data struct {
+		ErrorResults []string `json:"errorResults"`
+	} `json:"data"`
 }
 
 type CSEMatchListItemsInMatchListResponse struct {

--- a/sumologic/sumologic_cse_match_list_item.go
+++ b/sumologic/sumologic_cse_match_list_item.go
@@ -164,20 +164,22 @@ func (s *Client) SendCreateCSEMatchListItemsRequest(cseMatchListItemPost []CSEMa
 }
 
 func (s *Client) DeleteCSEMatchListItems(ids []string) error {
-	var start = 0
-	var end = 1000
-
+	if len(ids) == 0 {
+		return nil
+	}
 	//If there are more than 1000 items, batch delete
-	for end < len(ids) {
-		err := s.SendBulkDeleteCSEMatchListItemsRequest(ids[start:end])
-		if err != nil {
+	const batchSize = 1000
+	for start := 0; start < len(ids); start += batchSize {
+		end := start + batchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		if err :=
+			s.SendBulkDeleteCSEMatchListItemsRequest(ids[start:end]); err != nil {
 			return err
 		}
-		start += 1000
-		end += 1000
 	}
-
-	return s.SendBulkDeleteCSEMatchListItemsRequest(ids[start:])
+	return nil
 }
 
 func (s *Client) CreateCSEMatchListItems(cseMatchListItemPost []CSEMatchListItemPost, matchListID string) error {


### PR DESCRIPTION
### Description

- Replace individual deletes in match list item with a call to bulk delete API (`POST sec/v1/match-list-items/bulk-delete`), batching in groups of 1000. 
- Added error handling for partial failures (surfaces IDs that failed to delete)
- Added unit tests for bulk delete success and partial success cases

### Check list
* [X ] Describe the changes and their purpose
* [ X] Update HTML docs (if applicable)
    * [preview tool](https://registry.terraform.io/tools/doc-preview)
* [X] Update [`CHANGELOG.md`](../CHANGELOG.md)
* [X] Check [`CONTRIBUTING.md`](../CONTRIBUTING.md) for anything forgotten
