### PR TITLE
multiNotificationSupport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## X.Y.Z (Unreleased)
 
+ENHANCEMENTS:
+* `sumologic_log_search`: Added support for multiple notifications in a schedule via the new `notifications` block. The existing singular `notification` block remains supported for backward compatibility.
+
 ## 3.2.10 (Jul 15, 2026)
 FEATURES:
 * **New Resource:** `sumologic_data_mask_rule` - Manage data mask rules for masking sensitive data in search results at query time using regex patterns.

--- a/sumologic/resource_sumologic_log_search.go
+++ b/sumologic/resource_sumologic_log_search.go
@@ -158,9 +158,18 @@ func resourceSumologicLogSearch() *schema.Resource {
 							Optional: true,
 						},
 						"notification": {
-							Type:     schema.TypeList,
-							Required: true,
-							MaxItems: 1,
+							Type:       schema.TypeList,
+							Optional:   true,
+							MaxItems:   1,
+							AtLeastOneOf: []string{"schedule.0.notification", "schedule.0.notifications"},
+							Elem: &schema.Resource{
+								Schema: getSearchNotificationSchema(),
+							},
+						},
+						"notifications": {
+							Type:       schema.TypeList,
+							Optional:   true,
+							AtLeastOneOf: []string{"schedule.0.notification", "schedule.0.notifications"},
 							Elem: &schema.Resource{
 								Schema: getSearchNotificationSchema(),
 							},
@@ -492,8 +501,17 @@ func getTerraformLogSearchSchedule(schedule *LogSearchSchedule) []map[string]int
 	tfSearchSchedule[0]["parseable_time_range"] =
 		GetTerraformTimeRange(schedule.ParseableTimeRange.(map[string]interface{}))
 
-	tfSearchSchedule[0]["notification"] =
-		getTerraformLogSearchNotification(schedule.Notification.(map[string]interface{}))
+	if schedule.Notifications != nil && len(schedule.Notifications) > 0 {
+		tfNotifications := make([]interface{}, len(schedule.Notifications))
+		for i, n := range schedule.Notifications {
+			notifMap := n.(map[string]interface{})
+			tfNotifications[i] = getTerraformLogSearchNotification(notifMap)[0]
+		}
+		tfSearchSchedule[0]["notifications"] = tfNotifications
+	} else if schedule.Notification != nil {
+		tfSearchSchedule[0]["notification"] =
+			getTerraformLogSearchNotification(schedule.Notification.(map[string]interface{}))
+	}
 
 	if schedule.Threshold != nil {
 		tfSearchSchedule[0]["threshold"] = getTerraformLogSearchNotificationThreshold(schedule.Threshold)
@@ -660,8 +678,24 @@ func resourceToLogSearchSchedule(data interface{}) *LogSearchSchedule {
 		schedule.TimeZone = scheduleObj["time_zone"].(string)
 		schedule.CronExpression = scheduleObj["cron_expression"].(string)
 		schedule.MuteErrorEmails = scheduleObj["mute_error_emails"].(bool)
-		schedule.Notification = resourceToScheduleSearchNotification(scheduleObj["notification"])
 		schedule.ScheduleType = scheduleObj["schedule_type"].(string)
+
+		notifData := scheduleObj["notification"].([]interface{})
+		if len(notifData) > 0 && notifData[0] != nil {
+			schedule.Notification = resourceToScheduleSearchNotification(scheduleObj["notification"])
+		}
+
+		notifsData := scheduleObj["notifications"].([]interface{})
+		if len(notifsData) > 0 {
+			notifications := make([]interface{}, 0, len(notifsData))
+			for _, n := range notifsData {
+				converted := resourceToScheduleSearchNotification([]interface{}{n})
+				if converted != nil {
+					notifications = append(notifications, converted)
+				}
+			}
+			schedule.Notifications = notifications
+		}
 	}
 
 	return &schedule

--- a/sumologic/resource_sumologic_log_search.go
+++ b/sumologic/resource_sumologic_log_search.go
@@ -158,18 +158,20 @@ func resourceSumologicLogSearch() *schema.Resource {
 							Optional: true,
 						},
 						"notification": {
-							Type:       schema.TypeList,
-							Optional:   true,
-							MaxItems:   1,
-							AtLeastOneOf: []string{"schedule.0.notification", "schedule.0.notifications"},
+							Type:         schema.TypeList,
+							Optional:     true,
+							Computed:     true,
+							MaxItems:     1,
+							ExactlyOneOf: []string{"schedule.0.notification", "schedule.0.notifications"},
 							Elem: &schema.Resource{
 								Schema: getSearchNotificationSchema(),
 							},
 						},
 						"notifications": {
-							Type:       schema.TypeList,
-							Optional:   true,
-							AtLeastOneOf: []string{"schedule.0.notification", "schedule.0.notifications"},
+							Type:         schema.TypeList,
+							Optional:     true,
+							Computed:     true,
+							ExactlyOneOf: []string{"schedule.0.notification", "schedule.0.notifications"},
 							Elem: &schema.Resource{
 								Schema: getSearchNotificationSchema(),
 							},
@@ -466,7 +468,7 @@ func setLogSearch(d *schema.ResourceData, logSearch *LogSearch) error {
 	}
 
 	if logSearch.Schedule != nil {
-		searchSchedule := getTerraformLogSearchSchedule(logSearch.Schedule)
+		searchSchedule := getTerraformLogSearchSchedule(logSearch.Schedule, d)
 		if err := d.Set("schedule", searchSchedule); err != nil {
 			return err
 		}
@@ -485,7 +487,7 @@ func getTerraformLogSearchQueryParameter(parameter LogSearchQueryParameter) map[
 	return tfSearchQueryParameter
 }
 
-func getTerraformLogSearchSchedule(schedule *LogSearchSchedule) []map[string]interface{} {
+func getTerraformLogSearchSchedule(schedule *LogSearchSchedule, d *schema.ResourceData) []map[string]interface{} {
 	tfSearchSchedule := []map[string]interface{}{}
 	tfSearchSchedule = append(tfSearchSchedule, make(map[string]interface{}))
 
@@ -501,16 +503,30 @@ func getTerraformLogSearchSchedule(schedule *LogSearchSchedule) []map[string]int
 	tfSearchSchedule[0]["parseable_time_range"] =
 		GetTerraformTimeRange(schedule.ParseableTimeRange.(map[string]interface{}))
 
+	userUsesNotifications := len(d.Get("schedule.0.notifications").([]interface{})) > 0
+	userUsesNotification := len(d.Get("schedule.0.notification").([]interface{})) > 0
+
 	if schedule.Notifications != nil && len(schedule.Notifications) > 0 {
-		tfNotifications := make([]interface{}, len(schedule.Notifications))
-		for i, n := range schedule.Notifications {
-			notifMap := n.(map[string]interface{})
-			tfNotifications[i] = getTerraformLogSearchNotification(notifMap)[0]
+		if userUsesNotification && !userUsesNotifications && len(schedule.Notifications) == 1 {
+			notifMap := schedule.Notifications[0].(map[string]interface{})
+			tfSearchSchedule[0]["notification"] = getTerraformLogSearchNotification(notifMap)
+		} else {
+			tfNotifications := make([]interface{}, len(schedule.Notifications))
+			for i, n := range schedule.Notifications {
+				notifMap := n.(map[string]interface{})
+				tfNotifications[i] = getTerraformLogSearchNotification(notifMap)[0]
+			}
+			tfSearchSchedule[0]["notifications"] = tfNotifications
 		}
-		tfSearchSchedule[0]["notifications"] = tfNotifications
 	} else if schedule.Notification != nil {
-		tfSearchSchedule[0]["notification"] =
-			getTerraformLogSearchNotification(schedule.Notification.(map[string]interface{}))
+		if userUsesNotifications && !userUsesNotification {
+			notifMap := schedule.Notification.(map[string]interface{})
+			tfNotifications := []interface{}{getTerraformLogSearchNotification(notifMap)[0]}
+			tfSearchSchedule[0]["notifications"] = tfNotifications
+		} else {
+			tfSearchSchedule[0]["notification"] =
+				getTerraformLogSearchNotification(schedule.Notification.(map[string]interface{}))
+		}
 	}
 
 	if schedule.Threshold != nil {
@@ -680,12 +696,12 @@ func resourceToLogSearchSchedule(data interface{}) *LogSearchSchedule {
 		schedule.MuteErrorEmails = scheduleObj["mute_error_emails"].(bool)
 		schedule.ScheduleType = scheduleObj["schedule_type"].(string)
 
-		notifData := scheduleObj["notification"].([]interface{})
+		notifData, _ := scheduleObj["notification"].([]interface{})
 		if len(notifData) > 0 && notifData[0] != nil {
 			schedule.Notification = resourceToScheduleSearchNotification(scheduleObj["notification"])
 		}
 
-		notifsData := scheduleObj["notifications"].([]interface{})
+		notifsData, _ := scheduleObj["notifications"].([]interface{})
 		if len(notifsData) > 0 {
 			notifications := make([]interface{}, 0, len(notifsData))
 			for _, n := range notifsData {

--- a/sumologic/resource_sumologic_log_search_test.go
+++ b/sumologic/resource_sumologic_log_search_test.go
@@ -1054,9 +1054,11 @@ func testAccSumologicLogSearchSingularNotification(tfResourceName string, name s
 }
 
 func TestAccSumologicLogSearch_both_notification_fields_errors(t *testing.T) {
+	var logSearch LogSearch
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLogSearchDestroy(logSearch),
 		Steps: []resource.TestStep{
 			{
 				Config: `

--- a/sumologic/resource_sumologic_log_search_test.go
+++ b/sumologic/resource_sumologic_log_search_test.go
@@ -2,6 +2,7 @@ package sumologic
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -10,6 +11,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
+
+func testAccPreCheckMultiNotification(t *testing.T) {
+	if os.Getenv("SUMOLOGIC_MULTI_NOTIFICATION_ENABLED") == "" {
+		t.Skip("Skipping multi-notification test: set SUMOLOGIC_MULTI_NOTIFICATION_ENABLED=true to run")
+	}
+}
 
 func TestAccSumologicLogSearch_basic(t *testing.T) {
 	var logSearch LogSearch
@@ -616,6 +623,7 @@ func testAccSumologicUpdatedLogSearch(tfResourceName string, name string, descri
 }
 
 func TestAccSumologicLogSearch_multi_notification(t *testing.T) {
+	testAccPreCheckMultiNotification(t)
 	var logSearch LogSearch
 	name := "TF Multi Notification Search Test"
 	description := "TF Multi Notification Search Test Description"
@@ -747,6 +755,7 @@ func testAccSumologicLogSearchMultiNotification(tfResourceName string, name stri
 }
 
 func TestAccSumologicLogSearch_multi_notification_email_and_webhook(t *testing.T) {
+	testAccPreCheckMultiNotification(t)
 	var logSearch LogSearch
 	name := "TF Multi Notif Email+Webhook Test"
 	description := "TF Multi Notification with Email and Webhook"
@@ -1124,6 +1133,7 @@ func TestAccSumologicLogSearch_both_notification_fields_errors(t *testing.T) {
 }
 
 func TestAccSumologicLogSearch_single_notification_in_notifications_array(t *testing.T) {
+	testAccPreCheckMultiNotification(t)
 	var logSearch LogSearch
 	name := "TF Single Notif In Array"
 	description := "Single notification using the notifications (plural) field"

--- a/sumologic/resource_sumologic_log_search_test.go
+++ b/sumologic/resource_sumologic_log_search_test.go
@@ -2,6 +2,7 @@ package sumologic
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -715,6 +716,497 @@ func testAccSumologicLogSearchMultiNotification(tfResourceName string, name stri
 					subject_template = "Alert 2: {{TriggerCondition}} for {{SearchName}}"
 					to_list = [
 						"tf_multi_notif_2@sumologic.com",
+					]
+				}
+			}
+			parameter {
+				name = "timeslice"
+				value = "15m"
+			}
+			parseable_time_range {
+				begin_bounded_time_range {
+					from {
+						relative_time_range {
+							relative_time = "-15m"
+						}
+					}
+				}
+			}
+			schedule_type = "Custom"
+			threshold {
+				count = 10
+				operator = "gt"
+				threshold_type = "group"
+			}
+			time_zone = "America/Los_Angeles"
+		}
+	}
+	`, tfResourceName, name, description, queryString, parsingMode, runByReceiptTime,
+		queryParameter.Name, queryParameter.Description, queryParameter.DataType, queryParameter.Value,
+		literalRangeName)
+}
+
+func TestAccSumologicLogSearch_multi_notification_email_and_webhook(t *testing.T) {
+	var logSearch LogSearch
+	name := "TF Multi Notif Email+Webhook Test"
+	description := "TF Multi Notification with Email and Webhook"
+	queryString := "error | timeslice {{timeslice}} | count by _timeslice"
+	parsingMode := "Manual"
+	literalRangeName := "today"
+	runByReceiptTime := false
+
+	queryParameter := LogSearchQueryParameter{
+		Name:        "timeslice",
+		Description: "timeslice query param",
+		DataType:    "ANY",
+		Value:       "1d",
+	}
+
+	tfResourceName := "tf_multi_notif_email_webhook_test"
+	tfSearchResource := fmt.Sprintf("sumologic_log_search.%s", tfResourceName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLogSearchDestroy(logSearch),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSumologicLogSearchMultiNotificationEmailAndWebhook(tfResourceName, name,
+					description, queryString, parsingMode, runByReceiptTime, queryParameter, literalRangeName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLogSearchExists(tfSearchResource, &logSearch, t),
+					testAccCheckLogSearchMultiNotifEmailAndWebhook(tfSearchResource, &logSearch, t),
+					resource.TestCheckResourceAttr(tfSearchResource, "name", name),
+					resource.TestCheckResourceAttr(tfSearchResource, "schedule.0.notifications.#", "2"),
+					resource.TestCheckResourceAttr(tfSearchResource,
+						"schedule.0.notifications.0.email_search_notification.0.to_list.0",
+						"tf_multi_notif_email_webhook@sumologic.com"),
+					resource.TestCheckResourceAttr(tfSearchResource,
+						"schedule.0.notifications.1.webhook_search_notification.#", "1"),
+				),
+			},
+			{
+				ResourceName:      tfSearchResource,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckLogSearchMultiNotifEmailAndWebhook(name string, logSearch *LogSearch, t *testing.T) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("LogSearch not found: %s", name)
+		}
+
+		id := rs.Primary.ID
+		client := testAccProvider.Meta().(*Client)
+		fetchedLogSearch, err := client.GetLogSearch(id)
+		if err != nil {
+			return fmt.Errorf("Error fetching LogSearch %s via API: %v", id, err)
+		}
+
+		if fetchedLogSearch.Schedule == nil {
+			return fmt.Errorf("LogSearch %s has no schedule", id)
+		}
+
+		notifications := fetchedLogSearch.Schedule.Notifications
+		if notifications == nil || len(notifications) == 0 {
+			return fmt.Errorf("API response missing 'notifications' field for LogSearch %s", id)
+		}
+
+		if len(notifications) != 2 {
+			return fmt.Errorf("Expected 2 notifications in API response, got %d", len(notifications))
+		}
+
+		foundEmail := false
+		foundWebhook := false
+		for _, n := range notifications {
+			notifMap, ok := n.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			taskType, _ := notifMap["taskType"].(string)
+			if taskType == "EmailSearchNotificationSyncDefinition" {
+				foundEmail = true
+			}
+			if taskType == "WebhookSearchNotificationSyncDefinition" {
+				foundWebhook = true
+			}
+		}
+
+		if !foundEmail {
+			return fmt.Errorf("API response notifications missing Email notification for LogSearch %s", id)
+		}
+		if !foundWebhook {
+			return fmt.Errorf("API response notifications missing Webhook notification for LogSearch %s", id)
+		}
+
+		t.Logf("API verification passed: LogSearch %s has 2 notifications (Email + Webhook)", id)
+		return nil
+	}
+}
+
+func testAccSumologicLogSearchMultiNotificationEmailAndWebhook(tfResourceName string, name string,
+	description string, queryString string, parsingMode string, runByReceiptTime bool,
+	queryParameter LogSearchQueryParameter, literalRangeName string) string {
+
+	return fmt.Sprintf(`
+	data "sumologic_personal_folder" "personalFolder" {}
+
+	resource "sumologic_connection" "tf_test_webhook" {
+		name        = "TF Test Webhook for Multi Notif"
+		type        = "WebhookConnection"
+		description = "Webhook connection for multi-notification test"
+		url         = "https://example.com"
+		webhook_type = "Webhook"
+		default_payload = <<JSON
+{"eventType": "{{Name}}"}
+JSON
+	}
+
+	resource "sumologic_log_search" "%s" {
+		name = "%s"
+		description = "%s"
+		query_string = "%s"
+		parsing_mode = "%s"
+		parent_id = data.sumologic_personal_folder.personalFolder.id
+		run_by_receipt_time = %t
+		query_parameter {
+			name = "%s"
+			description = "%s"
+			data_type = "%s"
+			value = "%s"
+		}
+		time_range {
+			begin_bounded_time_range {
+				from {
+					literal_time_range {
+						range_name = "%s"
+					}
+				}
+			}
+		}
+		schedule {
+			cron_expression = "0 0 6 ? * 3 *"
+			mute_error_emails = false
+			notifications {
+				email_search_notification {
+					include_csv_attachment = false
+					include_histogram = true
+					include_query = true
+					include_result_set = true
+					subject_template = "Alert: {{TriggerCondition}} for {{SearchName}}"
+					to_list = [
+						"tf_multi_notif_email_webhook@sumologic.com",
+					]
+				}
+			}
+			notifications {
+				webhook_search_notification {
+					webhook_id = sumologic_connection.tf_test_webhook.id
+					payload    = "{\"alertName\": \"{{SearchName}}\"}"
+				}
+			}
+			parameter {
+				name = "timeslice"
+				value = "15m"
+			}
+			parseable_time_range {
+				begin_bounded_time_range {
+					from {
+						relative_time_range {
+							relative_time = "-15m"
+						}
+					}
+				}
+			}
+			schedule_type = "Custom"
+			threshold {
+				count = 10
+				operator = "gt"
+				threshold_type = "group"
+			}
+			time_zone = "America/Los_Angeles"
+		}
+	}
+	`, tfResourceName, name, description, queryString, parsingMode, runByReceiptTime,
+		queryParameter.Name, queryParameter.Description, queryParameter.DataType, queryParameter.Value,
+		literalRangeName)
+}
+
+func TestAccSumologicLogSearch_singular_notification_backward_compat(t *testing.T) {
+	var logSearch LogSearch
+	name := "TF Singular Notification Backward Compat"
+	description := "Verifies singular notification still works"
+	queryString := "error | timeslice {{timeslice}} | count by _timeslice"
+	parsingMode := "Manual"
+	literalRangeName := "today"
+	runByReceiptTime := false
+
+	queryParameter := LogSearchQueryParameter{
+		Name:        "timeslice",
+		Description: "timeslice query param",
+		DataType:    "ANY",
+		Value:       "1d",
+	}
+
+	tfResourceName := "tf_singular_notif_compat_test"
+	tfSearchResource := fmt.Sprintf("sumologic_log_search.%s", tfResourceName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLogSearchDestroy(logSearch),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSumologicLogSearchSingularNotification(tfResourceName, name, description,
+					queryString, parsingMode, runByReceiptTime, queryParameter, literalRangeName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLogSearchExists(tfSearchResource, &logSearch, t),
+					resource.TestCheckResourceAttr(tfSearchResource, "name", name),
+					resource.TestCheckResourceAttr(tfSearchResource, "schedule.0.notification.#", "1"),
+					resource.TestCheckResourceAttr(tfSearchResource,
+						"schedule.0.notification.0.email_search_notification.0.to_list.0",
+						"tf_singular_compat@sumologic.com"),
+				),
+			},
+			{
+				ResourceName:      tfSearchResource,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccSumologicLogSearchSingularNotification(tfResourceName string, name string, description string,
+	queryString string, parsingMode string, runByReceiptTime bool, queryParameter LogSearchQueryParameter,
+	literalRangeName string) string {
+
+	return fmt.Sprintf(`
+	data "sumologic_personal_folder" "personalFolder" {}
+
+	resource "sumologic_log_search" "%s" {
+		name = "%s"
+		description = "%s"
+		query_string = "%s"
+		parsing_mode = "%s"
+		parent_id = data.sumologic_personal_folder.personalFolder.id
+		run_by_receipt_time = %t
+		query_parameter {
+			name = "%s"
+			description = "%s"
+			data_type = "%s"
+			value = "%s"
+		}
+		time_range {
+			begin_bounded_time_range {
+				from {
+					literal_time_range {
+						range_name = "%s"
+					}
+				}
+			}
+		}
+		schedule {
+			cron_expression = "0 0 6 ? * 3 *"
+			mute_error_emails = false
+			notification {
+				email_search_notification {
+					include_csv_attachment = false
+					include_histogram = true
+					include_query = true
+					include_result_set = true
+					subject_template = "Alert: {{TriggerCondition}} for {{SearchName}}"
+					to_list = [
+						"tf_singular_compat@sumologic.com",
+					]
+				}
+			}
+			parameter {
+				name = "timeslice"
+				value = "15m"
+			}
+			parseable_time_range {
+				begin_bounded_time_range {
+					from {
+						relative_time_range {
+							relative_time = "-15m"
+						}
+					}
+				}
+			}
+			schedule_type = "Custom"
+			threshold {
+				count = 10
+				operator = "gt"
+				threshold_type = "group"
+			}
+			time_zone = "America/Los_Angeles"
+		}
+	}
+	`, tfResourceName, name, description, queryString, parsingMode, runByReceiptTime,
+		queryParameter.Name, queryParameter.Description, queryParameter.DataType, queryParameter.Value,
+		literalRangeName)
+}
+
+func TestAccSumologicLogSearch_both_notification_fields_errors(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+				data "sumologic_personal_folder" "personalFolder" {}
+
+				resource "sumologic_log_search" "tf_both_notif_test" {
+					name = "TF Both Notif Error Test"
+					description = "Should fail validation"
+					query_string = "error"
+					parsing_mode = "Manual"
+					parent_id = data.sumologic_personal_folder.personalFolder.id
+					run_by_receipt_time = false
+					time_range {
+						begin_bounded_time_range {
+							from {
+								relative_time_range {
+									relative_time = "-15m"
+								}
+							}
+						}
+					}
+					schedule {
+						cron_expression = "0 0 6 ? * 3 *"
+						mute_error_emails = false
+						notification {
+							email_search_notification {
+								include_csv_attachment = false
+								include_histogram = true
+								include_query = true
+								include_result_set = true
+								subject_template = "Alert"
+								to_list = ["a@sumologic.com"]
+							}
+						}
+						notifications {
+							email_search_notification {
+								include_csv_attachment = false
+								include_histogram = true
+								include_query = true
+								include_result_set = true
+								subject_template = "Alert"
+								to_list = ["b@sumologic.com"]
+							}
+						}
+						parseable_time_range {
+							begin_bounded_time_range {
+								from {
+									relative_time_range {
+										relative_time = "-15m"
+									}
+								}
+							}
+						}
+						schedule_type = "Custom"
+						time_zone = "America/Los_Angeles"
+					}
+				}
+				`,
+				ExpectError: regexp.MustCompile(`"schedule.0.notification": only one of`),
+			},
+		},
+	})
+}
+
+func TestAccSumologicLogSearch_single_notification_in_notifications_array(t *testing.T) {
+	var logSearch LogSearch
+	name := "TF Single Notif In Array"
+	description := "Single notification using the notifications (plural) field"
+	queryString := "error | timeslice {{timeslice}} | count by _timeslice"
+	parsingMode := "Manual"
+	literalRangeName := "today"
+	runByReceiptTime := false
+
+	queryParameter := LogSearchQueryParameter{
+		Name:        "timeslice",
+		Description: "timeslice query param",
+		DataType:    "ANY",
+		Value:       "1d",
+	}
+
+	tfResourceName := "tf_single_in_array_test"
+	tfSearchResource := fmt.Sprintf("sumologic_log_search.%s", tfResourceName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLogSearchDestroy(logSearch),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSumologicLogSearchSingleNotifInArray(tfResourceName, name, description,
+					queryString, parsingMode, runByReceiptTime, queryParameter, literalRangeName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLogSearchExists(tfSearchResource, &logSearch, t),
+					resource.TestCheckResourceAttr(tfSearchResource, "name", name),
+					resource.TestCheckResourceAttr(tfSearchResource, "schedule.0.notifications.#", "1"),
+					resource.TestCheckResourceAttr(tfSearchResource,
+						"schedule.0.notifications.0.email_search_notification.0.to_list.0",
+						"tf_single_in_array@sumologic.com"),
+				),
+			},
+			{
+				ResourceName:      tfSearchResource,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccSumologicLogSearchSingleNotifInArray(tfResourceName string, name string, description string,
+	queryString string, parsingMode string, runByReceiptTime bool, queryParameter LogSearchQueryParameter,
+	literalRangeName string) string {
+
+	return fmt.Sprintf(`
+	data "sumologic_personal_folder" "personalFolder" {}
+
+	resource "sumologic_log_search" "%s" {
+		name = "%s"
+		description = "%s"
+		query_string = "%s"
+		parsing_mode = "%s"
+		parent_id = data.sumologic_personal_folder.personalFolder.id
+		run_by_receipt_time = %t
+		query_parameter {
+			name = "%s"
+			description = "%s"
+			data_type = "%s"
+			value = "%s"
+		}
+		time_range {
+			begin_bounded_time_range {
+				from {
+					literal_time_range {
+						range_name = "%s"
+					}
+				}
+			}
+		}
+		schedule {
+			cron_expression = "0 0 6 ? * 3 *"
+			mute_error_emails = false
+			notifications {
+				email_search_notification {
+					include_csv_attachment = false
+					include_histogram = true
+					include_query = true
+					include_result_set = true
+					subject_template = "Alert: {{TriggerCondition}} for {{SearchName}}"
+					to_list = [
+						"tf_single_in_array@sumologic.com",
 					]
 				}
 			}

--- a/sumologic/resource_sumologic_log_search_test.go
+++ b/sumologic/resource_sumologic_log_search_test.go
@@ -614,6 +614,137 @@ func testAccSumologicUpdatedLogSearch(tfResourceName string, name string, descri
 		literalRangeName, tfSchedule)
 }
 
+func TestAccSumologicLogSearch_multi_notification(t *testing.T) {
+	var logSearch LogSearch
+	name := "TF Multi Notification Search Test"
+	description := "TF Multi Notification Search Test Description"
+	queryString := "error | timeslice {{timeslice}} | count by _timeslice"
+	parsingMode := "Manual"
+	literalRangeName := "today"
+	runByReceiptTime := false
+
+	queryParameter := LogSearchQueryParameter{
+		Name:        "timeslice",
+		Description: "timeslice query param",
+		DataType:    "ANY",
+		Value:       "1d",
+	}
+
+	tfResourceName := "tf_multi_notif_test"
+	tfSearchResource := fmt.Sprintf("sumologic_log_search.%s", tfResourceName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLogSearchDestroy(logSearch),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSumologicLogSearchMultiNotification(tfResourceName, name, description,
+					queryString, parsingMode, runByReceiptTime, queryParameter, literalRangeName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLogSearchExists(tfSearchResource, &logSearch, t),
+					resource.TestCheckResourceAttr(tfSearchResource, "name", name),
+					resource.TestCheckResourceAttr(tfSearchResource, "schedule.0.notifications.#", "2"),
+					resource.TestCheckResourceAttr(tfSearchResource,
+						"schedule.0.notifications.0.email_search_notification.0.to_list.0",
+						"tf_multi_notif_1@sumologic.com"),
+					resource.TestCheckResourceAttr(tfSearchResource,
+						"schedule.0.notifications.1.email_search_notification.0.to_list.0",
+						"tf_multi_notif_2@sumologic.com"),
+				),
+			},
+			{
+				ResourceName:      tfSearchResource,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccSumologicLogSearchMultiNotification(tfResourceName string, name string, description string,
+	queryString string, parsingMode string, runByReceiptTime bool, queryParameter LogSearchQueryParameter,
+	literalRangeName string) string {
+
+	return fmt.Sprintf(`
+	data "sumologic_personal_folder" "personalFolder" {}
+
+	resource "sumologic_log_search" "%s" {
+		name = "%s"
+		description = "%s"
+		query_string = "%s"
+		parsing_mode = "%s"
+		parent_id = data.sumologic_personal_folder.personalFolder.id
+		run_by_receipt_time = %t
+		query_parameter {
+			name = "%s"
+			description = "%s"
+			data_type = "%s"
+			value = "%s"
+		}
+		time_range {
+			begin_bounded_time_range {
+				from {
+					literal_time_range {
+						range_name = "%s"
+					}
+				}
+			}
+		}
+		schedule {
+			cron_expression = "0 0 6 ? * 3 *"
+			mute_error_emails = false
+			notifications {
+				email_search_notification {
+					include_csv_attachment = false
+					include_histogram = true
+					include_query = true
+					include_result_set = true
+					subject_template = "Alert 1: {{TriggerCondition}} for {{SearchName}}"
+					to_list = [
+						"tf_multi_notif_1@sumologic.com",
+					]
+				}
+			}
+			notifications {
+				email_search_notification {
+					include_csv_attachment = false
+					include_histogram = false
+					include_query = false
+					include_result_set = true
+					subject_template = "Alert 2: {{TriggerCondition}} for {{SearchName}}"
+					to_list = [
+						"tf_multi_notif_2@sumologic.com",
+					]
+				}
+			}
+			parameter {
+				name = "timeslice"
+				value = "15m"
+			}
+			parseable_time_range {
+				begin_bounded_time_range {
+					from {
+						relative_time_range {
+							relative_time = "-15m"
+						}
+					}
+				}
+			}
+			schedule_type = "Custom"
+			threshold {
+				count = 10
+				operator = "gt"
+				threshold_type = "group"
+			}
+			time_zone = "America/Los_Angeles"
+		}
+	}
+	`, tfResourceName, name, description, queryString, parsingMode, runByReceiptTime,
+		queryParameter.Name, queryParameter.Description, queryParameter.DataType, queryParameter.Value,
+		literalRangeName)
+}
+
 func TestAccSumologicLogSearch_intervalTimeType(t *testing.T) {
 	var logSearch LogSearch
 	name := "TF IntervalTimeType Test"

--- a/sumologic/resource_sumologic_permissions_test.go
+++ b/sumologic/resource_sumologic_permissions_test.go
@@ -4,12 +4,15 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccPermission_create(t *testing.T) {
 	var response PermissionsResponse
+	suffix := acctest.RandString(8)
+	otherResource := getOtherResource(suffix)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -35,6 +38,8 @@ func TestAccPermission_create(t *testing.T) {
 
 func TestAccPermission_update(t *testing.T) {
 	var response PermissionsResponse
+	suffix := acctest.RandString(8)
+	otherResource := getOtherResource(suffix)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -70,6 +75,8 @@ func TestAccPermission_update(t *testing.T) {
 
 func TestAccPermission_delete(t *testing.T) {
 	var response PermissionsResponse
+	suffix := acctest.RandString(8)
+	otherResource := getOtherResource(suffix)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -88,7 +95,7 @@ func TestAccPermission_delete(t *testing.T) {
 						"sumologic_content_permission.content_permission_test", "notification_message", "create"),
 				),
 			}, {
-				Config: testAccSumologicPermissionDelete(),
+				Config: testAccSumologicPermissionDelete(suffix),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPermissionDelete("sumologic_content.permission_test_content"),
 				),
@@ -229,33 +236,35 @@ func testAccSumologicPermissionUpdate(resource string, notify_recipient bool,
 	)
 }
 
-func testAccSumologicPermissionDelete() string {
-	return otherResource
+func testAccSumologicPermissionDelete(suffix string) string {
+	return getOtherResource(suffix)
 }
 
-var otherResource = `
+func getOtherResource(suffix string) string {
+	return fmt.Sprintf(`
 	data "sumologic_personal_folder" "personalFolder" {}
 
 	resource "sumologic_content" "permission_test_content" {
 		parent_id = data.sumologic_personal_folder.personalFolder.id
 		config = jsonencode({
 			"type": "FolderSyncDefinition",
-			"name": "test_permission_resource_folder",
+			"name": "test_permission_resource_folder_%s",
 			"description": "",
 			"children": []
 		})
 	}
 
 	resource "sumologic_role" "permission_test_role" {
-		name        = "permission_test_role"
+		name        = "permission_test_role_%s"
 		description = "Testing content permission resource"
 	}
 
 	resource "sumologic_user" "permission_test_user" {
 		first_name   = "test"
 		last_name    = "permission"
-		email        = "testpermission@gmail.com"
+		email        = "testpermission_%s@gmail.com"
 		is_active    = true
 		role_ids     = [sumologic_role.permission_test_role.id]
 		transfer_to  = ""
-	}`
+	}`, suffix, suffix, suffix)
+}

--- a/sumologic/sumologic_log_search.go
+++ b/sumologic/sumologic_log_search.go
@@ -105,7 +105,8 @@ type LogSearchSchedule struct {
 	Threshold          *SearchNotificationThreshold `json:"threshold,omitempty"`
 	Parameters         []ScheduleSearchParameter    `json:"parameters,omitempty"`
 	MuteErrorEmails    bool                         `json:"muteErrorEmails"`
-	Notification       interface{}                  `json:"notification"`
+	Notification       interface{}                  `json:"notification,omitempty"`
+	Notifications      []interface{}                `json:"notifications,omitempty"`
 	ScheduleType       string                       `json:"scheduleType"`
 }
 

--- a/website/docs/r/log_search.html.markdown
+++ b/website/docs/r/log_search.html.markdown
@@ -94,6 +94,71 @@ resource "sumologic_log_search" "example_log_search" {
 }
 ```
 
+## Example Usage - Multiple Notifications
+```hcl
+data "sumologic_personal_folder" "personalFolder" {}
+
+resource "sumologic_log_search" "example_multi_notif" {
+    name = "Multi Notification Search"
+    description = "Search with multiple notifications"
+    parent_id = data.sumologic_personal_folder.personalFolder.id
+    query_string = "_sourceCategory=api | count by _sourceHost"
+    parsing_mode = "Manual"
+    run_by_receipt_time = false
+
+    time_range {
+        begin_bounded_time_range {
+            from {
+                relative_time_range {
+                    relative_time = "-30m"
+                }
+            }
+        }
+    }
+
+    schedule {
+        cron_expression = "0 0 * * * ? *"
+        mute_error_emails = false
+        notifications {
+            email_search_notification {
+                include_csv_attachment = false
+                include_histogram = false
+                include_query = true
+                include_result_set = true
+                subject_template = "Alert: {{TriggerCondition}} found for {{SearchName}}"
+                to_list = ["team-a@acme.com"]
+            }
+        }
+        notifications {
+            email_search_notification {
+                include_csv_attachment = true
+                include_histogram = true
+                include_query = true
+                include_result_set = true
+                subject_template = "Alert: {{TriggerCondition}} found for {{SearchName}}"
+                to_list = ["team-b@acme.com"]
+            }
+        }
+        parseable_time_range {
+            begin_bounded_time_range {
+                from {
+                    relative_time_range {
+                        relative_time = "-15m"
+                    }
+                }
+            }
+        }
+        schedule_type = "1Hour"
+        threshold {
+            count = 10
+            operator = "gt"
+            threshold_type = "group"
+        }
+        time_zone = "America/Los_Angeles"
+    }
+}
+```
+
 ## Argument reference
 
 The following arguments are supported:
@@ -147,8 +212,11 @@ The following arguments are supported:
     abbreviations is for JDK 1.1.x compatibility only and full names should be used.
 - `threshold` - (Block List, Max: 1, Optional) Threshold for when to send notification. See
     [threshold schema](#schema-threshold)
-- `notification` - (Block List, Max: 1, Required) Notification of the log search. See
-    [notification schema](#schema-for-notification)
+- `notification` - (Block List, Max: 1, Optional) Single notification for the log search. Exactly one of
+    `notification` or `notifications` must be specified. See [notification schema](#schema-for-notification)
+- `notifications` - (Block List, Optional) Multiple notifications for the log search. Each block defines one
+    notification. Exactly one of `notification` or `notifications` must be specified. See
+    [notification schema](#schema-for-notification) for the schema of each block.
 - `mute_error_emails` - (Optional) If enabled, emails are not sent out in case of errors with the search.
 - `parameters` - (Block List, Optional) A list of scheduled search parameters. See
     [parameter schema](#schema-for-parameter)


### PR DESCRIPTION
## Description

Adds support for **multiple notifications** in a Log Search schedule. Previously, only a single `notification` block was allowed per schedule. This PR introduces a new `notifications` (plural) block that accepts a list of notification configurations.

### Changes
- Added `notifications` field to the `LogSearchSchedule` model and Terraform schema
- Made `notification` and `notifications` mutually exclusive via `ExactlyOneOf`
- Added `Computed: true` to both fields to prevent state drift
- Read path intelligently maps API response to whichever field the user configured
- Safe type assertions to prevent panics on nil values

### Migration Path for Existing Users

**No breaking changes.** Existing configurations using the singular `notification` block continue to work without modification.

To adopt multiple notifications, replace:

```hcl
schedule {
  notification {
    email_search_notification { ... }
  }
}
```

With:

```hcl
schedule {
  notifications {
    email_search_notification { ... }
  }
  notifications {
    webhook_search_notification { ... }
  }
}
```

> **Note:** You cannot use both `notification` and `notifications` in the same schedule block. Terraform will reject the config at plan time.

### API Dependency

This feature requires the Sumo Logic `v1/logSearches` API to accept and return the `notifications` (plural) field in the schedule object.

## Check list
* [x] Describe the changes and their purpose
* [x] Update HTML docs (if applicable)
* [x] Update [`CHANGELOG.md`](../CHANGELOG.md)
* [x] Check [`CONTRIBUTING.md`](../CONTRIBUTING.md) for anything forgotten