### PR TITLE
Release 3.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## X.Y.Z (Unreleased)
+* Add new change notes here
+
+## 3.3.2 (Sep 2, 2026)
 ENHANCEMENTS:
 * `sumologic_lookup_table`: Added `content` argument to populate a lookup table's rows with CSV data (e.g. via `file()`), addressing [#202](https://github.com/SumoLogic/terraform-provider-sumologic/issues/202).
 


### PR DESCRIPTION
## Summary
Cut release 3.3.2. Changes since 3.3.1, moved from Unreleased into a dated section per CONTRIBUTING.md release process:
- `sumologic_lookup_table` `content` argument (#893)
- `sumologic_source_template` acceptance test schema-version fix (#895, SUMO-292887)

Rebased onto master and dated Sep 2, 2026.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`