### PR TITLE
Add content argument to sumologic_lookup_table for CSV uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## X.Y.Z (Unreleased)
+ENHANCEMENTS:
+* `sumologic_lookup_table`: Added `content` argument to populate a lookup table's rows with CSV data (e.g. via `file()`), addressing [#202](https://github.com/SumoLogic/terraform-provider-sumologic/issues/202).
 
 ## 3.3.1 (Aug 20, 2026)
 FEATURES:

--- a/sumologic/resource_sumologic_lookup_table.go
+++ b/sumologic/resource_sumologic_lookup_table.go
@@ -1,22 +1,40 @@
 package sumologic
 
 import (
+	"context"
+	"crypto/sha256"
+	"encoding/csv"
+	"encoding/hex"
 	"fmt"
+	"io"
 	"log"
+	"strings"
+	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
+// Sumo Logic's documented limits for the lookup table CSV upload API
+// (https://api.sumologic.com/docs/#operation/uploadFile). maxContentBytes is
+// enforced as a hard error; warnContentBytes is a softer nudge that large,
+// slow-changing data belongs in an ingest pipeline rather than Terraform.
+const (
+	maxContentBytes  = 100 * 1024 * 1024
+	warnContentBytes = 10 * 1024 * 1024
+)
+
 func resourceSumologicLookupTable() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceSumologicLookupTableCreate,
-		Read:   resourceSumologicLookupTableRead,
-		Update: resourceSumologicLookupTableUpdate,
-		Delete: resourceSumologicLookupTableDelete,
+		CreateContext: resourceSumologicLookupTableCreate,
+		ReadContext:   resourceSumologicLookupTableRead,
+		UpdateContext: resourceSumologicLookupTableUpdate,
+		DeleteContext: resourceSumologicLookupTableDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+		CustomizeDiff: lookupTableCustomizeDiff,
 
 		Schema: map[string]*schema.Schema{
 
@@ -84,36 +102,65 @@ func resourceSumologicLookupTable() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+
+			"content": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "CSV content to populate the lookup table with. The first row must be a header matching the field names in \"fields\" (case-insensitive). Uploading replaces all existing rows. This value cannot be read back from the API: importing an existing table will show a diff on the first plan if \"content\" is set, and the state stores only a hash of the content, not the content itself. Removing this argument truncates the table.",
+				StateFunc:    hashLookupContent,
+				ValidateFunc: validateLookupContent,
+			},
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Read:   schema.DefaultTimeout(1 * time.Minute),
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(1 * time.Minute),
 		},
 	}
 }
 
-func resourceSumologicLookupTableCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceSumologicLookupTableCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*Client)
 
 	if d.Id() == "" {
 		lookupTable := resourceToLookupTable(d)
 		id, err := c.CreateLookupTable(lookupTable)
 		if err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 
 		d.SetId(id)
 	}
 
+	var diags diag.Diagnostics
+
+	if content := d.Get("content").(string); content != "" {
+		warning, err := c.UploadLookupTableContent(d.Id(), content, d.Timeout(schema.TimeoutCreate))
+		if err != nil {
+			// The table was already created; return the error without clearing
+			// the id so Terraform taints the resource instead of orphaning it.
+			return diag.FromErr(err)
+		}
+		if warning != "" {
+			diags = append(diags, lookupTablePartialSuccessDiagnostic(warning))
+		}
+	}
+
 	log.Printf("created lookup: %+v\n", d)
 	log.Printf("lookup id: %v\n", d.Id())
-	return resourceSumologicLookupTableRead(d, meta)
+	return append(diags, resourceSumologicLookupTableRead(ctx, d, meta)...)
 }
 
-func resourceSumologicLookupTableRead(d *schema.ResourceData, meta interface{}) error {
+func resourceSumologicLookupTableRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*Client)
 
 	id := d.Id()
 	lookupTable, err := c.GetLookupTable(id)
 	log.Printf("##DEBUG## read lookup: %+v\n", lookupTable)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	if lookupTable == nil {
@@ -124,7 +171,7 @@ func resourceSumologicLookupTableRead(d *schema.ResourceData, meta interface{}) 
 
 	d.Set("name", lookupTable.Name)
 	if err := d.Set("fields", fieldsToList(lookupTable.Fields)); err != nil {
-		return fmt.Errorf("error setting fields for resource %s: %s", d.Id(), err)
+		return diag.FromErr(fmt.Errorf("error setting fields for resource %s: %s", d.Id(), err))
 	}
 	d.Set("ttl", lookupTable.Ttl)
 	d.Set("primary_keys", lookupTable.PrimaryKeys)
@@ -132,26 +179,61 @@ func resourceSumologicLookupTableRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("size_limit_action", lookupTable.SizeLimitAction)
 	d.Set("description", lookupTable.Description)
 
+	// "content" is intentionally not set here: there is no API to read a
+	// lookup table's rows back out, so any value written would be a guess.
+	// The existing state (or config) value is left as-is.
+
 	return nil
 }
 
-func resourceSumologicLookupTableDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceSumologicLookupTableDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*Client)
 
 	log.Printf("##DEBUG## resourceSumologicLookupTableDelete: %s", d.Id())
-	return c.DeleteLookupTable(d.Id())
+	return diag.FromErr(c.DeleteLookupTable(d.Id()))
 }
 
-func resourceSumologicLookupTableUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceSumologicLookupTableUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c := meta.(*Client)
 
 	lookupTable := resourceToLookupTable(d)
-	err := c.UpdateLookupTable(lookupTable)
-	if err != nil {
-		return err
+	if err := c.UpdateLookupTable(lookupTable); err != nil {
+		return diag.FromErr(err)
 	}
 
-	return resourceSumologicLookupTableRead(d, meta)
+	var diags diag.Diagnostics
+
+	if d.HasChange("content") {
+		var warning string
+		var err error
+		if content := d.Get("content").(string); content != "" {
+			warning, err = c.UploadLookupTableContent(d.Id(), content, d.Timeout(schema.TimeoutUpdate))
+		} else {
+			// Removing the argument truncates the table rather than leaving
+			// stale rows that Terraform no longer has any record of.
+			warning, err = c.TruncateLookupTable(d.Id(), d.Timeout(schema.TimeoutUpdate))
+		}
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		if warning != "" {
+			diags = append(diags, lookupTablePartialSuccessDiagnostic(warning))
+		}
+	}
+
+	return append(diags, resourceSumologicLookupTableRead(ctx, d, meta)...)
+}
+
+// lookupTablePartialSuccessDiagnostic surfaces a PartialSuccess job's warning
+// text as a non-fatal diagnostic, visible in `terraform apply` output. A
+// plain `error` return can't do this - either it fails the apply (wrong: the
+// upload did partially succeed) or it says nothing (the prior behavior).
+func lookupTablePartialSuccessDiagnostic(warning string) diag.Diagnostic {
+	return diag.Diagnostic{
+		Severity: diag.Warning,
+		Summary:  "Lookup table upload completed with warnings",
+		Detail:   warning,
+	}
 }
 
 func resourceToLookupTable(d *schema.ResourceData) LookupTable {
@@ -205,4 +287,146 @@ func fieldsToList(lookupTableField []LookupTableField) []map[string]interface{} 
 	}
 
 	return s
+}
+
+// hashLookupContent is the StateFunc for "content": state stores only a
+// sha256 of the CSV, not the CSV itself, since the content can be arbitrarily
+// large and cannot be derived back from the API. The empty string is left as
+// the empty string so a plan clearing "content" reads as "-> \"\"" (truncate)
+// rather than a hash of the empty string.
+func hashLookupContent(v interface{}) string {
+	content := v.(string)
+	if content == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(content))
+	return hex.EncodeToString(sum[:])
+}
+
+// validateLookupContent runs cheap, single-value checks on "content" at plan
+// time. Checks that need sibling attributes (fields, primary_keys) live in
+// lookupTableCustomizeDiff instead, since ValidateFunc only sees one value.
+// lintignore:V012
+func validateLookupContent(v interface{}, k string) (warnings []string, errors []error) {
+	content, ok := v.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("%q: expected type string", k))
+		return warnings, errors
+	}
+
+	if size := len(content); size > maxContentBytes {
+		errors = append(errors, fmt.Errorf(
+			"%q is %d bytes, which exceeds Sumo Logic's %d byte (100MB) lookup table CSV upload limit",
+			k, size, maxContentBytes))
+	} else if size > warnContentBytes {
+		warnings = append(warnings, fmt.Sprintf(
+			"%q is %d bytes; consider populating large lookup tables via an ingest pipeline or scheduled search instead of Terraform, since every plan and apply carries this value across the provider boundary",
+			k, size))
+	}
+
+	if strings.Contains(content, "\r\n") {
+		warnings = append(warnings, fmt.Sprintf(
+			"%q contains Windows-style line endings (\\r\\n); Sumo Logic's lookup table upload API expects Unix-style newlines (\\n)",
+			k))
+	}
+
+	return warnings, errors
+}
+
+// lookupTableCustomizeDiff validates the CSV structure of "content" against
+// the table's "fields" and "primary_keys" at plan time, so a malformed CSV
+// fails terraform plan instead of terraform apply.
+func lookupTableCustomizeDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+	if !d.NewValueKnown("content") {
+		// Content built from an interpolation unresolved at plan time; nothing
+		// to validate yet without failing the plan spuriously.
+		return nil
+	}
+
+	content := d.Get("content").(string)
+	if content == "" {
+		return nil
+	}
+
+	if !d.NewValueKnown("fields") {
+		return nil
+	}
+
+	fieldsData := d.Get("fields").([]interface{})
+	if len(fieldsData) == 0 {
+		return nil
+	}
+
+	var fields []LookupTableField
+	for _, data := range fieldsData {
+		fields = append(fields, resourceToLookupTableField([]interface{}{data}))
+	}
+
+	primaryKeysData := d.Get("primary_keys").([]interface{})
+	var primaryKeys []string
+	for _, data := range primaryKeysData {
+		primaryKeys = append(primaryKeys, data.(string))
+	}
+
+	return validateLookupCSV(content, fields, primaryKeys)
+}
+
+// validateLookupCSV checks that content parses as CSV and that its header
+// matches fields/primaryKeys. It deliberately does not validate cell values
+// against field types: that would duplicate server-side coercion rules this
+// provider cannot observe, and getting it wrong would reject configs the API
+// would have accepted. Pulled out as a pure function so it is testable
+// without a *schema.ResourceDiff.
+func validateLookupCSV(content string, fields []LookupTableField, primaryKeys []string) error {
+	fieldNames := make(map[string]bool, len(fields))
+	for _, f := range fields {
+		fieldNames[strings.ToLower(f.FieldName)] = true
+	}
+
+	reader := csv.NewReader(strings.NewReader(content))
+
+	header, err := reader.Read()
+	if err != nil {
+		return fmt.Errorf("failed to parse CSV header of \"content\": %w", err)
+	}
+
+	seenColumns := make(map[string]bool, len(header))
+	for i, col := range header {
+		trimmed := strings.TrimSpace(col)
+		if trimmed == "" {
+			return fmt.Errorf("CSV header column %d in \"content\" is empty", i+1)
+		}
+		lower := strings.ToLower(trimmed)
+		if !fieldNames[lower] {
+			return fmt.Errorf("CSV header column %q in \"content\" does not match any field name in \"fields\"", trimmed)
+		}
+		seenColumns[lower] = true
+	}
+
+	for _, f := range fields {
+		if !seenColumns[strings.ToLower(f.FieldName)] {
+			return fmt.Errorf("CSV header in \"content\" is missing column %q, which is defined in \"fields\"", f.FieldName)
+		}
+	}
+
+	for _, pk := range primaryKeys {
+		if !seenColumns[strings.ToLower(pk)] {
+			return fmt.Errorf("CSV header in \"content\" is missing column %q, which is listed in \"primary_keys\"", pk)
+		}
+	}
+
+	// Read the remaining rows so ragged rows and unbalanced quotes fail at
+	// plan time. FieldsPerRecord defaults to 0, which locks csv.Reader to the
+	// header's column count after the first Read, so mismatched rows are
+	// rejected automatically.
+	for {
+		if _, err := reader.Read(); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return fmt.Errorf("failed to parse CSV row in \"content\": %w", err)
+		}
+	}
+
+	return nil
 }

--- a/sumologic/resource_sumologic_lookup_table_test.go
+++ b/sumologic/resource_sumologic_lookup_table_test.go
@@ -2,6 +2,8 @@ package sumologic
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -119,6 +121,95 @@ func TestAccSumologicLookupTable_update(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccSumologicLookupTable_content(t *testing.T) {
+	var lookupTable LookupTable
+	testName := "SampleLookupTable"
+	testFieldName := "FieldName1"
+	testFieldType := "string"
+	testTtl := 100
+	testPrimaryKeys := "FieldName1"
+	testSizeLimitAction := "StopIncomingMessages"
+	testDescription := "This is a sample lookup table description."
+
+	// Exercise the real-world path: content read from disk via the HCL
+	// file() function, not an inline string, since that's how the feature
+	// is actually meant to be used (see website/docs/r/lookup_table.html.markdown).
+	contentPath, err := filepath.Abs("testdata/lookup_table_content.csv")
+	if err != nil {
+		t.Fatal(err)
+	}
+	updatedContentPath, err := filepath.Abs("testdata/lookup_table_content_updated.csv")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	contentBytes, err := os.ReadFile(contentPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updatedContentBytes, err := os.ReadFile(updatedContentPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// content cannot be read back from the API, so state stores only its
+	// hash - assert against that rather than the raw CSV. Hash what's
+	// actually on disk so the expectation can't drift from the fixture.
+	testContentHash := hashLookupContent(string(contentBytes))
+	testUpdatedContentHash := hashLookupContent(string(updatedContentBytes))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLookupTableDestroy(lookupTable),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSumologicLookupTableContent(testName, testFieldName, testFieldType, testTtl, testPrimaryKeys, testSizeLimitAction, testDescription, fmt.Sprintf("file(%q)", contentPath)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLookupTableExists("sumologic_lookup_table.test", &lookupTable, t),
+					resource.TestCheckResourceAttr("sumologic_lookup_table.test", "content", testContentHash),
+				),
+			},
+			{
+				Config: testAccSumologicLookupTableContent(testName, testFieldName, testFieldType, testTtl, testPrimaryKeys, testSizeLimitAction, testDescription, fmt.Sprintf("file(%q)", updatedContentPath)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("sumologic_lookup_table.test", "content", testUpdatedContentHash),
+				),
+			},
+			{
+				// Removing the argument entirely must truncate the table
+				// rather than leaving it unmanaged.
+				Config: testAccSumologicLookupTable(testName, testFieldName, testFieldType, testTtl, testPrimaryKeys, testSizeLimitAction, testDescription),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("sumologic_lookup_table.test", "content", ""),
+				),
+			},
+		},
+	})
+}
+
+// testAccSumologicLookupTableContent embeds contentExpr verbatim as the
+// "content" argument's value - callers pass a full HCL expression (e.g.
+// `file("/abs/path.csv")`), not a string to be quoted.
+func testAccSumologicLookupTableContent(name string, testFieldName string, testFieldType string, ttl int, primaryKeys string, sizeLimitAction string, description string, contentExpr string) string {
+	return fmt.Sprintf(`
+data "sumologic_personal_folder" "personalFolder" {}
+resource "sumologic_lookup_table" "test" {
+    name = "%s"
+    fields {
+      field_name = "%s"
+      field_type = "%s"
+    }
+    ttl = %d
+    primary_keys = ["%s"]
+    parent_folder_id = "${data.sumologic_personal_folder.personalFolder.id}"
+    size_limit_action = "%s"
+    description = "%s"
+    content = %s
+}
+`, name, testFieldName, testFieldType, ttl, primaryKeys, sizeLimitAction, description, contentExpr)
 }
 
 func testAccCheckLookupTableDestroy(lookupTable LookupTable) resource.TestCheckFunc {

--- a/sumologic/resource_sumologic_lookup_table_unit_test.go
+++ b/sumologic/resource_sumologic_lookup_table_unit_test.go
@@ -1,0 +1,273 @@
+package sumologic
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestWaitForLookupJob(t *testing.T) {
+	tests := []struct {
+		name        string
+		body        string
+		wantErr     bool
+		wantWarning bool
+	}{
+		{
+			name: "success",
+			body: `{"jobId":"job1","status":"Success"}`,
+		},
+		{
+			name:        "partial success does not fail the job but returns a warning",
+			body:        `{"jobId":"job1","status":"PartialSuccess","warnings":[{"message":"60 rows were dropped"}]}`,
+			wantWarning: true,
+		},
+		{
+			name:    "failed",
+			body:    `{"jobId":"job1","status":"Failed","errors":[{"code":"x","message":"boom"}]}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response := &http.Response{
+				Status:     http.StatusText(200),
+				StatusCode: 200,
+				Body:       io.NopCloser(bytes.NewReader([]byte(tt.body))),
+			}
+			client := newTestClient(response)
+
+			warning, err := waitForLookupJob("job1", 5*time.Second, client)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("waitForLookupJob() error = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if (warning != "") != tt.wantWarning {
+				t.Errorf("waitForLookupJob() warning = %q, wantWarning = %v", warning, tt.wantWarning)
+			}
+		})
+	}
+}
+
+func TestHashLookupContent(t *testing.T) {
+	if got := hashLookupContent(""); got != "" {
+		t.Errorf("hashLookupContent(\"\") = %q, want empty string", got)
+	}
+
+	a := hashLookupContent("host,team\na,b\n")
+	b := hashLookupContent("host,team\na,b\n")
+	if a != b {
+		t.Errorf("hashLookupContent is not stable: %q != %q", a, b)
+	}
+	if len(a) != 64 {
+		t.Errorf("hashLookupContent returned %d hex chars, want 64 (sha256)", len(a))
+	}
+
+	c := hashLookupContent("host,team\nc,d\n")
+	if a == c {
+		t.Errorf("hashLookupContent returned the same hash for different content: %q", a)
+	}
+}
+
+func TestValidateLookupContent(t *testing.T) {
+	tests := []struct {
+		name         string
+		content      string
+		wantErrors   bool
+		wantWarnings bool
+	}{
+		{name: "empty is fine", content: ""},
+		{name: "small csv is fine", content: "host,team\na,b\n"},
+		{
+			name:         "over warn threshold warns",
+			content:      strings.Repeat("a", warnContentBytes+1),
+			wantWarnings: true,
+		},
+		{
+			name:       "over max threshold errors",
+			content:    strings.Repeat("a", maxContentBytes+1),
+			wantErrors: true,
+		},
+		{
+			name:         "crlf warns",
+			content:      "host,team\r\na,b\r\n",
+			wantWarnings: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			warnings, errs := validateLookupContent(tt.content, "content")
+			if (len(errs) > 0) != tt.wantErrors {
+				t.Errorf("errors = %v, wantErrors = %v", errs, tt.wantErrors)
+			}
+			if (len(warnings) > 0) != tt.wantWarnings {
+				t.Errorf("warnings = %v, wantWarnings = %v", warnings, tt.wantWarnings)
+			}
+		})
+	}
+}
+
+func TestValidateLookupCSV(t *testing.T) {
+	fields := []LookupTableField{
+		{FieldName: "host", FieldType: "string"},
+		{FieldName: "team", FieldType: "string"},
+	}
+	primaryKeys := []string{"host"}
+
+	tests := []struct {
+		name        string
+		content     string
+		fields      []LookupTableField
+		primaryKeys []string
+		wantErr     bool
+	}{
+		{
+			name:    "happy path",
+			content: "host,team\nweb-1,team-a\n",
+			fields:  fields, primaryKeys: primaryKeys,
+		},
+		{
+			name:    "header case differs from fields",
+			content: "Host,TEAM\nweb-1,team-a\n",
+			fields:  fields, primaryKeys: primaryKeys,
+		},
+		{
+			name:    "header-only is valid",
+			content: "host,team\n",
+			fields:  fields, primaryKeys: primaryKeys,
+		},
+		{
+			name:    "missing column",
+			content: "host\nweb-1\n",
+			fields:  fields, primaryKeys: primaryKeys,
+			wantErr: true,
+		},
+		{
+			name:    "unknown extra column",
+			content: "host,team,extra\nweb-1,team-a,x\n",
+			fields:  fields, primaryKeys: primaryKeys,
+			wantErr: true,
+		},
+		{
+			name:    "primary key absent from header",
+			content: "host,team\nweb-1,team-a\n",
+			fields:  fields, primaryKeys: []string{"missing"},
+			wantErr: true,
+		},
+		{
+			name:    "ragged row",
+			content: "host,team\nweb-1,team-a,extra-value\n",
+			fields:  fields, primaryKeys: primaryKeys,
+			wantErr: true,
+		},
+		{
+			name:    "unbalanced quote",
+			content: "host,team\n\"web-1,team-a\n",
+			fields:  fields, primaryKeys: primaryKeys,
+			wantErr: true,
+		},
+		{
+			name:    "empty header name",
+			content: ",team\nweb-1,team-a\n",
+			fields:  fields, primaryKeys: primaryKeys,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateLookupCSV(tt.content, tt.fields, tt.primaryKeys)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateLookupCSV() error = %v, wantErr = %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestLookupTableCustomizeDiff exercises lookupTableCustomizeDiff itself
+// (rather than validateLookupCSV directly), through the same *schema.Resource
+// entry point Terraform uses at plan time - covering the NewValueKnown gating
+// and the ResourceDiff-to-Go-slice reconstruction that TestValidateLookupCSV,
+// operating on hand-built slices, doesn't touch.
+func TestLookupTableCustomizeDiff(t *testing.T) {
+	fields := []interface{}{
+		map[string]interface{}{"field_name": "host", "field_type": "string"},
+		map[string]interface{}{"field_name": "team", "field_type": "string"},
+	}
+
+	tests := []struct {
+		name         string
+		raw          map[string]interface{}
+		computedKeys []string
+		wantErr      bool
+	}{
+		{
+			name: "valid content matching fields",
+			raw: map[string]interface{}{
+				"content":      "host,team\nweb-1,team-a\n",
+				"fields":       fields,
+				"primary_keys": []interface{}{"host"},
+			},
+		},
+		{
+			name: "content header does not match fields",
+			raw: map[string]interface{}{
+				"content":      "host,other\nweb-1,x\n",
+				"fields":       fields,
+				"primary_keys": []interface{}{"host"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty content skips validation",
+			raw: map[string]interface{}{
+				"content": "",
+				"fields":  fields,
+			},
+		},
+		{
+			name: "empty fields list skips validation even with mismatched content",
+			raw: map[string]interface{}{
+				"content": "anything,goes\nhere,too\n",
+				"fields":  []interface{}{},
+			},
+		},
+		{
+			name: "unknown content at plan time skips validation",
+			raw: map[string]interface{}{
+				"content": "",
+				"fields":  fields,
+			},
+			computedKeys: []string{"content"},
+		},
+		{
+			name: "unknown fields at plan time skips validation",
+			raw: map[string]interface{}{
+				"content": "host,other\nweb-1,x\n",
+				"fields":  fields,
+			},
+			computedKeys: []string{"fields"},
+		},
+	}
+
+	resource := resourceSumologicLookupTable()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := terraform.NewResourceConfigRaw(tt.raw)
+			config.ComputedKeys = tt.computedKeys
+
+			_, err := resource.Diff(context.Background(), nil, config, nil)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Diff() error = %v, wantErr = %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/sumologic/sumologic_client.go
+++ b/sumologic/sumologic_client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"mime/multipart"
 	"net/http"
 	"net/url"
 	"strings"
@@ -43,7 +44,7 @@ var endpoints = map[string]string{
 	"in":  "https://api.in.sumologic.com/api/",
 	"kr":  "https://api.kr.sumologic.com/api/",
 	"ch":  "https://api.ch.sumologic.com/api/",
-	"esc":  "https://api.esc.sumologic.com/api/",
+	"esc": "https://api.esc.sumologic.com/api/",
 }
 
 var rateLimiter = time.NewTicker(time.Minute / 240)
@@ -140,6 +141,35 @@ func (s *Client) PostRawPayload(urlPath string, payload string) ([]byte, error) 
 	if err != nil {
 		return nil, err
 	}
+
+	resp, err := s.doSumoRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.handleSumoResponse(resp)
+}
+
+// PostMultipartFile uploads content as a multipart/form-data file part named fieldName.
+func (s *Client) PostMultipartFile(urlPath, fieldName, fileName string, content []byte) ([]byte, error) {
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile(fieldName, fileName)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := part.Write(content); err != nil {
+		return nil, err
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+
+	req, err := s.createSumoRequest(http.MethodPost, urlPath, &body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
 
 	resp, err := s.doSumoRequest(req)
 	if err != nil {

--- a/sumologic/sumologic_lookup_table.go
+++ b/sumologic/sumologic_lookup_table.go
@@ -4,6 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func (s *Client) CreateLookupTable(lookupTable LookupTable) (string, error) {
@@ -97,4 +101,132 @@ type LookupTable struct {
 type LookupTableField struct {
 	FieldName string `json:"fieldName"`
 	FieldType string `json:"fieldType"`
+}
+
+// LookupJobStatus mirrors the LookupAsyncJobStatus schema returned by
+// v1/lookupTables/jobs/{jobId}/status. It intentionally does not reuse the
+// generic Status struct (sumologic_client.go): lookup jobs can report
+// Pending/PartialSuccess (which Status/waitForJob treat as errors) and carry
+// their error/warning detail in arrays rather than a single message.
+type LookupJobStatus struct {
+	JobId          string             `json:"jobId"`
+	Status         string             `json:"status"`
+	StatusMessages []string           `json:"statusMessages,omitempty"`
+	Errors         []Error            `json:"errors,omitempty"`
+	Warnings       []LookupJobWarning `json:"warnings,omitempty"`
+}
+
+type LookupJobWarning struct {
+	Message string `json:"message"`
+	Cause   string `json:"cause,omitempty"`
+}
+
+// UploadLookupTableContent replaces the contents of the lookup table with the
+// given CSV. Existing rows are removed (merge=false) since Terraform's
+// declarative model treats content as the full desired state of the table.
+// The returned warning is non-empty when the job completed as PartialSuccess;
+// callers should surface it to the user (e.g. as a diag.Diagnostics warning)
+// rather than only logging it, since some rows may have been dropped.
+func (s *Client) UploadLookupTableContent(id string, content string, timeout time.Duration) (string, error) {
+	urlPath := fmt.Sprintf("v1/lookupTables/%s/upload?merge=false", id)
+
+	data, err := s.PostMultipartFile(urlPath, "file", "lookup.csv", []byte(content))
+	if err != nil {
+		return "", err
+	}
+
+	var jobId JobId
+	if err := json.Unmarshal(data, &jobId); err != nil {
+		return "", err
+	}
+
+	return waitForLookupJob(jobId.ID, timeout, s)
+}
+
+// TruncateLookupTable deletes all rows from the lookup table. See
+// UploadLookupTableContent for the meaning of the returned warning.
+func (s *Client) TruncateLookupTable(id string, timeout time.Duration) (string, error) {
+	urlPath := fmt.Sprintf("v1/lookupTables/%s/truncate", id)
+
+	data, err := s.Post(urlPath, nil)
+	if err != nil {
+		return "", err
+	}
+
+	var jobId JobId
+	if err := json.Unmarshal(data, &jobId); err != nil {
+		return "", err
+	}
+
+	return waitForLookupJob(jobId.ID, timeout, s)
+}
+
+// waitForLookupJob polls until the job reaches a terminal state. It returns a
+// non-empty warning string on PartialSuccess so callers can decide how to
+// surface it (this package has no dependency on the SDK's diag package).
+func waitForLookupJob(jobId string, timeout time.Duration, s *Client) (string, error) {
+	url := fmt.Sprintf("v1/lookupTables/jobs/%s/status", jobId)
+
+	conf := &resource.StateChangeConf{
+		Pending: []string{
+			"Pending",
+			"InProgress",
+		},
+		Target: []string{
+			"Success",
+			"PartialSuccess",
+		},
+		Refresh: func() (interface{}, string, error) {
+			var status LookupJobStatus
+			b, err := s.Get(url)
+			if err != nil {
+				return nil, "", err
+			}
+
+			if err := json.Unmarshal(b, &status); err != nil {
+				return nil, "", err
+			}
+
+			if status.Status == "Failed" {
+				return status, status.Status, fmt.Errorf("lookup table job failed: %s", formatLookupJobErrors(status.Errors))
+			}
+
+			return status, status.Status, nil
+		},
+		Timeout:    timeout,
+		Delay:      1 * time.Second,
+		MinTimeout: 1 * time.Second,
+	}
+
+	result, err := conf.WaitForState()
+	if err != nil {
+		return "", err
+	}
+
+	if status, ok := result.(LookupJobStatus); ok && status.Status == "PartialSuccess" {
+		warning := formatLookupJobWarnings(status.Warnings)
+		if warning == "" {
+			warning = "job completed with PartialSuccess but returned no warning detail"
+		}
+		log.Printf("[WARN] lookup table job %s completed with warnings: %s", jobId, warning)
+		return warning, nil
+	}
+
+	return "", nil
+}
+
+func formatLookupJobErrors(errs []Error) string {
+	messages := make([]string, len(errs))
+	for i, e := range errs {
+		messages[i] = e.Message
+	}
+	return strings.Join(messages, "; ")
+}
+
+func formatLookupJobWarnings(warnings []LookupJobWarning) string {
+	messages := make([]string, len(warnings))
+	for i, w := range warnings {
+		messages[i] = w.Message
+	}
+	return strings.Join(messages, "; ")
 }

--- a/sumologic/testdata/lookup_table_content.csv
+++ b/sumologic/testdata/lookup_table_content.csv
@@ -1,0 +1,2 @@
+FieldName1
+value1

--- a/sumologic/testdata/lookup_table_content_updated.csv
+++ b/sumologic/testdata/lookup_table_content_updated.csv
@@ -1,0 +1,2 @@
+FieldName1
+value2

--- a/website/docs/r/lookup_table.html.markdown
+++ b/website/docs/r/lookup_table.html.markdown
@@ -27,6 +27,7 @@ resource "sumologic_lookup_table" "lookupTable" {
     parent_folder_id  = "${data.sumologic_personal_folder.personalFolder.id}"
     size_limit_action = "DeleteOldData"
     description       = "some description"
+    content           = file("${path.module}/lookup.csv")
 }
 ```
 
@@ -43,6 +44,15 @@ The following arguments are supported:
 - `primaryKeys` - (Required) The names of the fields that make up the primary key for the lookup table. These will be a subset of the fields that the table will contain.
 - `ttl` - (Optional) A time to live for each entry in the lookup table (in minutes). 365 days is the maximum time to live for each entry that you can specify. Setting it to 0 means that the records will not expire automatically.
 - `sizeLimitAction` - (Optional) The action that needs to be taken when the size limit is reached for the table. The possible values can be StopIncomingMessages or DeleteOldData. DeleteOldData will start deleting old data once size limit is reached whereas StopIncomingMessages will discard all the updates made to the lookup table once size limit is reached.
+- `content` - (Optional) CSV content to populate the lookup table with, e.g. `file("${path.module}/lookup.csv")`. Notes:
+  - The first row must be a header with column names matching `fields.field_name` (case-insensitive).
+  - Every field in `fields` must have a matching column, and every field listed in `primary_keys` must be present.
+  - Uploading replaces all existing rows in the table (it is not merged with existing data).
+  - Removing this argument truncates the table rather than leaving it unmanaged.
+  - This value cannot be read back from the Sumo Logic API. Importing an existing table will show a diff on the first plan if `content` is set locally, and the state stores a hash of the content rather than the content itself.
+  - CSV structure (headers, column count, quoting) is validated at plan time. Cell values are not validated against `field_type` locally - that is enforced by the API at apply time.
+  - The API's upload limit is 100MB per CSV; values over 10MB produce a plan-time warning recommending an ingest pipeline or scheduled search instead.
+  - If the upload completes with some rows rejected (e.g. duplicate primary keys), `terraform apply` still succeeds but shows a warning with the rejected-row detail.
 
 ## Attributes reference
 


### PR DESCRIPTION
> Supersedes #892 — moved in-repo so the acceptance suite runs with credentials (fork PRs get no repository secrets, so `Matrix Test` always fails on `SUMOLOGIC_ACCESSKEY must be set`). Also fixes a `tfproviderlint` failure from #892: converting `Create`/`Update` to the Context+diag CRUD signature while leaving `Read`/`Delete` on the legacy signature made tfproviderlint misclassify the resource as a data source (R012 + 6x S024); `Read`/`Delete` are now `ReadContext`/`DeleteContext` to match. Also adds a fallback warning message for a `PartialSuccess` upload with no warning detail, and a direct unit test for the `CustomizeDiff` wiring itself (previously only the pure CSV-validation helper was tested).

## Summary
- Closes #202. Adds a `content` string argument to `sumologic_lookup_table` (populate via `file("data.csv")`), which uploads CSV rows through Sumo Logic's lookup table upload/truncate APIs on create/update.
- CSV structure (headers vs. `fields`/`primary_keys`, ragged rows, unbalanced quotes) is validated at `terraform plan` time via `CustomizeDiff`, before any API call.
- State stores only a sha256 hash of `content`, never the raw CSV, since the API has no way to read rows back.
- Size guard: errors above Sumo Logic's 100MB CSV upload limit, warns above 10MB.

## Details
- `sumologic/sumologic_client.go`: new `PostMultipartFile` helper (multipart/form-data POST), reusing the existing request/response pipeline.
- `sumologic/sumologic_lookup_table.go`: new `UploadLookupTableContent`, `TruncateLookupTable`, and a dedicated `waitForLookupJob` poller. The existing `waitForJob` helper can't be reused as-is — lookup jobs report `Pending`/`PartialSuccess` states it would treat as errors, and its `Status` struct doesn't carry the `errors[]`/`warnings[]` detail lookup jobs return.
- `sumologic/resource_sumologic_lookup_table.go`: `content` schema field (`StateFunc` hashes it, `ValidateFunc` checks size/line-endings), a `Timeouts` block (the resource had none), and `CustomizeDiff` wiring the plan-time CSV structure check. Removing `content` truncates the table on update rather than leaving stale rows.
- Docs (`website/docs/r/lookup_table.html.markdown`) and `CHANGELOG.md` updated.

Deliberately out of scope (documented in code comments): cell-value validation against `field_type` (would duplicate server-side coercion this provider can't observe), a `merge` toggle (Terraform's declarative model is full-replace), and `content_file`/`content_hash` args (additive if a real oversized-CSV case shows up; `file()` covers the realistic range under the API's 100MB ceiling).

## Test plan
- [x] `go vet ./sumologic/...`, `go build .`, and `tfproviderlint ./...` clean
- [x] `go test ./sumologic/ -run 'TestHashLookupContent|TestValidateLookupContent|TestValidateLookupCSV|TestWaitForLookupJob|TestLookupTableCustomizeDiff' -v` — all pass, including ragged-row/unbalanced-quote cases and direct `CustomizeDiff` wiring tests (NewValueKnown gating, empty-fields skip)
- [x] `TF_ACC=1 go test ./sumologic -run 'TestAccSumologicLookupTable' -v` against a real org (run against #892 prior to this move) — all 4 pass (`_basic`, `_create`, `_update`, `_content`), each creates and destroys its own table
- [x] Manual e2e against the same real org, one throwaway table, config-driven (no repo changes):
  - create with `content` → API confirms non-zero stored size
  - re-plan with unchanged `content` → no diff (hash is stable, no needless re-upload)
  - swap `content` to a different CSV → exactly 1 changed, stored size reflects the new bytes
  - CSV header missing a declared field → rejected at `terraform plan`, before any API call
  - `cat path://"<table path>"` search → returned the exact row uploaded (`{"key":"alpha","value":"one"}`), confirming rows are genuinely queryable, not just accepted
  - remove `content` → stored size drops to 0 (truncate-on-removal)
  - `terraform destroy` → table gone (API 404/400)
  - org diffed before/after: personal folder contents identical, no leftover tables or other content

🤖 Generated with [Claude Code](https://claude.com/claude-code)
