### PR TITLE
Add sumologic_async_aws_lambda_invocation resource and multi-profile …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ FEATURES:
 * **New Resource:** `sumologic_async_aws_lambda_invocation` - Asynchronously invoke an AWS Lambda function with support for AWS named profiles, enabling multi-account deployments.
 
 ENHANCEMENTS:
-* `sumologic_s3_logging_lambda_enable`: Added `region` and `aws_profile` arguments to support explicit AWS region configuration and named AWS credential profiles, enabling multi-account deployments.
+* `sumologic_s3_logging_lambda_enable` (renamed from `sumologic_lambda_invoke_action`): Added `region` and `aws_profile` arguments to support explicit AWS region configuration and named AWS credential profiles, enabling multi-account deployments.
 
 BUG FIXES:
 * Updated `sumologic_cse_match_list` to handle cases where case differences in values and empty expirations resulted in plan diffs with no functional changes. These will no longer result in a plan diff.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## X.Y.Z (Unreleased)
+FEATURES:
+* **New Resource:** `sumologic_async_aws_lambda_invocation` - Asynchronously invoke an AWS Lambda function with support for AWS named profiles, enabling multi-account deployments.
+
+ENHANCEMENTS:
+* `sumologic_s3_logging_lambda_enable`: Added `region` and `aws_profile` arguments to support explicit AWS region configuration and named AWS credential profiles, enabling multi-account deployments.
 
 ## 3.2.10 (Jul 15, 2026)
 FEATURES:

--- a/sumologic/provider.go
+++ b/sumologic/provider.go
@@ -129,7 +129,8 @@ func Provider() *schema.Provider {
 			"sumologic_local_windows_event_log_source":           resourceSumologicLocalWindowsEventLogSource(),
 			"sumologic_event_extraction_rule":                    resourceSumologicEventExtractionRule(),
 			"sumologic_data_mask_rule":                           resourceSumologicDataMaskRule(),
-			"sumologic_lambda_invoke_action":                     resourceSumologicLambdaInvokeAction(),
+			"sumologic_async_aws_lambda_invocation":              resourceSumologicAsyncAwsLambdaInvocation(),
+			"sumologic_s3_logging_lambda_enable":                 resourceSumologicLambdaInvokeAction(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"sumologic_cse_log_mapping_vendor_product": dataSourceCSELogMappingVendorAndProduct(),

--- a/sumologic/resource_sumologic_async_aws_lambda_invocation.go
+++ b/sumologic/resource_sumologic_async_aws_lambda_invocation.go
@@ -1,0 +1,114 @@
+package sumologic
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
+	"github.com/aws/aws-sdk-go-v2/service/lambda/types"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+var newAsyncLambdaClientFunc = defaultNewAsyncLambdaClient
+
+func defaultNewAsyncLambdaClient(ctx context.Context, region string, profile string) (*lambda.Client, error) {
+	var opts []func(*awsconfig.LoadOptions) error
+	if region != "" {
+		opts = append(opts, awsconfig.WithRegion(region))
+	}
+	if profile != "" {
+		opts = append(opts, awsconfig.WithSharedConfigProfile(profile))
+	}
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("unable to load AWS config: %w", err)
+	}
+	return lambda.NewFromConfig(cfg), nil
+}
+
+func resourceSumologicAsyncAwsLambdaInvocation() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceAsyncLambdaInvocationCreate,
+		ReadContext:   resourceAsyncLambdaInvocationRead,
+		DeleteContext: resourceAsyncLambdaInvocationDelete,
+		Schema: map[string]*schema.Schema{
+			"function_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"region": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"input": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Default:      "{}",
+				ValidateFunc: validation.StringIsJSON,
+			},
+			"qualifier": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "$LATEST",
+			},
+			"triggers": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"status_code": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"aws_profile": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "",
+			},
+		},
+	}
+}
+
+func resourceAsyncLambdaInvocationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	region := d.Get("region").(string)
+	functionName := d.Get("function_name").(string)
+	input := d.Get("input").(string)
+	qualifier := d.Get("qualifier").(string)
+
+	client, err := newAsyncLambdaClientFunc(ctx, region, d.Get("aws_profile").(string))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	resp, err := client.Invoke(ctx, &lambda.InvokeInput{
+		FunctionName:   aws.String(functionName),
+		InvocationType: types.InvocationTypeEvent,
+		Payload:        []byte(input),
+		Qualifier:      aws.String(qualifier),
+	})
+	if err != nil {
+		return diag.Errorf("async Lambda invocation failed for %s: %s", functionName, err)
+	}
+
+	d.SetId(fmt.Sprintf("%s-%d", functionName, resp.StatusCode))
+	d.Set("status_code", int(resp.StatusCode))
+	return nil
+}
+
+func resourceAsyncLambdaInvocationRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceAsyncLambdaInvocationDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return nil
+}

--- a/sumologic/resource_sumologic_async_aws_lambda_invocation_test.go
+++ b/sumologic/resource_sumologic_async_aws_lambda_invocation_test.go
@@ -1,0 +1,178 @@
+package sumologic
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/lambda"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func newMockAsyncLambdaClient(handler http.HandlerFunc) *lambda.Client {
+	server := httptest.NewServer(handler)
+	return lambda.New(lambda.Options{
+		Region:       "us-east-1",
+		BaseEndpoint: aws.String(server.URL),
+		Credentials: aws.CredentialsProviderFunc(func(ctx context.Context) (aws.Credentials, error) {
+			return aws.Credentials{
+				AccessKeyID:     "AKIAIOSFODNN7EXAMPLE",
+				SecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+				Source:          "test",
+			}, nil
+		}),
+	})
+}
+
+func withMockAsyncLambdaClient(handler http.HandlerFunc, fn func()) {
+	client := newMockAsyncLambdaClient(handler)
+	original := newAsyncLambdaClientFunc
+	newAsyncLambdaClientFunc = func(ctx context.Context, region string, profile string) (*lambda.Client, error) {
+		return client, nil
+	}
+	defer func() { newAsyncLambdaClientFunc = original }()
+	fn()
+}
+
+func asyncLambdaAcceptedHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+		w.Write([]byte(`{}`))
+	}
+}
+
+func asyncLambdaErrorHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"message": "internal server error"}`))
+	}
+}
+
+func newAsyncLambdaTestResourceData() *schema.ResourceData {
+	r := resourceSumologicAsyncAwsLambdaInvocation()
+	d := r.TestResourceData()
+	d.Set("function_name", "my-async-lambda")
+	d.Set("region", "us-east-1")
+	d.Set("input", `{}`)
+	d.Set("qualifier", "$LATEST")
+	return d
+}
+
+// --- Schema Tests ---
+
+func TestAsyncLambdaInvocationResourceSchema(t *testing.T) {
+	r := resourceSumologicAsyncAwsLambdaInvocation()
+
+	expectedAttrs := map[string]struct {
+		typ      schema.ValueType
+		required bool
+		optional bool
+		computed bool
+		forceNew bool
+	}{
+		"function_name": {typ: schema.TypeString, required: true, forceNew: true},
+		"region":        {typ: schema.TypeString, required: true, forceNew: true},
+		"input":         {typ: schema.TypeString, optional: true, forceNew: true},
+		"qualifier":     {typ: schema.TypeString, optional: true, forceNew: true},
+		"triggers":      {typ: schema.TypeMap, optional: true, forceNew: true},
+		"status_code":   {typ: schema.TypeInt, computed: true},
+	}
+
+	for name, expected := range expectedAttrs {
+		attr, ok := r.Schema[name]
+		if !ok {
+			t.Errorf("schema missing attribute '%s'", name)
+			continue
+		}
+		if attr.Type != expected.typ {
+			t.Errorf("attribute '%s': expected type %v, got %v", name, expected.typ, attr.Type)
+		}
+		if attr.Required != expected.required {
+			t.Errorf("attribute '%s': expected Required=%v, got %v", name, expected.required, attr.Required)
+		}
+		if attr.Optional != expected.optional {
+			t.Errorf("attribute '%s': expected Optional=%v, got %v", name, expected.optional, attr.Optional)
+		}
+		if attr.Computed != expected.computed {
+			t.Errorf("attribute '%s': expected Computed=%v, got %v", name, expected.computed, attr.Computed)
+		}
+		if attr.ForceNew != expected.forceNew {
+			t.Errorf("attribute '%s': expected ForceNew=%v, got %v", name, expected.forceNew, attr.ForceNew)
+		}
+	}
+}
+
+// --- CRUD Tests ---
+
+func TestAsyncLambdaInvocationCreate_Success(t *testing.T) {
+	withMockAsyncLambdaClient(asyncLambdaAcceptedHandler(), func() {
+		d := newAsyncLambdaTestResourceData()
+
+		diags := resourceAsyncLambdaInvocationCreate(context.Background(), d, nil)
+		if diags.HasError() {
+			t.Fatalf("unexpected error: %v", diags)
+		}
+
+		if d.Id() == "" {
+			t.Error("expected ID to be set")
+		}
+		expectedID := fmt.Sprintf("my-async-lambda-%d", 202)
+		if d.Id() != expectedID {
+			t.Errorf("expected ID '%s', got '%s'", expectedID, d.Id())
+		}
+		if d.Get("status_code").(int) != 202 {
+			t.Errorf("expected status_code 202, got %d", d.Get("status_code").(int))
+		}
+	})
+}
+
+func TestAsyncLambdaInvocationCreate_LambdaError(t *testing.T) {
+	withMockAsyncLambdaClient(asyncLambdaErrorHandler(), func() {
+		d := newAsyncLambdaTestResourceData()
+
+		diags := resourceAsyncLambdaInvocationCreate(context.Background(), d, nil)
+		if !diags.HasError() {
+			t.Error("expected error when Lambda invocation fails")
+		}
+	})
+}
+
+func TestAsyncLambdaInvocationCreate_ClientError(t *testing.T) {
+	original := newAsyncLambdaClientFunc
+	newAsyncLambdaClientFunc = func(ctx context.Context, region string, profile string) (*lambda.Client, error) {
+		return nil, fmt.Errorf("AWS credentials not configured")
+	}
+	defer func() { newAsyncLambdaClientFunc = original }()
+
+	d := newAsyncLambdaTestResourceData()
+	diags := resourceAsyncLambdaInvocationCreate(context.Background(), d, nil)
+	if !diags.HasError() {
+		t.Error("expected error when Lambda client cannot be created")
+	}
+}
+
+func TestAsyncLambdaInvocationRead_NoOp(t *testing.T) {
+	d := newAsyncLambdaTestResourceData()
+	d.SetId("my-async-lambda-202")
+
+	diags := resourceAsyncLambdaInvocationRead(context.Background(), d, nil)
+	if diags.HasError() {
+		t.Fatalf("unexpected error: %v", diags)
+	}
+	if d.Id() != "my-async-lambda-202" {
+		t.Errorf("expected ID preserved, got '%s'", d.Id())
+	}
+}
+
+func TestAsyncLambdaInvocationDelete_NoOp(t *testing.T) {
+	d := newAsyncLambdaTestResourceData()
+	d.SetId("my-async-lambda-202")
+
+	diags := resourceAsyncLambdaInvocationDelete(context.Background(), d, nil)
+	if diags.HasError() {
+		t.Fatalf("unexpected error: %v", diags)
+	}
+}

--- a/sumologic/resource_sumologic_async_aws_lambda_invocation_test.go
+++ b/sumologic/resource_sumologic_async_aws_lambda_invocation_test.go
@@ -12,9 +12,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-func newMockAsyncLambdaClient(handler http.HandlerFunc) *lambda.Client {
+func withMockAsyncLambdaClient(handler http.HandlerFunc, fn func()) {
 	server := httptest.NewServer(handler)
-	return lambda.New(lambda.Options{
+	defer server.Close()
+	client := lambda.New(lambda.Options{
 		Region:       "us-east-1",
 		BaseEndpoint: aws.String(server.URL),
 		Credentials: aws.CredentialsProviderFunc(func(ctx context.Context) (aws.Credentials, error) {
@@ -25,10 +26,6 @@ func newMockAsyncLambdaClient(handler http.HandlerFunc) *lambda.Client {
 			}, nil
 		}),
 	})
-}
-
-func withMockAsyncLambdaClient(handler http.HandlerFunc, fn func()) {
-	client := newMockAsyncLambdaClient(handler)
 	original := newAsyncLambdaClientFunc
 	newAsyncLambdaClientFunc = func(ctx context.Context, region string, profile string) (*lambda.Client, error) {
 		return client, nil
@@ -75,10 +72,11 @@ func TestAsyncLambdaInvocationResourceSchema(t *testing.T) {
 	}{
 		"function_name": {typ: schema.TypeString, required: true, forceNew: true},
 		"region":        {typ: schema.TypeString, required: true, forceNew: true},
-		"input":         {typ: schema.TypeString, optional: true, forceNew: true},
-		"qualifier":     {typ: schema.TypeString, optional: true, forceNew: true},
-		"triggers":      {typ: schema.TypeMap, optional: true, forceNew: true},
-		"status_code":   {typ: schema.TypeInt, computed: true},
+		"input":       {typ: schema.TypeString, optional: true, forceNew: true},
+		"qualifier":   {typ: schema.TypeString, optional: true, forceNew: true},
+		"triggers":    {typ: schema.TypeMap, optional: true, forceNew: true},
+		"aws_profile": {typ: schema.TypeString, optional: true, forceNew: true},
+		"status_code": {typ: schema.TypeInt, computed: true},
 	}
 
 	for name, expected := range expectedAttrs {

--- a/sumologic/resource_sumologic_s3_logging_lambda_enable.go
+++ b/sumologic/resource_sumologic_s3_logging_lambda_enable.go
@@ -63,6 +63,12 @@ func resourceSumologicLambdaInvokeAction() *schema.Resource {
 				Optional:    true,
 				Description: "AWS region where the Lambda function is deployed. If not set, uses AWS_REGION env var or SDK defaults.",
 			},
+			"aws_profile": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "",
+				Description: "AWS profile to use for Lambda invocation. If not set, uses the default credential chain.",
+			},
 			"last_lambda_output": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -79,10 +85,13 @@ func resourceSumologicLambdaInvokeAction() *schema.Resource {
 
 var newLambdaClientFunc = defaultNewLambdaClient
 
-func defaultNewLambdaClient(ctx context.Context, region string) (*lambda.Client, error) {
+func defaultNewLambdaClient(ctx context.Context, region string, profile string) (*lambda.Client, error) {
 	var opts []func(*awsconfig.LoadOptions) error
 	if region != "" {
 		opts = append(opts, awsconfig.WithRegion(region))
+	}
+	if profile != "" {
+		opts = append(opts, awsconfig.WithSharedConfigProfile(profile))
 	}
 	cfg, err := awsconfig.LoadDefaultConfig(ctx, opts...)
 	if err != nil {
@@ -92,7 +101,7 @@ func defaultNewLambdaClient(ctx context.Context, region string) (*lambda.Client,
 }
 
 func resourceSumologicLambdaInvokeActionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := newLambdaClientFunc(ctx, d.Get("region").(string))
+	client, err := newLambdaClientFunc(ctx, d.Get("region").(string), d.Get("aws_profile").(string))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -130,7 +139,7 @@ func resourceSumologicLambdaInvokeActionRead(ctx context.Context, d *schema.Reso
 }
 
 func resourceSumologicLambdaInvokeActionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := newLambdaClientFunc(ctx, d.Get("region").(string))
+	client, err := newLambdaClientFunc(ctx, d.Get("region").(string), d.Get("aws_profile").(string))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -170,7 +179,7 @@ func resourceSumologicLambdaInvokeActionUpdate(ctx context.Context, d *schema.Re
 }
 
 func resourceSumologicLambdaInvokeActionDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, err := newLambdaClientFunc(ctx, d.Get("region").(string))
+	client, err := newLambdaClientFunc(ctx, d.Get("region").(string), d.Get("aws_profile").(string))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/sumologic/resource_sumologic_s3_logging_lambda_enable_test.go
+++ b/sumologic/resource_sumologic_s3_logging_lambda_enable_test.go
@@ -32,7 +32,7 @@ func newMockLambdaClient(handler http.HandlerFunc) *lambda.Client {
 func withMockLambdaClient(handler http.HandlerFunc, fn func()) {
 	client := newMockLambdaClient(handler)
 	original := newLambdaClientFunc
-	newLambdaClientFunc = func(ctx context.Context, region string) (*lambda.Client, error) {
+	newLambdaClientFunc = func(ctx context.Context, region string, profile string) (*lambda.Client, error) {
 		return client, nil
 	}
 	defer func() { newLambdaClientFunc = original }()
@@ -224,7 +224,7 @@ func TestLambdaInvokeResourceCreate_LambdaError(t *testing.T) {
 
 func TestLambdaInvokeResourceCreate_ClientError(t *testing.T) {
 	original := newLambdaClientFunc
-	newLambdaClientFunc = func(ctx context.Context, region string) (*lambda.Client, error) {
+	newLambdaClientFunc = func(ctx context.Context, region string, profile string) (*lambda.Client, error) {
 		return nil, fmt.Errorf("AWS credentials not configured")
 	}
 	defer func() { newLambdaClientFunc = original }()
@@ -333,7 +333,7 @@ func TestLambdaInvokeResourceDelete_LambdaError(t *testing.T) {
 
 func TestLambdaInvokeResourceDelete_ClientError(t *testing.T) {
 	original := newLambdaClientFunc
-	newLambdaClientFunc = func(ctx context.Context, region string) (*lambda.Client, error) {
+	newLambdaClientFunc = func(ctx context.Context, region string, profile string) (*lambda.Client, error) {
 		return nil, fmt.Errorf("AWS credentials not configured")
 	}
 	defer func() { newLambdaClientFunc = original }()

--- a/website/docs/r/async_aws_lambda_invocation.html.markdown
+++ b/website/docs/r/async_aws_lambda_invocation.html.markdown
@@ -1,0 +1,66 @@
+---
+layout: "sumologic"
+page_title: "SumoLogic: sumologic_async_aws_lambda_invocation"
+description: |-
+  Provides a Sumologic Async AWS Lambda Invocation resource
+---
+
+# sumologic_async_aws_lambda_invocation
+
+Provides a resource to asynchronously invoke an AWS Lambda function. Uses Lambda's `Event` invocation type, so the function is triggered and Terraform does not wait for it to complete. Useful for triggering background setup operations during infrastructure provisioning.
+
+This resource creates its own AWS Lambda client. It does not use the Sumo Logic provider credentials for AWS operations.
+
+## Example Usage
+
+```hcl
+resource "sumologic_async_aws_lambda_invocation" "trigger_setup" {
+  function_name = "MySetupFunction"
+  region        = "us-east-1"
+  aws_profile   = "my-aws-profile"
+  input         = jsonencode({ env = "production" })
+  qualifier     = "$LATEST"
+}
+```
+
+### Multi-profile example
+
+```hcl
+resource "sumologic_async_aws_lambda_invocation" "cross_account" {
+  function_name = "SetupFunction"
+  region        = "us-west-2"
+  aws_profile   = "prod-account"
+  input         = jsonencode({ source = "terraform" })
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `function_name` - (Required, Forces new resource) The name or ARN of the AWS Lambda function to invoke.
+- `region` - (Required, Forces new resource) The AWS region where the Lambda function is deployed.
+- `input` - (Optional, Forces new resource) JSON string payload to pass to the Lambda function. Defaults to `"{}"`.
+- `qualifier` - (Optional, Forces new resource) The Lambda function version or alias to invoke. Defaults to `"$LATEST"`.
+- `aws_profile` - (Optional, Forces new resource) The AWS credentials profile to use. If not set, uses the default credential chain (`AWS_PROFILE` env var, instance profile, etc.).
+- `triggers` - (Optional, Forces new resource) A map of arbitrary key/value pairs. Changing any value forces re-invocation, useful for triggering a new invocation without changing other arguments.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+- `id` - Identifier in the format `<function_name>-<status_code>`.
+- `status_code` - HTTP status code returned by the Lambda invocation API (`202` indicates the async invocation was accepted).
+
+## AWS Authentication
+
+AWS credentials are resolved in the following order:
+
+1. `aws_profile` argument (if set)
+2. `AWS_PROFILE` environment variable
+3. `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` environment variables
+4. Instance profile / ECS task role / Web Identity token
+
+## Import
+
+This resource does not support import.

--- a/website/docs/r/s3_logging_lambda_enable.html.markdown
+++ b/website/docs/r/s3_logging_lambda_enable.html.markdown
@@ -1,19 +1,19 @@
 ---
 layout: "sumologic"
-page_title: "SumoLogic: sumologic_lambda_invoke_action"
+page_title: "SumoLogic: sumologic_s3_logging_lambda_enable"
 description: |-
-  Provides a Sumologic Lambda Invoke Action resource
+  Provides a Sumologic S3 Logging Lambda Enable resource
 ---
 
-# sumologic_lambda_invoke_action
+# sumologic_s3_logging_lambda_enable
 Provides a resource to invoke an AWS Lambda function for enabling S3 logging and other auto-enable operations as part of AWS Observability setup.
 
-This resource creates its own AWS Lambda client using environment variables (`AWS_REGION`, `AWS_PROFILE` or `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`). It does not use the Sumo Logic provider credentials for AWS operations.
+This resource creates its own AWS Lambda client. It does not use the Sumo Logic provider credentials for AWS operations.
 
 ## Example Usage
 
 ```hcl
-resource "sumologic_lambda_invoke_action" "enable_s3_logging" {
+resource "sumologic_s3_logging_lambda_enable" "enable_s3_logging" {
   lambda_name            = "SumologicEnableExistingResources"
   aws_resource           = "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/my-alb/abc123"
   bucket_name            = "my-access-logs-bucket"
@@ -34,6 +34,8 @@ The following arguments are supported:
 - `account_id` - (Required) The AWS account ID.
 - `filter` - (Optional) A filter expression to match specific resources. Defaults to `""`.
 - `bucket_prefix` - (Optional) The prefix path within the S3 bucket for log delivery. Defaults to `""`.
+- `region` - (Optional) The AWS region where the Lambda function is deployed. If not set, falls back to the `AWS_REGION` environment variable or the SDK default.
+- `aws_profile` - (Optional) The AWS credentials profile to use. If not set, uses the default credential chain (`AWS_PROFILE` env var, instance profile, etc.).
 - `remove_on_delete_stack` - (Optional) Whether to remove the logging configuration when the resource is destroyed. Defaults to `false`.
 
 ## Attributes Reference


### PR DESCRIPTION

### Description

- New resource sumologic_async_aws_lambda_invocation: Async
  Lambda invocation with aws_profile support for multi-account deployments
- Renamed sumologic_lambda_invoke_action to sumologic_s3_logging_lambda_enable
  to better reflect its purpose
- Added region and aws_profile fields to sumologic_s3_logging_lambda_enable
- Docs and CHANGELOG updated


### Check list
* [x] Describe the changes and their purpose
* [x] Update HTML docs (if applicable)
    * [preview tool](https://registry.terraform.io/tools/doc-preview)
* [x] Update [`CHANGELOG.md`](../CHANGELOG.md)
* [x] Check [`CONTRIBUTING.md`](../CONTRIBUTING.md) for anything forgotten
