### PR TITLE
CSIEM-2549: fix perpetual diffs from nil expiration and case-sensitive values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## X.Y.Z (Unreleased)
+BUG FIXES:
+* Updated `sumologic_cse_match_list` to handle cases where case differences in values and empty expirations resulted in plan diffs with no functional changes. These will no longer result in a plan diff.
 
 ## 3.2.10 (Jul 15, 2026)
 FEATURES:

--- a/sumologic/resource_sumologic_cse_match_list.go
+++ b/sumologic/resource_sumologic_cse_match_list.go
@@ -266,7 +266,7 @@ func resourceToCSEMatchListItem(data interface{}) CSEMatchListItemPost {
 		item.ID = itemObj["id"].(string)
 		item.Description = itemObj["description"].(string)
 		item.Active = true
-		item.Expiration = itemObj["expiration"].(string)
+		item.Expiration, _ = itemObj["expiration"].(string)
 		item.Value = itemObj["value"].(string)
 	}
 	return item

--- a/sumologic/resource_sumologic_cse_match_list.go
+++ b/sumologic/resource_sumologic_cse_match_list.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -77,11 +78,17 @@ func resourceSumologicCSEMatchList() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 							ForceNew: false,
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								return old == "" && new == ""
+							},
 						},
 						"value": {
 							Type:     schema.TypeString,
 							Required: true,
 							ForceNew: false,
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								return strings.EqualFold(old, new)
+							},
 						},
 					},
 				},
@@ -97,9 +104,10 @@ func matchListItemHash(v interface{}) int {
 		log.Printf("[WARN] matchListItemHash: unexpected type %T, expected map[string]interface{}", v)
 		return 0
 	}
-	buf.WriteString(m["value"].(string))
+	buf.WriteString(strings.ToLower(m["value"].(string)))
 	buf.WriteString(m["description"].(string))
-	buf.WriteString(m["expiration"].(string))
+	expiration, _ := m["expiration"].(string)
+	buf.WriteString(expiration)
 	return schema.HashString(buf.String())
 }
 
@@ -375,7 +383,7 @@ func matches(oldItem CSEMatchListItemGet, newItem CSEMatchListItemPost) bool {
 	return oldItem.ID == newItem.ID &&
 		oldItem.Expiration == newItem.Expiration &&
 		oldItem.Active == newItem.Active &&
-		oldItem.Value == newItem.Value &&
+		strings.EqualFold(oldItem.Value, newItem.Value) &&
 		oldItem.Meta.Description == newItem.Description
 }
 

--- a/sumologic/resource_sumologic_cse_match_list_test.go
+++ b/sumologic/resource_sumologic_cse_match_list_test.go
@@ -191,6 +191,86 @@ func TestAccSumologicSCEMatchList_idempotent(t *testing.T) {
 
 }
 
+func TestMatchListItemHash_CaseInsensitive(t *testing.T) {
+	item1 := map[string]interface{}{
+		"id":          "",
+		"value":       "Test Value",
+		"description": "desc",
+		"expiration":  "2122-02-27T04:00:00",
+	}
+	item2 := map[string]interface{}{
+		"id":          "some-id",
+		"value":       "test value",
+		"description": "desc",
+		"expiration":  "2122-02-27T04:00:00",
+	}
+	hash1 := matchListItemHash(item1)
+	hash2 := matchListItemHash(item2)
+	if hash1 != hash2 {
+		t.Errorf("Expected case-different values to hash equally, got %d != %d", hash1, hash2)
+	}
+}
+
+func TestMatchListItemHash_NilExpiration(t *testing.T) {
+	itemWithNilExpiration := map[string]interface{}{
+		"id":          "",
+		"value":       "test",
+		"description": "desc",
+		"expiration":  nil,
+	}
+	itemWithEmptyExpiration := map[string]interface{}{
+		"id":          "some-id",
+		"value":       "test",
+		"description": "desc",
+		"expiration":  "",
+	}
+	hash1 := matchListItemHash(itemWithNilExpiration)
+	hash2 := matchListItemHash(itemWithEmptyExpiration)
+	if hash1 != hash2 {
+		t.Errorf("Expected nil and empty expiration to hash equally, got %d != %d", hash1, hash2)
+	}
+}
+
+func TestMatchListItemHash_ExcludesId(t *testing.T) {
+	itemNoId := map[string]interface{}{
+		"id":          "",
+		"value":       "192.168.1.1",
+		"description": "test host",
+		"expiration":  "2122-02-27T04:00:00",
+	}
+	itemWithId := map[string]interface{}{
+		"id":          "abc-123-def",
+		"value":       "192.168.1.1",
+		"description": "test host",
+		"expiration":  "2122-02-27T04:00:00",
+	}
+	hash1 := matchListItemHash(itemNoId)
+	hash2 := matchListItemHash(itemWithId)
+	if hash1 != hash2 {
+		t.Errorf("Expected items with different ids to hash equally, got %d != %d", hash1, hash2)
+	}
+}
+
+func TestMatches_CaseInsensitiveValue(t *testing.T) {
+	oldItem := CSEMatchListItemGet{
+		ID:         "item-1",
+		Active:     true,
+		Expiration: "",
+		Value:      "test value",
+		Meta:       CSEMatchListItemMeta{Description: "desc"},
+	}
+	newItem := CSEMatchListItemPost{
+		ID:          "item-1",
+		Active:      true,
+		Expiration:  "",
+		Value:       "Test Value",
+		Description: "desc",
+	}
+	if !matches(oldItem, newItem) {
+		t.Error("Expected matches() to return true for case-different values")
+	}
+}
+
 func TestSumologicSCEMatchListBulkDeleteSuccess(t *testing.T) {
 	responseBody := []byte(`{"data": {"errorResults": []}}`)
 	response := &http.Response{


### PR DESCRIPTION
### Description

Adds some additional logic to the bulk match list update plan diffs that were resulting in an inordinate amount of time spent on plans that yielded no functional differences and could lead to timeouts.

* The hash function now lowercases values before hashing (matching the API's storage behavior) so that case differences won't cause a plan diff.
* Safely handles nil expiration via comma-ok type assertion. Previously empty strings assertions and null assertions were resulted in different hash values.

DiffSuppressFunc on both fields prevents plan-level diffs, and matches() uses case-insensitive comparison to avoid unnecessary update API calls.

### JIRA: [CSIEM-2549](https://sumologic.atlassian.net/browse/CSIEM-2549)

### Check list
* [X] Describe the changes and their purpose
* [ ] Update HTML docs (if applicable)
    * [preview tool](https://registry.terraform.io/tools/doc-preview)
* [X] Update [`CHANGELOG.md`](../CHANGELOG.md)
* [ ] Check [`CONTRIBUTING.md`](../CONTRIBUTING.md) for anything forgotten
