### PR TITLE
SUMO-292887: fix SourceTemplate tests failing due to missing schema version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ENHANCEMENTS:
 * `sumologic_lookup_table`: Added `content` argument to populate a lookup table's rows with CSV data (e.g. via `file()`), addressing [#202](https://github.com/SumoLogic/terraform-provider-sumologic/issues/202).
 
+BUG FIXES:
+* Fixed `sumologic_source_template` acceptance tests failing with `SchemaBaseNotFoundException` by adding the required `version` field to `schema_ref` in test configurations.
+
 ## 3.3.1 (Aug 20, 2026)
 FEATURES:
 * **New Resource:** `sumologic_data_archiving_destination` - Manage data archiving destinations for `S3`, `Syslog`, `Hitachi`, and `RestAPI` targets.

--- a/sumologic/resource_sumologic_source_template_test.go
+++ b/sumologic/resource_sumologic_source_template_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAccSumologicSourceTemplate_basic(t *testing.T) {
 	var sourceTemplate SourceTemplate
-	testSchemaRef := "type =     \"Mac\""
+	testSchemaRef := "type =     \"Mac\"\n    version = \"7.0.0\""
 
 	testSelector :=
 		"tags =  [\n[\n{\n key = \"tag\"\n values= [\"Value\"]\n}\n]\n] \n names = [\"TestCollector1\"]"
@@ -38,7 +38,7 @@ func TestAccSumologicSourceTemplate_basic(t *testing.T) {
 
 func TestAccSumologicSourceTemplate_create(t *testing.T) {
 	var sourceTemplate SourceTemplate
-	testSchemaRef := "type =     \"Mac\""
+	testSchemaRef := "type =     \"Mac\"\n    version = \"7.0.0\""
 	testSelector := "tags =  [\n[\n{\n key = \"tag\"\n values= [\"Value\"]\n}\n]\n]\n names = [\"TestCollector1\"]"
 
 	testInputJson := "jsonencode({\n\"name\": \"hostmetrics_test_source_template_acc\",\n\"description\": \"Host metric source\" ,\n\"receivers\": {\n\"hostmetrics\": {\n\"receiverType\": \"hostmetrics\",\n\"collection_interval\": \"5m\",\n\"cpu_scraper_enabled\": true,\n\"disk_scraper_enabled\": true,\n\"load_scraper_enabled\": true,\n\"filesystem_scraper_enabled\": true,\n\"memory_scraper_enabled\": true,\n\"network_scraper_enabled\": true,\n\"process_scraper_enabled\": true,\n\"paging_scraper_enabled\": true\n}\n},\n\"processors\": {\n\"resource\": {\n\"processorType\": \"resource\",\n\"user_attributes\": [\n{\n\"key\": \"_sourceCategory\",\n\"value\": \"otel/host\"\n}\n],\n\"default_attributes\": [\n{\n\"key\": \"sumo.datasource\",\n\"value\": \"apache\"\n},\n]\n}\n}\n})"
@@ -64,11 +64,11 @@ func TestAccSumologicSourceTemplate_create(t *testing.T) {
 func TestAccSumologicSourceTemplate_update(t *testing.T) {
 	var sourceTemplate SourceTemplate
 
-	testSchemaRef := "type =     \"Mac\""
+	testSchemaRef := "type =     \"Mac\"\n    version = \"7.0.0\""
 	testSelector := "tags =  [\n[\n{\n key = \"tag\"\n values= [\"Value\"]\n}\n]\n]"
 	testInputJson := "jsonencode({\n\"name\": \"hostmetrics_test_source_template_acc\",\n\"description\": \"Host metric source\" ,\n\"receivers\": {\n\"hostmetrics\": {\n\"receiverType\": \"hostmetrics\",\n\"collection_interval\": \"5m\",\n\"cpu_scraper_enabled\": true,\n\"disk_scraper_enabled\": true,\n\"load_scraper_enabled\": true,\n\"filesystem_scraper_enabled\": true,\n\"memory_scraper_enabled\": true,\n\"network_scraper_enabled\": true,\n\"process_scraper_enabled\": true,\n\"paging_scraper_enabled\": true\n}\n},\n\"processors\": {\n\"resource\": {\n\"processorType\": \"resource\",\n\"user_attributes\": [\n{\n\"key\": \"_sourceCategory\",\n\"value\": \"otel/host\"\n}\n],\n\"default_attributes\": [\n{\n\"key\": \"sumo.datasource\",\n\"value\": \"apache\"\n},\n]\n}\n}\n})"
 
-	testUpdatedSchemaRef := "type =     \"Mac\""
+	testUpdatedSchemaRef := "type =     \"Mac\"\n    version = \"7.0.0\""
 	testUpdatedSelector := "tags =  [\n[\n{\n key = \"updatedTag\"\n values= [\"Value\"]\n}\n]\n] \n names = [\"TestCollector1\"]"
 	testUpdatedInputJson := "jsonencode({\n\"name\": \"hostmetrics_test_source_template_acc\",\n\"description\": \"Host metric source\" ,\n\"receivers\": {\n\"hostmetrics\": {\n\"receiverType\": \"hostmetrics\",\n\"collection_interval\": \"5m\",\n\"cpu_scraper_enabled\": true,\n\"disk_scraper_enabled\": true,\n\"load_scraper_enabled\": true,\n\"filesystem_scraper_enabled\": true,\n\"memory_scraper_enabled\": true,\n\"network_scraper_enabled\": true,\n\"process_scraper_enabled\": true,\n\"paging_scraper_enabled\": true\n}\n},\n\"processors\": {\n\"resource\": {\n\"processorType\": \"resource\",\n\"user_attributes\": [\n{\n\"key\": \"_sourceCategory\",\n\"value\": \"otel/hostupdated\"\n}\n],\n\"default_attributes\": [\n{\n\"key\": \"sumo.datasource\",\n\"value\": \"apache\"\n},\n]\n}\n}\n})"
 
@@ -100,7 +100,8 @@ func TestAccSumologicSourceTemplate_update(t *testing.T) {
 func TestAccSumologicSourceTemplate_enableDisable(t *testing.T) {
 	var sourceTemplate SourceTemplate
 
-	testSchemaRef := `type = "Mac"`
+	testSchemaRef := `type = "Mac"
+    version = "7.0.0"`
 	testSelector := `tags = [
 	[
 	{


### PR DESCRIPTION
## Summary

- SourceTemplate acceptance tests (`_basic`, `_create`, `_update`, `_enableDisable`) were failing with `SchemaBaseNotFoundException: schema base with schemaType: Mac and version not found`
- Root cause: `schema_ref` in tests only specified `type = "Mac"` without a `version` field, causing the API to look up an empty version string which has no registered record
- Fix: Added `version = "7.0.0"` to all test `schema_ref` blocks to match the registered Mac schema base in us2

## Context

- Investigation confirmed `Mac` schema base exists and works with version `7.0.0` (12 successful operations from `collectorautomation` in the last 7 days)
- This failure is blocking CI for all pending PRs in the repo
- Slack thread: https://sumologic.slack.com/archives/CAU3N0Y92/p1781704154686779
- Jira: https://sumologic.atlassian.net/browse/SUMO-292887

## Test plan

- [ ] CI matrix tests pass with the updated schema version
- [ ] SourceTemplate tests (`_basic`, `_create`, `_update`, `_enableDisable`) all pass green
- [ ] No regressions in other test suites